### PR TITLE
fix: do not insert shim for globalThis directly in unary and binary expressions

### DIFF
--- a/rs-lib/src/visitors/deno_globals.rs
+++ b/rs-lib/src/visitors/deno_globals.rs
@@ -79,6 +79,7 @@ fn visit_children(node: Node, import_name: &str, context: &mut Context) {
     if is_top_level_context
       && ident_text == "globalThis"
       && !should_ignore(ident.into(), context)
+      && !is_in_type(ident.into())
     {
       context.text_changes.push(TextChange {
         span: ident.span(),
@@ -111,6 +112,19 @@ fn should_ignore(node: Node, context: &Context) -> bool {
     .contains(&node.span().start_line_fast(context.program))
     || in_left_hand_assignment(node)
     || is_declaration_ident(node)
+    || is_directly_in_condition(node)
+}
+
+fn is_directly_in_condition(node: Node) -> bool {
+  match node.parent() {
+    Some(Node::BinExpr(_)) => true,
+    Some(Node::IfStmt(_)) => true,
+    Some(Node::UnaryExpr(expr)) => expr.op() == UnaryOp::TypeOf,
+    Some(Node::CondExpr(cond_expr)) => {
+      cond_expr.test.span().contains(node.span())
+    }
+    _ => false,
+  }
 }
 
 fn is_declaration_ident(node: Node) -> bool {
@@ -149,6 +163,190 @@ fn in_left_hand_assignment(node: Node) -> bool {
       return expr.left.span().contains(node.span());
     }
   }
+  false
+}
+
+fn is_in_type(mut node: Node) -> bool {
+  // todo: add unit tests and investigate if there's something in swc that does this?
+  while let Some(parent) = node.parent() {
+    let is_type = match parent {
+      Node::ArrayLit(_)
+      | Node::ArrayPat(_)
+      | Node::ArrowExpr(_)
+      | Node::AssignExpr(_)
+      | Node::AssignPat(_)
+      | Node::AssignPatProp(_)
+      | Node::AssignProp(_)
+      | Node::AwaitExpr(_)
+      | Node::BinExpr(_)
+      | Node::BindingIdent(_)
+      | Node::BlockStmt(_)
+      | Node::BreakStmt(_)
+      | Node::CallExpr(_)
+      | Node::CatchClause(_)
+      | Node::Class(_)
+      | Node::ClassDecl(_)
+      | Node::ClassExpr(_)
+      | Node::ClassMethod(_)
+      | Node::ClassProp(_)
+      | Node::ComputedPropName(_)
+      | Node::CondExpr(_)
+      | Node::Constructor(_)
+      | Node::ContinueStmt(_)
+      | Node::DebuggerStmt(_)
+      | Node::Decorator(_)
+      | Node::DoWhileStmt(_)
+      | Node::EmptyStmt(_)
+      | Node::ExportAll(_)
+      | Node::ExportDecl(_)
+      | Node::ExportDefaultDecl(_)
+      | Node::ExportDefaultExpr(_)
+      | Node::ExportDefaultSpecifier(_)
+      | Node::ExportNamedSpecifier(_)
+      | Node::ExportNamespaceSpecifier(_)
+      | Node::ExprOrSpread(_)
+      | Node::ExprStmt(_)
+      | Node::FnDecl(_)
+      | Node::FnExpr(_)
+      | Node::ForInStmt(_)
+      | Node::ForOfStmt(_)
+      | Node::ForStmt(_)
+      | Node::Function(_)
+      | Node::GetterProp(_)
+      | Node::IfStmt(_)
+      | Node::ImportDecl(_)
+      | Node::ImportDefaultSpecifier(_)
+      | Node::ImportNamedSpecifier(_)
+      | Node::ImportStarAsSpecifier(_)
+      | Node::Invalid(_)
+      | Node::UnaryExpr(_)
+      | Node::UpdateExpr(_)
+      | Node::VarDecl(_)
+      | Node::VarDeclarator(_)
+      | Node::WhileStmt(_)
+      | Node::WithStmt(_)
+      | Node::YieldExpr(_)
+      | Node::JSXAttr(_)
+      | Node::JSXClosingElement(_)
+      | Node::JSXClosingFragment(_)
+      | Node::JSXElement(_)
+      | Node::JSXEmptyExpr(_)
+      | Node::JSXExprContainer(_)
+      | Node::JSXFragment(_)
+      | Node::JSXMemberExpr(_)
+      | Node::JSXNamespacedName(_)
+      | Node::JSXOpeningElement(_)
+      | Node::JSXOpeningFragment(_)
+      | Node::JSXSpreadChild(_)
+      | Node::JSXText(_)
+      | Node::KeyValuePatProp(_)
+      | Node::KeyValueProp(_)
+      | Node::LabeledStmt(_)
+      | Node::MetaPropExpr(_)
+      | Node::MethodProp(_)
+      | Node::Module(_)
+      | Node::NamedExport(_)
+      | Node::NewExpr(_)
+      | Node::ObjectLit(_)
+      | Node::ObjectPat(_)
+      | Node::OptChainExpr(_)
+      | Node::Param(_)
+      | Node::ParenExpr(_)
+      | Node::PrivateMethod(_)
+      | Node::PrivateName(_)
+      | Node::PrivateProp(_)
+      | Node::Regex(_)
+      | Node::RestPat(_)
+      | Node::ReturnStmt(_)
+      | Node::Script(_)
+      | Node::SeqExpr(_)
+      | Node::SetterProp(_)
+      | Node::SpreadElement(_)
+      | Node::StaticBlock(_)
+      | Node::Super(_)
+      | Node::SwitchCase(_)
+      | Node::SwitchStmt(_)
+      | Node::TaggedTpl(_)
+      | Node::ThisExpr(_)
+      | Node::ThrowStmt(_)
+      | Node::Tpl(_)
+      | Node::TplElement(_)
+      | Node::TryStmt(_)
+      | Node::TsEnumDecl(_)
+      | Node::TsEnumMember(_)
+      | Node::TsExportAssignment(_)
+      | Node::TsExternalModuleRef(_)
+      | Node::TsImportEqualsDecl(_)
+      | Node::TsModuleBlock(_)
+      | Node::TsModuleDecl(_)
+      | Node::TsNamespaceDecl(_)
+      | Node::TsNamespaceExportDecl(_) => Some(false),
+
+      Node::TsArrayType(_)
+      | Node::TsCallSignatureDecl(_)
+      | Node::TsConditionalType(_)
+      | Node::TsConstAssertion(_)
+      | Node::TsConstructSignatureDecl(_)
+      | Node::TsConstructorType(_)
+      | Node::TsExprWithTypeArgs(_)
+      | Node::TsFnType(_)
+      | Node::TsGetterSignature(_)
+      | Node::TsImportType(_)
+      | Node::TsIndexSignature(_)
+      | Node::TsIndexedAccessType(_)
+      | Node::TsInferType(_)
+      | Node::TsInterfaceBody(_)
+      | Node::TsInterfaceDecl(_)
+      | Node::TsIntersectionType(_)
+      | Node::TsKeywordType(_)
+      | Node::TsLitType(_)
+      | Node::TsMappedType(_)
+      | Node::TsMethodSignature(_)
+      | Node::TsNonNullExpr(_)
+      | Node::TsOptionalType(_)
+      | Node::TsParamProp(_)
+      | Node::TsParenthesizedType(_)
+      | Node::TsPropertySignature(_)
+      | Node::TsQualifiedName(_)
+      | Node::TsRestType(_)
+      | Node::TsSetterSignature(_)
+      | Node::TsThisType(_)
+      | Node::TsTplLitType(_)
+      | Node::TsTupleElement(_)
+      | Node::TsTupleType(_)
+      | Node::TsTypeAliasDecl(_)
+      | Node::TsTypeAnn(_)
+      | Node::TsTypeLit(_)
+      | Node::TsTypeOperator(_)
+      | Node::TsTypeParam(_)
+      | Node::TsTypeParamDecl(_)
+      | Node::TsTypeParamInstantiation(_)
+      | Node::TsTypePredicate(_)
+      | Node::TsTypeQuery(_)
+      | Node::TsTypeRef(_)
+      | Node::TsUnionType(_) => Some(true),
+
+      // may be a type
+      Node::TsTypeAssertion(expr) => {
+        Some(expr.type_ann.span().contains(node.span()))
+      }
+      Node::TsAsExpr(expr) => Some(expr.type_ann.span().contains(node.span())),
+
+      // still need more info
+      Node::BigInt(_)
+      | Node::Bool(_)
+      | Node::Null(_)
+      | Node::Number(_)
+      | Node::MemberExpr(_)
+      | Node::Str(_)
+      | Node::Ident(_) => None,
+    };
+    if let Some(is_type) = is_type {
+      return is_type;
+    }
+    node = parent;
+  }
+
   false
 }
 

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -105,17 +105,20 @@ async fn transform_deno_shim_with_name_collision() {
 async fn transform_global_this_deno() {
   assert_transforms(vec![
     (
-      "globalThis.Deno.readTextFile(); globalThis.test = 5;",
+      "globalThis.Deno.readTextFile(); globalThis.test = 5; true ? globalThis : globalThis; typeof globalThis.test;",
       concat!(
         r#"import * as denoShim from "test-shim";"#,
-        "\n({ ...denoShim, ...globalThis }).Deno.readTextFile(); globalThis.test = 5;"
+        "\n({ ...denoShim, ...globalThis }).Deno.readTextFile(); ",
+        "globalThis.test = 5; ",
+        "true ? ({ ...denoShim, ...globalThis }) : ({ ...denoShim, ...globalThis }); ",
+        "typeof ({ ...denoShim, ...globalThis }).test;"
       )
     ),
   ]).await;
 }
 
 #[tokio::test]
-async fn no_shim_for_declarations() {
+async fn no_shim_situations() {
   assert_identity_transforms(vec![
     "const { Deno } = test;",
     "const { asdf, ...Deno } = test;",
@@ -143,6 +146,10 @@ async fn no_shim_for_declarations() {
     "export { Deno as test } from 'test';",
     "try {} catch (Deno) {}",
     "function test(Deno) {}",
+    "typeof globalThis;",
+    "globalThis == null;",
+    "globalThis ? true : false;",
+    "type Test = typeof globalThis;",
   ])
   .await;
 }


### PR DESCRIPTION
Closes #22.

Also fixes a few more edge cases.