### PR TITLE
feat: rename `// deno-shim-ignore` to `// dnt-shim-ignore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,10 +219,10 @@ import * as denoShim from "deno.ns";
 denoShim.Deno.readTextFileSync(...);
 ```
 
-Maybe there are scenarios where you don't want that to happen though. To prevent it, add a `// deno-shim-ignore` comment:
+Maybe there are scenarios where you don't want that to happen though. To prevent it, add a `// dnt-shim-ignore` comment:
 
 ```ts
-// deno-shim-ignore
+// dnt-shim-ignore
 Deno.readTextFileSync(...);
 ```
 
@@ -249,7 +249,7 @@ await build({
 });
 ```
 
-Then within the file, use `// deno-shim-ignore` directives to disable shimming if you desire.
+Then within the file, use `// dnt-shim-ignore` directives to disable shimming if you desire.
 
 ### Pre & Post Build Steps
 

--- a/rs-lib/src/visitors/analyze/get_ignore_line_indexes.rs
+++ b/rs-lib/src/visitors/analyze/get_ignore_line_indexes.rs
@@ -2,19 +2,36 @@ use std::collections::HashSet;
 
 use deno_ast::view::*;
 
-pub fn get_ignore_line_indexes(program: &Program) -> HashSet<usize> {
-  let mut result = HashSet::new();
+pub struct IgnoredLineIndexes {
+  pub warnings: Vec<String>,
+  pub line_indexes: HashSet<usize>,
+}
+
+pub fn get_ignore_line_indexes(
+  specifier: &str,
+  program: &Program,
+) -> IgnoredLineIndexes {
+  let mut warnings = Vec::new();
+  let mut line_indexes = HashSet::new();
   for comment in program.comment_container().unwrap().all_comments() {
-    if comment
-      .text
-      .trim()
-      .to_lowercase()
-      .starts_with("deno-shim-ignore")
+    let lowercase_text = comment.text.trim().to_lowercase();
+    let starts_with_deno_shim_ignore =
+      lowercase_text.starts_with("deno-shim-ignore");
+    if starts_with_deno_shim_ignore
+      || lowercase_text.starts_with("dnt-shim-ignore")
     {
       if let Some(next_token) = comment.next_token_fast(program) {
-        result.insert(next_token.span.lo.start_line_fast(program));
+        line_indexes.insert(next_token.span.lo.start_line_fast(program));
       }
     }
+    if starts_with_deno_shim_ignore {
+      warnings.push(
+        format!("deno-shim-ignore has been renamed to dnt-shim-ignore. Please rename it in {}", specifier)
+      );
+    }
   }
-  result
+  IgnoredLineIndexes {
+    warnings,
+    line_indexes,
+  }
 }


### PR DESCRIPTION
This will give a warning for now if using the old one.

Closes #62