### PR TITLE
fix: ensure mappings get passed to rust

### DIFF
--- a/lib/pkg/dnt_wasm.js
+++ b/lib/pkg/dnt_wasm.js
@@ -363,8 +363,8 @@ async function init(input) {
     imports.wbg.__wbindgen_throw = function(arg0, arg1) {
         throw new Error(getStringFromWasm0(arg0, arg1));
     };
-    imports.wbg.__wbindgen_closure_wrapper311 = function(arg0, arg1, arg2) {
-        var ret = makeMutClosure(arg0, arg1, 121, __wbg_adapter_18);
+    imports.wbg.__wbindgen_closure_wrapper309 = function(arg0, arg1, arg2) {
+        var ret = makeMutClosure(arg0, arg1, 120, __wbg_adapter_18);
         return addHeapObject(ret);
     };
 

--- a/mod.ts
+++ b/mod.ts
@@ -169,7 +169,7 @@ export async function build(options: BuildOptions): Promise<void> {
       noStrictGenericChecks: false,
       noUncheckedIndexedAccess: false,
       declaration: options.declaration,
-      esModuleInterop: true,
+      esModuleInterop: false,
       isolatedModules: true,
       useDefineForClassFields: true,
       experimentalDecorators: true,

--- a/mod.ts
+++ b/mod.ts
@@ -169,7 +169,7 @@ export async function build(options: BuildOptions): Promise<void> {
       noStrictGenericChecks: false,
       noUncheckedIndexedAccess: false,
       declaration: options.declaration,
-      esModuleInterop: false,
+      esModuleInterop: true,
       isolatedModules: true,
       useDefineForClassFields: true,
       experimentalDecorators: true,

--- a/tests/mappings_project/mod.test.ts
+++ b/tests/mappings_project/mod.test.ts
@@ -1,0 +1,9 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { getResult } from "./mod.ts";
+
+Deno.test("should get the result", () => {
+  if (getResult() !== "test") {
+    throw new Error("fail");
+  }
+});

--- a/tests/mappings_project/mod.ts
+++ b/tests/mappings_project/mod.ts
@@ -1,0 +1,6 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+import CodeBlockWriter from "https://deno.land/x/code_block_writer@11.0.0/mod.ts";
+
+export function getResult() {
+  return new CodeBlockWriter().write("test").toString();
+}

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -49,7 +49,7 @@ pub struct TransformOptions {
   pub entry_points: Vec<String>,
   pub test_entry_points: Vec<String>,
   pub shim_package_name: String,
-  pub specifier_mappings: Option<HashMap<ModuleSpecifier, MappedSpecifier>>,
+  pub mappings: Option<HashMap<ModuleSpecifier, MappedSpecifier>>,
 }
 
 #[wasm_bindgen]
@@ -62,7 +62,7 @@ pub async fn transform(options: JsValue) -> Result<JsValue, JsValue> {
     test_entry_points: parse_module_specifiers(options.test_entry_points)?,
     shim_package_name: options.shim_package_name,
     loader: Some(Box::new(JsLoader {})),
-    specifier_mappings: options.specifier_mappings,
+    specifier_mappings: options.mappings,
   })
   .await
   .map_err(|err| err.to_string())?;


### PR DESCRIPTION
This was accidentally not working because the mappings weren't being properly passed to the rust code.