### PR TITLE
fix: test runner was not respecting `ignore`

### DIFF
--- a/lib/test_runner/test_runner.test.ts
+++ b/lib/test_runner/test_runner.test.ts
@@ -63,7 +63,7 @@ Deno.test("Ignored tests and test cases", async () => {
   const context = getContext();
   await runTestDefinitions([{
     name: "Ignored",
-    ignored: true,
+    ignore: true,
     fn: () => {
       throw new Error("FAIL");
     },
@@ -75,7 +75,7 @@ Deno.test("Ignored tests and test cases", async () => {
         fn: () => {
           throw new Error("FAIL");
         },
-        ignored: true,
+        ignore: true,
       });
     },
   }], context);

--- a/lib/test_runner/test_runner.ts
+++ b/lib/test_runner/test_runner.ts
@@ -21,7 +21,7 @@ export interface RunTestDefinitionsOptions {
 export interface TestDefinition {
   name: string | undefined;
   fn: (context: TestContext) => (Promise<void> | void);
-  ignored?: boolean;
+  ignore?: boolean;
 }
 
 export interface TestContext {
@@ -44,7 +44,7 @@ export async function runTestDefinitions(
   const testFailures = [];
   for (const definition of testDefinitions) {
     options.process.stdout.write("test " + definition.name + " ...");
-    if (definition.ignored) {
+    if (definition.ignore) {
       options.process.stdout.write(` ${options.chalk.gray("ignored")}\n`);
       continue;
     }
@@ -132,7 +132,7 @@ export async function runTestDefinitions(
         context.status = "pending";
         this.children.push(context);
 
-        if (definition.ignored) {
+        if (definition.ignore) {
           context.status = "ignored";
           return false;
         }

--- a/tests/test_project/mod.test.ts
+++ b/tests/test_project/mod.test.ts
@@ -6,3 +6,11 @@ import { assertEquals } from "https://deno.land/std@0.119.0/testing/asserts.ts";
 Deno.test("should add in test project", () => {
   assertEquals(add(1, 2), 3);
 });
+
+Deno.test({
+  name: "should ignore",
+  ignore: true,
+  fn() {
+    throw new Error("did not ignore");
+  }
+});

--- a/tests/test_project/mod.test.ts
+++ b/tests/test_project/mod.test.ts
@@ -12,5 +12,5 @@ Deno.test({
   ignore: true,
   fn() {
     throw new Error("did not ignore");
-  }
+  },
 });


### PR DESCRIPTION
Accidentally had my dnt side property name as `ignored` instead of `ignore`

Closes #123