### PR TITLE
fix: actually fail when require(umdPath) throws

### DIFF
--- a/lib/test_runner/get_test_runner_code.test.ts
+++ b/lib/test_runner/get_test_runner_code.test.ts
@@ -35,7 +35,12 @@ async function main() {
     const umdPath = "./umd/" + filePath;
     console.log("Running tests in " + chalk.underline(umdPath) + "...\\n");
     process.chdir(__dirname + "/umd");
-    require(umdPath);
+    try {
+      require(umdPath);
+    } catch(err) {
+      console.error(err);
+      process.exit(1);
+    }
 
     const esmPath = "./esm/" + filePath;
     process.chdir(__dirname + "/esm");
@@ -79,7 +84,12 @@ async function main() {
     const umdPath = "./umd/" + filePath;
     console.log("Running tests in " + chalk.underline(umdPath) + "...\\n");
     process.chdir(__dirname + "/umd");
-    require(umdPath);
+    try {
+      require(umdPath);
+    } catch(err) {
+      console.error(err);
+      process.exit(1);
+    }
     await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), testContext);
 
     const esmPath = "./esm/" + filePath;

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -43,11 +43,11 @@ export function getTestRunnerCode(options: {
             `console.log("Running tests in " + chalk.underline(umdPath) + "...\\n");`,
           );
           writer.writeLine(`process.chdir(__dirname + "/umd");`);
-          writer.writeLine("try").block(() => {
+          writer.write("try ").inlineBlock(() => {
             writer.writeLine(`require(umdPath);`);
-          }).write("catch(err)").block(() => {
-            writer.writeLine("console.error(err)");
-            writer.writeLine("process.exit(1)");
+          }).write(" catch(err)").block(() => {
+            writer.writeLine("console.error(err);");
+            writer.writeLine("process.exit(1);");
           });
           if (options.denoTestShimPackageName != null) {
             writer.writeLine(

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -43,7 +43,12 @@ export function getTestRunnerCode(options: {
             `console.log("Running tests in " + chalk.underline(umdPath) + "...\\n");`,
           );
           writer.writeLine(`process.chdir(__dirname + "/umd");`);
-          writer.writeLine(`require(umdPath);`);
+          writer.writeLine("try").block(() => {
+            writer.writeLine(`require(umdPath);`);
+          }).write("catch(err)").block(() => {
+            writer.writeLine("console.error(err)");
+            writer.writeLine("process.exit(1)");
+          });
           if (options.denoTestShimPackageName != null) {
             writer.writeLine(
               "await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), testContext);",


### PR DESCRIPTION
The generated test script did not actually fail when `require(umdPath)` throws.
Wrapping it in a try catch and explicitly calling `process.exit(1)` seems to do the trick.

This resolves #86 