### PR TITLE
fix: remove `dntGlobalThisType` and try to inline `globalThis.X` shim types directly instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Set any of these properties to `true` (distribution and test) or `"dev"` (test o
 - `crypto` - Shim the `crypto` global.
 - `domException` - Shim the `DOMException` global using the "domexception" package (https://www.npmjs.com/package/domexception)
 - `undici` - Shim `fetch`, `File`, `FormData`, `Headers`, `Request`, and `Response` by using the "undici" package (https://www.npmjs.com/package/undici).
+- `weakRef` - Sham for the `WeakRef` global, which uses `globalThis.WeakRef` when it exists. The sham will throw at runtime when calling `deref()` and `WeakRef` doesn't globally exist, so this is only intended to help type check code that won't actually use it.
 
 ##### `Deno.test`-only shim
 
@@ -232,14 +233,17 @@ await build({
         exportName: "default",
       }, {
         name: "RequestInit",
-        typeOnly: true, // only used in type declarations
+        kind: "typeOnly", // only used in type declarations
       }],
     }, {
       // this is what `blob: true` does internally
       package: {
         name: "buffer", // uses node's "buffer" module
       },
-      globalNames: ["Blob"],
+      globalNames: [{
+        name: "Blob",
+        kind: "class",
+      }],
     }, {
       // this is what `domException: true` does internally
       package: {
@@ -252,6 +256,7 @@ await build({
       },
       globalNames: [{
         name: "DOMException",
+        kind: "class",
         exportName: "default",
       }],
     }],
@@ -262,7 +267,13 @@ await build({
         name: "@deno/shim-timers",
         version: "~0.1.0",
       },
-      globalNames: ["setTimeout", "setInterval"],
+      globalNames: [{
+        name: "setTimeout",
+        kind: "value",
+      }, {
+        name: "setInterval",
+        kind: "value",
+      }],
     }],
   },
 });

