### PR TITLE
fix: add better/instructional error message when `npm` command doesn't exist on the path

### DIFF
--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,19 @@
+import { assertRejects } from "./test.deps.ts";
+import { runCommand } from "./utils.ts";
+
+Deno.test({
+  name: "should error when command doesn't exist",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const commandName = "somenonexistentcommandforsure";
+    await assertRejects(
+      () =>
+        runCommand({
+          cmd: [commandName],
+          cwd: Deno.cwd(),
+        }),
+      Error,
+      `Could not find command '${commandName}'. Ensure it is available on the path.`,
+    );
+  },
+});


### PR DESCRIPTION
It's actually kind of amusing that this was a problem for someone.