### PR TITLE
refactor: switch from "lazy_static" to "once_cell"

### DIFF
--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -18,7 +18,7 @@ base64 = "0.13.0"
 deno_ast = { version = "0.9.0", features = ["module_specifier", "transforms", "view", "visit", "utils"] }
 deno_graph = { version = "0.18.0", features = [] }
 futures = "0.3.17"
-lazy_static = "1.4.0"
+once_cell = "1.9.0"
 pathdiff = "0.2.1"
 regex = "1.5"
 reqwest = { version = "0.11", features = ["rustls"], optional = true }

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -9,8 +9,6 @@ use std::path::PathBuf;
 use analyze::get_top_level_decls;
 use anyhow::Context;
 use anyhow::Result;
-#[macro_use]
-extern crate lazy_static;
 
 use analyze::get_ignore_line_indexes;
 use graph::ModuleGraphOptions;

--- a/rs-lib/src/loader/specifier_mappers.rs
+++ b/rs-lib/src/loader/specifier_mappers.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 use deno_ast::ModuleSpecifier;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::MappedSpecifier;
@@ -36,11 +37,17 @@ pub fn get_all_specifier_mappers() -> Vec<Box<dyn SpecifierMapper>> {
   ]
 }
 
-lazy_static! {
-  // good enough for a first pass
-  static ref SKYPACK_MAPPING_RE: Regex = Regex::new(r"^https://cdn\.skypack\.dev/(@?[^@?]+)@([0-9.\^~\-A-Za-z]+)(?:/([^#?]+))?").unwrap();
-  static ref ESMSH_MAPPING_RE: Regex = Regex::new(r"^https://esm\.sh/(@?[^@?]+)@([0-9.\^~\-A-Za-z]+)(?:/([^#?]+))?$").unwrap();
-}
+// good enough for a first pass
+static SKYPACK_MAPPING_RE: Lazy<Regex> = Lazy::new(|| {
+  Regex::new(
+    r"^https://cdn\.skypack\.dev/(@?[^@?]+)@([0-9.\^~\-A-Za-z]+)(?:/([^#?]+))?",
+  )
+  .unwrap()
+});
+static ESMSH_MAPPING_RE: Lazy<Regex> = Lazy::new(|| {
+  Regex::new(r"^https://esm\.sh/(@?[^@?]+)@([0-9.\^~\-A-Za-z]+)(?:/([^#?]+))?$")
+    .unwrap()
+});
 
 struct SkypackMapper {}
 

--- a/rs-lib/src/mappings.rs
+++ b/rs-lib/src/mappings.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use deno_ast::MediaType;
 use deno_ast::ModuleSpecifier;
+use once_cell::sync::Lazy;
 
 use crate::graph::ModuleGraph;
 use crate::specifiers::Specifiers;
@@ -19,19 +20,16 @@ pub struct SyntheticSpecifiers {
   pub shims: ModuleSpecifier,
 }
 
-lazy_static! {
-  pub static ref SYNTHETIC_SPECIFIERS: SyntheticSpecifiers =
-    SyntheticSpecifiers {
-      polyfills: ModuleSpecifier::parse("dnt://_dnt.polyfills.ts").unwrap(),
-      shims: ModuleSpecifier::parse("dnt://_dnt.shims.ts").unwrap(),
-    };
-  pub static ref SYNTHETIC_TEST_SPECIFIERS: SyntheticSpecifiers =
-    SyntheticSpecifiers {
-      polyfills: ModuleSpecifier::parse("dnt://_dnt.test_polyfills.ts")
-        .unwrap(),
-      shims: ModuleSpecifier::parse("dnt://_dnt.test_shims.ts").unwrap(),
-    };
-}
+pub static SYNTHETIC_SPECIFIERS: Lazy<SyntheticSpecifiers> =
+  Lazy::new(|| SyntheticSpecifiers {
+    polyfills: ModuleSpecifier::parse("dnt://_dnt.polyfills.ts").unwrap(),
+    shims: ModuleSpecifier::parse("dnt://_dnt.shims.ts").unwrap(),
+  });
+pub static SYNTHETIC_TEST_SPECIFIERS: Lazy<SyntheticSpecifiers> =
+  Lazy::new(|| SyntheticSpecifiers {
+    polyfills: ModuleSpecifier::parse("dnt://_dnt.test_polyfills.ts").unwrap(),
+    shims: ModuleSpecifier::parse("dnt://_dnt.test_shims.ts").unwrap(),
+  });
 
 pub struct Mappings {
   inner: HashMap<ModuleSpecifier, PathBuf>,

--- a/rs-lib/src/visitors/deno_comment_directives.rs
+++ b/rs-lib/src/visitors/deno_comment_directives.rs
@@ -5,25 +5,24 @@ use deno_ast::swc::common::BytePos;
 use deno_ast::swc::common::Span;
 use deno_ast::swc::common::Spanned;
 use deno_ast::view::*;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::text_changes::TextChange;
 
 // lifted from deno_graph
-lazy_static! {
-  /// Matched the `@deno-types` pragma.
-  static ref DENO_TYPES_RE: Regex =
-    Regex::new(r#"(?i)^\s*@deno-types\s*=\s*(?:["']([^"']+)["']|(\S+))"#)
-      .unwrap();
-  /// Matches a `/// <reference ... />` comment reference.
-  static ref TRIPLE_SLASH_REFERENCE_RE: Regex =
-    Regex::new(r"(?i)^/\s*<reference\s.*?/>").unwrap();
-  /// Matches a types reference, which for JavaScript files indicates the
-  /// location of types to use when type checking a program that includes it as
-  /// a dependency.
-  static ref TYPES_REFERENCE_RE: Regex =
-    Regex::new(r#"(?i)\stypes\s*=\s*["']([^"']*)["']"#).unwrap();
-}
+/// Matched the `@deno-types` pragma.
+static DENO_TYPES_RE: Lazy<Regex> = Lazy::new(|| {
+  Regex::new(r#"(?i)^\s*@deno-types\s*=\s*(?:["']([^"']+)["']|(\S+))"#).unwrap()
+});
+/// Matches a `/// <reference ... />` comment reference.
+static TRIPLE_SLASH_REFERENCE_RE: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"(?i)^/\s*<reference\s.*?/>").unwrap());
+/// Matches a types reference, which for JavaScript files indicates the
+/// location of types to use when type checking a program that includes it as
+/// a dependency.
+static TYPES_REFERENCE_RE: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r#"(?i)\stypes\s*=\s*["']([^"']*)["']"#).unwrap());
 
 pub fn get_deno_comment_directive_text_changes(
   program: &Program,


### PR DESCRIPTION
"once_cell" is preferred in Rust community at the moment. [More details.](https://docs.rs/once_cell/latest/once_cell/#faq)