### PR TITLE
feat: support sub path in CDN imports

### DIFF
--- a/rs-lib/src/loader/specifier_mappers.rs
+++ b/rs-lib/src/loader/specifier_mappers.rs
@@ -38,8 +38,8 @@ pub fn get_all_specifier_mappers() -> Vec<Box<dyn SpecifierMapper>> {
 
 lazy_static! {
   // good enough for a first pass
-  static ref SKYPACK_MAPPING_RE: Regex = Regex::new(r"^https://cdn\.skypack\.dev/(@?[^@?]+)@([0-9\.\^~\-A-Za-z]+)").unwrap();
-  static ref ESMSH_MAPPING_RE: Regex = Regex::new(r"^https://esm\.sh/(@?[^@?]+)@([0-9\.\^~\-A-Za-z]+)$").unwrap();
+  static ref SKYPACK_MAPPING_RE: Regex = Regex::new(r"^https://cdn\.skypack\.dev/(@?[^@?]+)@([0-9.\^~\-A-Za-z]+)(?:/([^#?]+))?").unwrap();
+  static ref ESMSH_MAPPING_RE: Regex = Regex::new(r"^https://esm\.sh/(@?[^@?]+)@([0-9.\^~\-A-Za-z]+)(?:/([^#?]+))?$").unwrap();
 }
 
 struct SkypackMapper {}
@@ -51,7 +51,7 @@ impl SpecifierMapper for SkypackMapper {
       .map(|captures| MappedSpecifier {
         name: captures.get(1).unwrap().as_str().to_string(),
         version: Some(captures.get(2).unwrap().as_str().to_string()),
-        sub_path: None,
+        sub_path: captures.get(3).map(|m| m.as_str().to_owned()),
       })
   }
 }
@@ -65,7 +65,7 @@ impl SpecifierMapper for EsmShMapper {
       .map(|captures| MappedSpecifier {
         name: captures.get(1).unwrap().as_str().to_string(),
         version: Some(captures.get(2).unwrap().as_str().to_string()),
-        sub_path: None,
+        sub_path: captures.get(3).map(|m| m.as_str().to_owned()),
       })
   }
 }

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1036,6 +1036,8 @@ async fn skypack_esm_module_mapping() {
             // custom esm.sh stuff like this should download the dependency
             "import package4 from 'https://esm.sh/swr?deps=react@16.14.0';\n",
             "import package5 from 'https://esm.sh/test@1.2.5?deps=react@16.14.0';\n",
+            "import package6 from 'https://cdn.skypack.dev/preact@^10.5.0/hooks?dts';\n",
+            "import package7 from 'https://esm.sh/react-dom@17.0.2/server';\n",
           ),
         )
         .add_remote_file_with_headers(
@@ -1062,7 +1064,9 @@ async fn skypack_esm_module_mapping() {
           "import package2 from '@scope/package-name';\n",
           "import package3 from 'react';\n",
           "import package4 from './deps/esm_sh/swr.js';\n",
-          "import package5 from './deps/esm_sh/test_1.2.5.js';\n"
+          "import package5 from './deps/esm_sh/test_1.2.5.js';\n",
+          "import package6 from 'preact/hooks';\n",
+          "import package7 from 'react-dom/server';\n",
         )
       ),
       ("deps/esm_sh/swr.ts", "",),
@@ -1084,6 +1088,10 @@ async fn skypack_esm_module_mapping() {
         name: "react".to_string(),
         version: "17.0.2".to_string(),
       },
+      Dependency {
+        name: "react-dom".to_string(),
+        version: "17.0.2".to_string(),
+      }
     ]
   );
 }


### PR DESCRIPTION
This PR will allow imports like this:

```js
import pkg1 from 'https://cdn.skypack.dev/preact@^10.5.0/hooks?dts';
import pkg2 from 'https://esm.sh/react-dom@17.0.2/server';
```