### PR TITLE
feat: `globalThis` proxy shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ Deno.readTextFileSync(...);
 ...then dnt will create a shim file in the output, re-exporting the [@deno/shim-deno](https://github.com/denoland/node_deno_shims) npm shim package and change the Deno global be used as a property of this object.
 
 ```ts
-import * as dntGlobalShim from "./_dnt.shims.js";
+import * as dntShim from "./_dnt.shims.js";
 
-dntGlobalShim.Deno.readTextFileSync(...);
+dntShim.Deno.readTextFileSync(...);
 ```
 
 #### Test-Only Shimming

--- a/lib/pkg/dnt_wasm.js
+++ b/lib/pkg/dnt_wasm.js
@@ -407,8 +407,8 @@ async function init(input) {
     imports.wbg.__wbindgen_throw = function(arg0, arg1) {
         throw new Error(getStringFromWasm0(arg0, arg1));
     };
-    imports.wbg.__wbindgen_closure_wrapper385 = function(arg0, arg1, arg2) {
-        var ret = makeMutClosure(arg0, arg1, 148, __wbg_adapter_24);
+    imports.wbg.__wbindgen_closure_wrapper389 = function(arg0, arg1, arg2) {
+        var ret = makeMutClosure(arg0, arg1, 151, __wbg_adapter_24);
         return addHeapObject(ret);
     };
 

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -96,7 +96,7 @@ pub struct MappedSpecifier {
 
 #[cfg_attr(feature = "serialization", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GlobalName {
   /// Name to use as the global name.
   pub name: String,
@@ -108,7 +108,7 @@ pub struct GlobalName {
 
 #[cfg_attr(feature = "serialization", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Shim {
   /// Information about the npm package to use for this shim.
   pub package: MappedSpecifier,

--- a/rs-lib/src/scripts/createMergeProxy.test.ts
+++ b/rs-lib/src/scripts/createMergeProxy.test.ts
@@ -1,0 +1,59 @@
+import { createMergeProxy } from "./createMergeProxy.ts";
+
+Deno.test("should merge two objects", () => {
+  const baseObj = {
+    shared1: "base_shared1",
+    base1: "base_base1",
+  };
+  const extObj = {
+    shared1: "ext_shared1",
+    ext1: "ext_ext1",
+  };
+  const merged = createMergeProxy(baseObj, extObj);
+
+  // get
+  assertEqual(merged.base1, "base_base1");
+  assertEqual(merged.shared1, "ext_shared1");
+  assertEqual(merged.ext1, "ext_ext1");
+
+  // keys
+  const keys = Object.keys(merged);
+  assertEqual(keys.length, 3);
+  assertEqual(keys[0], "base1");
+  assertEqual(keys[1], "shared1");
+  assertEqual(keys[2], "ext1");
+
+  // has own
+  assertEqual(Object.hasOwn(merged, "ext1"), true);
+  assertEqual(Object.hasOwn(merged, "base1"), true);
+  assertEqual(Object.hasOwn(merged, "random"), false);
+
+  // setting property
+  merged.ext1 = "asdf";
+  assertEqual(merged.ext1, "asdf");
+  assertEqual((baseObj as any).ext1, "asdf");
+  assertEqual(extObj.ext1, undefined);
+
+  // deleting property
+  delete (merged as any).shared1;
+  assertEqual(merged.shared1, undefined);
+  assertEqual(baseObj.shared1, undefined);
+  assertEqual(extObj.shared1, undefined);
+});
+
+Deno.test("should allow spreading globalThis", () => {
+  const extObj = {
+    test: 5,
+  };
+  const merged = createMergeProxy(globalThis, extObj);
+  // was getting an error when not using Reflect.ownKeys
+  const _result = { ...merged, extObj };
+  const { test } = merged;
+  assertEqual(test, 5);
+});
+
+function assertEqual(a: any, b: any) {
+  if (a !== b) {
+    throw new Error(`The value ${a} did not equal ${b}.`);
+  }
+}

--- a/rs-lib/src/scripts/createMergeProxy.ts
+++ b/rs-lib/src/scripts/createMergeProxy.ts
@@ -1,0 +1,57 @@
+// deno-lint-ignore ban-types
+export function createMergeProxy<T extends object, U extends object>(
+  baseObj: T,
+  extObj: U,
+): Omit<T, keyof U> & U {
+  return new Proxy(baseObj, {
+    get(_target, prop, _receiver) {
+      if (prop in extObj) {
+        return (extObj as any)[prop];
+      } else {
+        return (baseObj as any)[prop];
+      }
+    },
+    set(_target, prop, value) {
+      if (prop in extObj) {
+        delete (extObj as any)[prop];
+      }
+      (baseObj as any)[prop] = value;
+      return true;
+    },
+    deleteProperty(_target, prop) {
+      let success = false;
+      if (prop in extObj) {
+        delete (extObj as any)[prop];
+        success = true;
+      }
+      if (prop in baseObj) {
+        delete (baseObj as any)[prop];
+        success = true;
+      }
+      return success;
+    },
+    ownKeys(_target) {
+      const baseKeys = Reflect.ownKeys(baseObj);
+      const extKeys = Reflect.ownKeys(extObj);
+      const extKeysSet = new Set(extKeys);
+      return [...baseKeys.filter((k) => !extKeysSet.has(k)), ...extKeys];
+    },
+    defineProperty(_target, prop, desc) {
+      if (prop in extObj) {
+        delete (extObj as any)[prop];
+      }
+      Reflect.defineProperty(baseObj, prop, desc);
+      return true;
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      if (prop in extObj) {
+        return Reflect.getOwnPropertyDescriptor(extObj, prop);
+      } else {
+        return Reflect.getOwnPropertyDescriptor(baseObj, prop);
+      }
+    },
+    has(_target, prop) {
+      return prop in extObj || prop in baseObj;
+    },
+  }) as any;
+}

--- a/rs-lib/tests/integration/test_builder.rs
+++ b/rs-lib/tests/integration/test_builder.rs
@@ -73,6 +73,7 @@ impl TestBuilder {
       global_names: vec![GlobalName {
         name: "Deno".to_string(),
         export_name: None,
+        type_only: false,
       }],
     };
     self.add_shim(deno_shim.clone());
@@ -86,10 +87,12 @@ impl TestBuilder {
         GlobalName {
           name: "setTimeout".to_string(),
           export_name: None,
+          type_only: false,
         },
         GlobalName {
           name: "setInterval".to_string(),
           export_name: None,
+          type_only: false,
         },
       ],
     };

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -366,6 +366,9 @@ Deno.test("should build shim project when using node-fetch", async () => {
         globalNames: [{
           name: "fetch",
           exportName: "default",
+        }, {
+          name: "RequestInit",
+          typeOnly: true,
         }],
       }],
     },
@@ -395,28 +398,30 @@ export { setInterval, setTimeout } from "@deno/shim-timers";
 import { File, FormData, Headers, Request, Response } from "undici";
 export { File, FormData, Headers, Request, Response } from "undici";
 import { default as fetch } from "node-fetch";
-export { default as fetch } from "node-fetch";
+export { default as fetch, type RequestInit } from "node-fetch";
+
 const dntGlobals = {
-    Deno,
-    Blob,
-    crypto,
-    alert,
-    confirm,
-    prompt,
-    setInterval,
-    setTimeout,
-    File,
-    FormData,
-    Headers,
-    Request,
-    Response,
-    fetch,
+  Deno,
+  Blob,
+  crypto,
+  alert,
+  confirm,
+  prompt,
+  setInterval,
+  setTimeout,
+  File,
+  FormData,
+  Headers,
+  Request,
+  Response,
+  fetch,
 };
 `;
     assertEquals(
-      output.getFileText("esm/_dnt.shims.js").substring(0, expectedText.length),
+      output.getFileText("src/_dnt.shims.ts").substring(0, expectedText.length),
       expectedText,
     );
+    output.assertExists("esm/_dnt.shims.js");
   });
 });
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -382,16 +382,40 @@ Deno.test("should build shim project when using node-fetch", async () => {
       "undici": versions.undici,
       "node-fetch": "~3.1.0",
     });
-    assertEquals(
-      output.getFileText("esm/_dnt.shims.js"),
-      `export { Deno } from "@deno/shim-deno";
+    const expectedText = `import { Deno } from "@deno/shim-deno";
+export { Deno } from "@deno/shim-deno";
+import { Blob } from "buffer";
 export { Blob } from "buffer";
+import { crypto } from "@deno/shim-crypto";
 export { crypto } from "@deno/shim-crypto";
+import { alert, confirm, prompt } from "@deno/shim-prompts";
 export { alert, confirm, prompt } from "@deno/shim-prompts";
+import { setInterval, setTimeout } from "@deno/shim-timers";
 export { setInterval, setTimeout } from "@deno/shim-timers";
+import { File, FormData, Headers, Request, Response } from "undici";
 export { File, FormData, Headers, Request, Response } from "undici";
+import { default as fetch } from "node-fetch";
 export { default as fetch } from "node-fetch";
-`,
+const dntGlobals = {
+    Deno,
+    Blob,
+    crypto,
+    alert,
+    confirm,
+    prompt,
+    setInterval,
+    setTimeout,
+    File,
+    FormData,
+    Headers,
+    Request,
+    Response,
+    fetch,
+};
+`;
+    assertEquals(
+      output.getFileText("esm/_dnt.shims.js").substring(0, expectedText.length),
+      expectedText,
     );
   });
 });

--- a/transform.ts
+++ b/transform.ts
@@ -33,6 +33,8 @@ export interface GlobalName {
    * @remarks Defaults to the name. Specify `"default"` to use the default export.
    */
   exportName?: string;
+  /** Whether this is a name that only exists as a type declaration. */
+  typeOnly?: boolean;
 }
 
 export interface Shim {
@@ -123,8 +125,10 @@ function mapToGlobalName(value: string | GlobalName): GlobalName {
   if (typeof value === "string") {
     return {
       name: value,
+      typeOnly: false,
     };
   } else {
+    value.typeOnly ??= false;
     return value;
   }
 }


### PR DESCRIPTION
This PR adds a `globalThis` proxy shim, which will be more correct and faster than the previous `({ ..globalThis, ..dntShim })` business that was going on before.

Additionaly, since shimming is a bit more complicated now there needed a way to be able to say "this global is type only". So now that can be done by setting the `typeOnly` property on the `GlobalName` to true:

```ts
globalNames: [{
  name: "MyType",
  typeOnly: true,
}],
```