### PR TITLE
feat: support inlining sources in source maps

### DIFF
--- a/lib/npm_ignore.test.ts
+++ b/lib/npm_ignore.test.ts
@@ -1,0 +1,70 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "./test.deps.ts";
+import { getNpmIgnoreText } from "./npm_ignore.ts";
+import { SourceMapOptions } from "./compiler.ts";
+
+Deno.test("should include src directory when the source files are not necessary", () => {
+  runTest({
+    sourceMaps: undefined,
+    inlineSources: undefined,
+    expectHasSrcFolder: true,
+  });
+  runTest({
+    sourceMaps: true,
+    inlineSources: undefined,
+    expectHasSrcFolder: false,
+  });
+  runTest({
+    sourceMaps: "inline",
+    inlineSources: undefined,
+    expectHasSrcFolder: false,
+  });
+
+  runTest({
+    sourceMaps: true,
+    inlineSources: false,
+    expectHasSrcFolder: false,
+  });
+
+  runTest({
+    sourceMaps: undefined,
+    inlineSources: true,
+    expectHasSrcFolder: true,
+  });
+  runTest({
+    sourceMaps: true,
+    inlineSources: true,
+    expectHasSrcFolder: true,
+  });
+  runTest({
+    sourceMaps: "inline",
+    inlineSources: true,
+    expectHasSrcFolder: true,
+  });
+});
+
+function runTest(options: {
+  sourceMaps: SourceMapOptions | undefined;
+  inlineSources: boolean | undefined;
+  expectHasSrcFolder: boolean;
+}) {
+  const fileText = getNpmIgnoreText({
+    sourceMap: options.sourceMaps,
+    inlineSources: options.inlineSources,
+    testFiles: [{
+      filePath: "mod.test.ts",
+      fileText: "",
+    }],
+  });
+
+  assertEquals(fileText, getExpectedText());
+
+  function getExpectedText() {
+    const startText = options.expectHasSrcFolder ? "src/\n" : "";
+    return startText + `esm/mod.test.js
+umd/mod.test.js
+test_runner.js
+`;
+  }
+}

--- a/lib/npm_ignore.ts
+++ b/lib/npm_ignore.ts
@@ -1,0 +1,40 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { OutputFile } from "../transform.ts";
+import { SourceMapOptions } from "./compiler.ts";
+
+export function getNpmIgnoreText(options: {
+  sourceMap?: SourceMapOptions;
+  inlineSources?: boolean;
+  testFiles: OutputFile[];
+}) {
+  // Try to make as little of this conditional in case a user edits settings
+  // to exclude something, but then the output directory still has that file
+  const lines = [];
+  if (!isUsingSourceMaps() || options.inlineSources) {
+    lines.push("src/");
+  }
+  for (const fileName of getTestFileNames()) {
+    lines.push(fileName);
+  }
+  return Array.from(lines).join("\n") + "\n";
+
+  function* getTestFileNames() {
+    for (const file of options.testFiles) {
+      // ignore test declaration files as they won't show up in the emit
+      if (/\.d\.ts$/i.test(file.filePath)) {
+        continue;
+      }
+
+      const filePath = file.filePath.replace(/\.ts$/i, ".js");
+      yield `esm/${filePath}`;
+      yield `umd/${filePath}`;
+    }
+    yield "test_runner.js";
+  }
+
+  function isUsingSourceMaps() {
+    return options?.sourceMap === "inline" ||
+      options?.sourceMap === true;
+  }
+}


### PR DESCRIPTION
I've added a jsdoc remark recommending not to do this when creating a hybrid package (the default) since it will duplicate the sources in the final package.

Closes #19