--- a/lib/shims.ts
+++ b/lib/shims.ts
@@ -37,9 +37,9 @@ export interface ShimOptions {
    * using the "undici" package (https://www.npmjs.com/package/undici).
    */
   undici?: ShimValue;
-  /** Use a sham for the `WeakRef` global, which uses `globalThis.WeakRef`
-   * when it exists. The sham will throw at runtime when `WeakRef` doesn't
-   * globally exist, so this is only intended to help type check code that
+  /** Use a sham for the `WeakRef` global, which uses `globalThis.WeakRef` when
+   * it exists. The sham will throw at runtime when calling `deref()` and `WeakRef`
+   * doesn't globally exist, so this is only intended to help type check code that
    * won't actually use it.
    */
   weakRef?: ShimValue;
@@ -205,6 +205,10 @@ function getUndiciShim(): Shim {
       "Headers",
       "Request",
       "Response",
+      typeOnly("BodyInit"),
+      typeOnly("HeadersInit"),
+      typeOnly("RequestInit"),
+      typeOnly("ResponseInit"),
     ],
   };
 }

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -474,7 +474,11 @@ fn check_add_shim_file_to_environment(
 
     let mut text = String::new();
     for shim in shims.iter() {
-      let declaration_names = shim.global_names.iter().collect::<Vec<_>>();
+      let declaration_names = shim
+        .global_names
+        .iter()
+        .filter(|n| !n.type_only)
+        .collect::<Vec<_>>();
       if !declaration_names.is_empty() {
         text.push_str(&format!(
           "import {{ {} }} from \"{}\";\n",
@@ -510,14 +514,7 @@ fn check_add_shim_file_to_environment(
       }
     }
     text.push_str("};\n");
-    text.push_str("export const dntGlobalThis = createMergeProxy(globalThis, dntGlobals);\n");
-    text.push_str("export type dntGlobalThisType = Omit<typeof dntGlobals, keyof typeof dntGlobals> & typeof dntGlobals & {\n");
-    for global_name in shims.iter().map(|s| s.global_names.iter()).flatten() {
-      if global_name.type_only {
-        text.push_str(&format!("  {0}: {0},\n", global_name.name));
-      }
-    }
-    text.push_str("};\n");
+    text.push_str("export const dntGlobalThis = createMergeProxy(globalThis, dntGlobals);\n\n");
 
     text.push_str(
       &include_str!("scripts/createMergeProxy.ts")

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -178,9 +178,8 @@ async fn transform_shim_custom_shims() {
             "export { fetchTestName as fetchTest } from \"node-fetch/test\";\n",
             "import { default as DOMException } from \"domexception\";\n",
             "export { default as DOMException } from \"domexception\";\n",
-            "import { Blob, type Other } from \"buffer\";\n",
+            "import { Blob } from \"buffer\";\n",
             "export { Blob, type Other } from \"buffer\";\n",
-            "import { type TypeOnly } from \"type-only\";\n",
             "export { type TypeOnly } from \"type-only\";\n",
             "\n",
             "const dntGlobals = {\n",
@@ -190,10 +189,6 @@ async fn transform_shim_custom_shims() {
             "  Blob,\n",
             "};\n",
             "export const dntGlobalThis = createMergeProxy(globalThis, dntGlobals);\n",
-            "export type dntGlobalThisType = Omit<typeof dntGlobals, keyof typeof dntGlobals> & typeof dntGlobals & {\n",
-            "  Other: Other,\n",
-            "  TypeOnly: TypeOnly,\n",
-            "};"
           ).to_string(),
         ),
       ),
@@ -272,6 +267,8 @@ async fn transform_global_this_shim() {
       "globalThis ? true : false;",
       "type Test1 = typeof globalThis;",
       "type Test2 = typeof globalThis.Window;",
+      "type Test3 = typeof globalThis.Deno;",
+      "type Test4 = window.Something;",
     ),
     concat!(
       r#"import * as dntShim from "./_dnt.shims.js";"#,
@@ -287,8 +284,10 @@ async fn transform_global_this_shim() {
       "typeof dntShim.dntGlobalThis;",
       "dntShim.dntGlobalThis == null;",
       "dntShim.dntGlobalThis ? true : false;",
-      "type Test1 = typeof dntShim.dntGlobalThis;",
-      "type Test2 = dntShim.dntGlobalThisType[\"Window\"];",
+      "type Test1 = typeof globalThis;",
+      "type Test2 = typeof globalThis.Window;",
+      "type Test3 = typeof dntShim.Deno;",
+      "type Test4 = globalThis.Something;",
     ),
   )])
   .await;
@@ -1203,8 +1202,6 @@ async fn test_entry_points() {
             "  setInterval,\n",
             "};\n",
             "export const dntGlobalThis = createMergeProxy(globalThis, dntGlobals);\n",
-            "export type dntGlobalThisType = Omit<typeof dntGlobals, keyof typeof dntGlobals> & typeof dntGlobals & {\n",
-            "};"
           )
           .to_string(),
         ),

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -453,7 +453,7 @@ Deno.test("should build shim project when using node-fetch", async () => {
 export { Deno } from "@deno/shim-deno";
 import { Blob } from "buffer";
 export { Blob } from "buffer";
-import { crypto, type Crypto, type SubtleCrypto, type AlgorithmIdentifier, type Algorithm, type RsaOaepParams, type BufferSource, type AesCtrParams, type AesCbcParams, type AesGcmParams, type CryptoKey, type KeyAlgorithm, type KeyType, type KeyUsage, type EcdhKeyDeriveParams, type HkdfParams, type HashAlgorithmIdentifier, type Pbkdf2Params, type AesDerivedKeyParams, type HmacImportParams, type JsonWebKey, type RsaOtherPrimesInfo, type KeyFormat, type RsaHashedKeyGenParams, type RsaKeyGenParams, type BigInteger, type EcKeyGenParams, type NamedCurve, type CryptoKeyPair, type AesKeyGenParams, type HmacKeyGenParams, type RsaHashedImportParams, type EcKeyImportParams, type AesKeyAlgorithm, type RsaPssParams, type EcdsaParams } from "@deno/shim-crypto";
+import { crypto } from "@deno/shim-crypto";
 export { crypto, type Crypto, type SubtleCrypto, type AlgorithmIdentifier, type Algorithm, type RsaOaepParams, type BufferSource, type AesCtrParams, type AesCbcParams, type AesGcmParams, type CryptoKey, type KeyAlgorithm, type KeyType, type KeyUsage, type EcdhKeyDeriveParams, type HkdfParams, type HashAlgorithmIdentifier, type Pbkdf2Params, type AesDerivedKeyParams, type HmacImportParams, type JsonWebKey, type RsaOtherPrimesInfo, type KeyFormat, type RsaHashedKeyGenParams, type RsaKeyGenParams, type BigInteger, type EcKeyGenParams, type NamedCurve, type CryptoKeyPair, type AesKeyGenParams, type HmacKeyGenParams, type RsaHashedImportParams, type EcKeyImportParams, type AesKeyAlgorithm, type RsaPssParams, type EcdsaParams } from "@deno/shim-crypto";
 import { alert, confirm, prompt } from "@deno/shim-prompts";
 export { alert, confirm, prompt } from "@deno/shim-prompts";
@@ -463,7 +463,7 @@ import { default as DOMException } from "domexception";
 export { default as DOMException } from "domexception";
 import { File, FormData, Headers, Request, Response } from "undici";
 export { File, FormData, Headers, Request, Response } from "undici";
-import { default as fetch, type RequestInit } from "node-fetch";
+import { default as fetch } from "node-fetch";
 export { default as fetch, type RequestInit } from "node-fetch";
 
 const dntGlobals = {
@@ -484,44 +484,6 @@ const dntGlobals = {
   fetch,
 };
 export const dntGlobalThis = createMergeProxy(globalThis, dntGlobals);
-export type dntGlobalThisType = Omit<typeof dntGlobals, keyof typeof dntGlobals> & typeof dntGlobals & {
-  Crypto: Crypto,
-  SubtleCrypto: SubtleCrypto,
-  AlgorithmIdentifier: AlgorithmIdentifier,
-  Algorithm: Algorithm,
-  RsaOaepParams: RsaOaepParams,
-  BufferSource: BufferSource,
-  AesCtrParams: AesCtrParams,
-  AesCbcParams: AesCbcParams,
-  AesGcmParams: AesGcmParams,
-  CryptoKey: CryptoKey,
-  KeyAlgorithm: KeyAlgorithm,
-  KeyType: KeyType,
-  KeyUsage: KeyUsage,
-  EcdhKeyDeriveParams: EcdhKeyDeriveParams,
-  HkdfParams: HkdfParams,
-  HashAlgorithmIdentifier: HashAlgorithmIdentifier,
-  Pbkdf2Params: Pbkdf2Params,
-  AesDerivedKeyParams: AesDerivedKeyParams,
-  HmacImportParams: HmacImportParams,
-  JsonWebKey: JsonWebKey,
-  RsaOtherPrimesInfo: RsaOtherPrimesInfo,
-  KeyFormat: KeyFormat,
-  RsaHashedKeyGenParams: RsaHashedKeyGenParams,
-  RsaKeyGenParams: RsaKeyGenParams,
-  BigInteger: BigInteger,
-  EcKeyGenParams: EcKeyGenParams,
-  NamedCurve: NamedCurve,
-  CryptoKeyPair: CryptoKeyPair,
-  AesKeyGenParams: AesKeyGenParams,
-  HmacKeyGenParams: HmacKeyGenParams,
-  RsaHashedImportParams: RsaHashedImportParams,
-  EcKeyImportParams: EcKeyImportParams,
-  AesKeyAlgorithm: AesKeyAlgorithm,
-  RsaPssParams: RsaPssParams,
-  EcdsaParams: EcdsaParams,
-  RequestInit: RequestInit,
-};
 `;
     assertEquals(
       output.getFileText("src/_dnt.shims.ts").substring(0, expectedText.length),


### PR DESCRIPTION
This is more correct. The `dntGlobalThisType` wasn't correct because it didn't really merge with the `globalThis` type (ex. `WeakRef` fell apart because it used generics). I don't see any way to make that work in TypeScript actually, so this PR changes it to inline `globalThis.X` shim types to `dntShim.X`.