### PR TITLE
feat: allow to override package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,21 +454,12 @@ await build({
 
 For some reasons you may want to use another Node.js package manager, such as Yarn or pnpm. You can override the `packageManager` option in build options. Default value is `npm`.
 
-If you're using Yarn:
+For example:
 
 ```ts
 await build({
   // ...etc...
-  packageManager: "yarn",
-});
-```
-
-If you're using pnpm:
-
-```ts
-await build({
-  // ...etc...
-  packageManager: "pnpm",
+  packageManager: "yarn", // or "pnpm"
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -450,6 +450,38 @@ await build({
 
 1. Ensure the workflow will run on tag creation. For example, see [Trigger GitHub Action Only on New Tags](https://stackoverflow.com/q/61891328/188246)).
 
+### Using Another Package Manager
+
+For some reasons you may want to use another Node.js package manager, such as Yarn or pnpm.
+You can override the `packageManager` option in build options. Default value is `npm`.
+
+If you're using Yarn:
+
+```ts
+await build({
+  // ...etc...
+  packageManager: 'yarn',
+});
+```
+
+If you're using pnpm:
+
+```ts
+await build({
+  // ...etc...
+  packageManager: 'pnpm',
+});
+```
+
+You can even specify an absolute path to the executable file of package manager:
+
+```ts
+await build({
+  // ...etc...
+  packageManager: '/usr/bin/pnpm',
+});
+```
+
 ## JS API Example
 
 For only the Deno to canonical TypeScript transform which may be useful for bundlers, use the following:

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ If you're using Yarn:
 ```ts
 await build({
   // ...etc...
-  packageManager: 'yarn',
+  packageManager: "yarn",
 });
 ```
 
@@ -469,7 +469,7 @@ If you're using pnpm:
 ```ts
 await build({
   // ...etc...
-  packageManager: 'pnpm',
+  packageManager: "pnpm",
 });
 ```
 
@@ -478,7 +478,7 @@ You can even specify an absolute path to the executable file of package manager:
 ```ts
 await build({
   // ...etc...
-  packageManager: '/usr/bin/pnpm',
+  packageManager: "/usr/bin/pnpm",
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -452,8 +452,7 @@ await build({
 
 ### Using Another Package Manager
 
-For some reasons you may want to use another Node.js package manager, such as Yarn or pnpm.
-You can override the `packageManager` option in build options. Default value is `npm`.
+For some reasons you may want to use another Node.js package manager, such as Yarn or pnpm. You can override the `packageManager` option in build options. Default value is `npm`.
 
 If you're using Yarn:
 

--- a/lib/npm_ignore.test.ts
+++ b/lib/npm_ignore.test.ts
@@ -65,6 +65,8 @@ function runTest(options: {
     return startText + `esm/mod.test.js
 umd/mod.test.js
 test_runner.js
+yarn.lock
+pnpm-lock.yaml
 `;
   }
 }

--- a/lib/npm_ignore.ts
+++ b/lib/npm_ignore.ts
@@ -17,6 +17,7 @@ export function getNpmIgnoreText(options: {
   for (const fileName of getTestFileNames()) {
     lines.push(fileName);
   }
+  lines.push("yarn.lock", "pnpm-lock.yaml");
   return Array.from(lines).join("\n") + "\n";
 
   function* getTestFileNames() {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -23,12 +23,13 @@ export async function glob(options: {
   return paths;
 }
 
-export function runNpmCommand({ args, cwd }: {
+export function runNpmCommand({ bin, args, cwd }: {
+  bin: string;
   args: string[];
   cwd: string;
 }) {
   return runCommand({
-    cmd: ["npm", ...args],
+    cmd: [bin, ...args],
     cwd,
   });
 }

--- a/mod.ts
+++ b/mod.ts
@@ -85,6 +85,10 @@ export interface BuildOptions {
   redirects?: Redirects;
   /** Package.json output. You may override dependencies and dev dependencies in here. */
   package: PackageJsonObject;
+  /** Package manager used to install dependencies and run npm scripts.
+   * @default npm
+   */
+  packageManager?: string;
   /** Optional compiler options. */
   compilerOptions?: {
     /** Uses tslib to import helper functions once per project instead of including them per-file if necessary.
@@ -119,6 +123,7 @@ export async function build(options: BuildOptions): Promise<void> {
     test: options.test ?? true,
     declaration: options.declaration ?? true,
   };
+  const packageManager = options.packageManager ?? "npm";
   const entryPoints: EntryPoint[] = options.entryPoints.map((e, i) => {
     if (typeof e === "string") {
       return {
@@ -154,6 +159,7 @@ export async function build(options: BuildOptions): Promise<void> {
   // npm install in order to prepare for checking TS diagnostics
   log("Running npm install...");
   const npmInstallPromise = runNpmCommand({
+    bin: packageManager,
     args: ["install"],
     cwd: options.outDir,
   });
@@ -310,6 +316,7 @@ export async function build(options: BuildOptions): Promise<void> {
     log("Running tests...");
     createTestLauncherScript();
     await runNpmCommand({
+      bin: packageManager,
       args: ["run", "test"],
       cwd: options.outDir,
     });

--- a/mod.ts
+++ b/mod.ts
@@ -86,9 +86,10 @@ export interface BuildOptions {
   /** Package.json output. You may override dependencies and dev dependencies in here. */
   package: PackageJsonObject;
   /** Package manager used to install dependencies and run npm scripts.
-   * @default npm
+   * This also can be an absolute path to the executable file of package manager.
+   * @default "npm"
    */
-  packageManager?: string;
+  packageManager?: "npm" | "yarn" | "pnpm" | string;
   /** Optional compiler options. */
   compilerOptions?: {
     /** Uses tslib to import helper functions once per project instead of including them per-file if necessary.

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -74,6 +74,8 @@ umd/deps/deno_land_std_0_119_0/testing/asserts.js
 esm/_dnt.test_shims.js
 umd/_dnt.test_shims.js
 test_runner.js
+yarn.lock
+pnpm-lock.yaml
 `,
     );
   });
@@ -117,6 +119,8 @@ Deno.test("should build with all options off", async () => {
       output.npmIgnore,
       `src/
 test_runner.js
+yarn.lock
+pnpm-lock.yaml
 `,
     );
   });
@@ -254,6 +258,8 @@ umd/deps/deno_land_std_0_119_0/testing/asserts.js
 esm/_dnt.test_shims.js
 umd/_dnt.test_shims.js
 test_runner.js
+yarn.lock
+pnpm-lock.yaml
 `,
     );
   });
@@ -311,6 +317,8 @@ umd/mod.test.js
 esm/_dnt.test_shims.js
 umd/_dnt.test_shims.js
 test_runner.js
+yarn.lock
+pnpm-lock.yaml
 `,
     );
   });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -484,6 +484,28 @@ Deno.test("should handle json modules", async () => {
   });
 });
 
+Deno.test("should build project with another package manager", async () => {
+  await runTest("test_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    shims: {
+      ...getAllShimOptions(false),
+      deno: "dev",
+    },
+    package: {
+      name: "add",
+      version: "1.0.0",
+    },
+    packageManager: "yarn",
+    typeCheck: false,
+    cjs: false,
+    declaration: false,
+  }, (output) => {
+    output.assertExists("yarn.lock");
+    output.assertNotExists("package-lock.json");
+  });
+});
+
 export interface Output {
   packageJson: any;
   npmIgnore: string;


### PR DESCRIPTION
This PR introduces a new build option: `packageManager` which allows to use Yarn or pnpm.