### PR TITLE
fix(types): fix types with global fallback (such as `Headers`)

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -116,7 +116,7 @@ export async function build(options: BuildOptions): Promise<void> {
 
   const shimPackage = options.shimPackage ?? {
     name: "deno.ns",
-    version: "0.7.0",
+    version: "0.7.2",
   };
 
   log("Transforming...");

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -7,13 +7,13 @@ import {
 import { build, BuildOptions } from "../mod.ts";
 
 const versions = {
-  denoNs: "0.7.0",
+  denoNs: "0.7.2",
   chalk: "4.1.2",
   nodeTypes: "16.11.1",
   tsLib: "2.3.1",
 };
 
-Deno.test("should build", async () => {
+Deno.test("should build test project", async () => {
   await runTest("test_project", {
     entryPoints: ["mod.ts"],
     outDir: "./npm",
@@ -278,7 +278,7 @@ test_runner.js
   });
 });
 
-Deno.test("should build", async () => {
+Deno.test("should build shim project", async () => {
   await runTest("shim_project", {
     entryPoints: ["mod.ts"],
     outDir: "./npm",

--- a/tests/test_project/mod.test.ts
+++ b/tests/test_project/mod.test.ts
@@ -6,3 +6,10 @@ import { assertEquals } from "https://deno.land/std@0.109.0/testing/asserts.ts";
 Deno.test("should add in test project", () => {
   assertEquals(add(1, 2), 3);
 });
+
+function _testTypes(headers: Headers) {
+  // this was previously erroring
+  const _test: string | null = headers.get("some-header-name");
+  const otherHeaders = new Headers();
+  const _test2: string | null = otherHeaders.get("some-header-name");
+}


### PR DESCRIPTION
Closes #18