### PR TITLE
feat: add `Deno.test`-only shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ There are several steps done in a pipeline:
        license: "MIT",
        repository: {
          type: "git",
-         url: "git+https://github.com/username/package.git",
+         url: "git+https://github.com/username/repo.git",
        },
        bugs: {
-         url: "https://github.com/username/package/issues",
+         url: "https://github.com/username/repo/issues",
        },
      },
    });
@@ -189,6 +189,23 @@ Set any of these properties to `true` (distribution and test) or `"dev"` (test o
 - `blob` - Shim the `Blob` global with the one from the `"buffer"` module.
 - `crypto` - Shim the `crypto` global.
 - `undici` - Shim `fetch`, `File`, `FormData`, `Headers`, `Request`, and `Response` by using the "undici" package (https://www.npmjs.com/package/undici).
+
+##### `Deno.test`-only shim
+
+If you only want to shim `Deno.test` then provide the following:
+
+```ts
+await build({
+  // ...etc...
+  shims: {
+    deno: {
+      test: "dev",
+    },
+  },
+});
+```
+
+This may be useful in Node v14 and below where the full deno shim doesn't always work. See the section on Node v14 below for more details
 
 #### Custom Shims (Advanced)
 
@@ -372,6 +389,8 @@ await build({
 
 Then within the file, use `// dnt-shim-ignore` directives to disable shimming if you desire.
 
+A redirect file should be written similar to how you write Deno code (ex. use extensions on imports), except you can also import built-in node modules such as `import fs from "fs";` (just remember to include an `@types/node` dev dependency, if necessary).
+
 ### Pre & Post Build Steps
 
 Since the file you're calling is a script, simply add statements before and after the `await build({ ... })` statement:
@@ -483,7 +502,7 @@ await build({
 
 ### Using Another Package Manager
 
-For some reasons you may want to use another Node.js package manager, such as Yarn or pnpm. You can override the `packageManager` option in build options. Default value is `npm`.
+You may want to use another Node.js package manager instead of npm, such as Yarn or pnpm. To do this, override the `packageManager` option in the build options.
 
 For example:
 
@@ -494,7 +513,7 @@ await build({
 });
 ```
 
-You can even specify an absolute path to the executable file of package manager:
+You can even specify an absolute path to the executable file of the package manager:
 
 ```ts
 await build({
@@ -502,6 +521,14 @@ await build({
   packageManager: "/usr/bin/pnpm",
 });
 ```
+
+### Node v14 and Below
+
+dnt should be able to target old versions of Node by specifying a `{ compilerOption: { target: ... }}` value in the build options (see [Node Target Mapping](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping) for what target maps to what Node version). A problem though is that certain shims might not work in old versions of Node.
+
+If wanting to target a version of Node v14 and below, its recommend to use the `Deno.test`-only shim (described above) and then making use of the "redirects" feature to write Node-only files where you can handle differences. Alternatively, see if changes to the shim libraries might make it run on old versions of Node. Unfortunately, certain features are impossible or infeasible to get working.
+
+See [this thread](https://github.com/denoland/node_deno_shims/issues/15) in node_deno_shims for more details.
 
 ## JS API Example
 

--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -64,11 +64,11 @@ export function getPackageJson({
     ...(!Object.keys(dependencies).includes("@types/node") &&
         // todo(dsherret): don't hardcode the package name here and come up with some better solution
         (transformOutput.main.dependencies.some((d) =>
-          d.name === "@deno/shim-deno"
+          d.name === "@deno/shim-deno" || d.name === "@deno/shim-deno-test"
         ) ||
           (testEnabled &&
             transformOutput.test.dependencies.some((d) =>
-              d.name === "@deno/shim-deno"
+              d.name === "@deno/shim-deno" || d.name === "@deno/shim-deno-test"
             )))
       ? {
         "@types/node": "16.11.1",

--- a/lib/shims.test.ts
+++ b/lib/shims.test.ts
@@ -65,3 +65,16 @@ Deno.test("should get when all undefined", () => {
   assertEquals(result.shims.length, 0);
   assertEquals(result.testShims.length, 0);
 });
+
+Deno.test("should get for inner deno namespace", () => {
+  const result = shimOptionsToTransformShims({
+    deno: {
+      test: true,
+    },
+  });
+
+  assertEquals(result.shims.length, 1);
+  assertEquals(result.shims[0].package.name, "@deno/shim-deno-test");
+  assertEquals(result.testShims.length, 1);
+  assertEquals(result.testShims[0].package.name, "@deno/shim-deno-test");
+});

--- a/lib/test_runner/get_test_runner_code.test.ts
+++ b/lib/test_runner/get_test_runner_code.test.ts
@@ -10,8 +10,7 @@ const runTestDefinitionsCode = runTestDefinitions.toString()
 Deno.test("gets code when no shim used", () => {
   const code = getTestRunnerCode({
     testEntryPoints: ["./test.ts"],
-    shimPackageName: "test-shim-package",
-    testShimUsed: false,
+    denoTestShimPackageName: undefined,
     includeCjs: true,
   });
   assertEquals(
@@ -53,8 +52,7 @@ main();
 Deno.test("gets code when shim used", () => {
   const code = getTestRunnerCode({
     testEntryPoints: ["./1.test.ts", "./2.test.ts"],
-    shimPackageName: "test-shim-package",
-    testShimUsed: true,
+    denoTestShimPackageName: "test-shim-package/test-internals",
     includeCjs: true,
   });
   assertEquals(
@@ -102,8 +100,7 @@ main();
 Deno.test("gets code when cjs is not used", () => {
   const code = getTestRunnerCode({
     testEntryPoints: ["./test.ts"],
-    shimPackageName: "test-shim-package",
-    testShimUsed: false,
+    denoTestShimPackageName: undefined,
     includeCjs: false,
   });
   assertEquals(

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -5,16 +5,15 @@ import { runTestDefinitions } from "./test_runner.ts";
 
 export function getTestRunnerCode(options: {
   testEntryPoints: string[];
-  testShimUsed: boolean;
-  shimPackageName: string;
+  denoTestShimPackageName: string | undefined;
   includeCjs: boolean | undefined;
 }) {
   const writer = createWriter();
   writer.writeLine(`const chalk = require("chalk");`)
     .writeLine(`const process = require("process");`);
-  if (options.testShimUsed) {
+  if (options.denoTestShimPackageName != null) {
     writer.writeLine(
-      `const { testDefinitions } = require("${options.shimPackageName}/test-internals");`,
+      `const { testDefinitions } = require("${options.denoTestShimPackageName}");`,
     );
   }
   writer.blankLine();
@@ -45,7 +44,7 @@ export function getTestRunnerCode(options: {
           );
           writer.writeLine(`process.chdir(__dirname + "/umd");`);
           writer.writeLine(`require(umdPath);`);
-          if (options.testShimUsed) {
+          if (options.denoTestShimPackageName != null) {
             writer.writeLine(
               "await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), testContext);",
             );
@@ -59,7 +58,7 @@ export function getTestRunnerCode(options: {
           `console.log("\\nRunning tests in " + chalk.underline(esmPath) + "...\\n");`,
         );
         writer.writeLine(`await import(esmPath);`);
-        if (options.testShimUsed) {
+        if (options.denoTestShimPackageName != null) {
           writer.writeLine(
             "await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), testContext);",
           );
@@ -68,7 +67,7 @@ export function getTestRunnerCode(options: {
   });
   writer.blankLine();
 
-  if (options.testShimUsed) {
+  if (options.denoTestShimPackageName != null) {
     writer.writeLine(`${getRunTestDefinitionsCode()}`);
     writer.blankLine();
   }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -8,6 +8,7 @@ import { build, BuildOptions, ShimOptions } from "../mod.ts";
 
 const versions = {
   denoShim: "~0.1.1",
+  denoTestShim: "~0.2.0",
   cryptoShim: "~0.2.0",
   promptsShim: "~0.1.0",
   timersShim: "~0.1.0",
@@ -169,6 +170,34 @@ Deno.test("should build bin project", async () => {
       output.getFileText("esm/mod.js").substring(0, expectedText.length),
       expectedText,
     );
+  });
+});
+
+Deno.test("should run tests when using @deno/shim-deno-test shim", async () => {
+  await runTest("test_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    shims: {
+      ...getAllShimOptions(false),
+      deno: {
+        test: "dev",
+      },
+    },
+    package: {
+      name: "add",
+      version: "1.0.0",
+    },
+    compilerOptions: {
+      importHelpers: true,
+    },
+  }, (output) => {
+    output.assertNotExists("umd/mod.js.map");
+    output.assertNotExists("esm/mod.js.map");
+    assertEquals(output.packageJson.devDependencies, {
+      "@types/node": versions.nodeTypes,
+      chalk: versions.chalk,
+      "@deno/shim-deno-test": versions.denoTestShim,
+    });
   });
 });
 
@@ -489,7 +518,7 @@ Deno.test("should build polyfill project", async () => {
   });
 });
 
-Deno.test("should build and test node files project", async () => {
+Deno.test("should build and test redirects files project", async () => {
   await runTest("redirects_project", {
     entryPoints: ["mod.ts"],
     outDir: "./npm",

--- a/tests/redirects_project/node_file.ts
+++ b/tests/redirects_project/node_file.ts
@@ -1,0 +1,3 @@
+export function getValue() {
+  return "node";
+}

--- a/tests/redirects_project/output.node.ts
+++ b/tests/redirects_project/output.node.ts
@@ -1,3 +1,5 @@
+import { getValue } from "./node_file.ts";
+
 export function output() {
-  return "node";
+  return getValue();
 }


### PR DESCRIPTION
For running `Deno.test` code on very old node versions where the `Deno` shim might not work at the moment.