### PR TITLE
fix: complete logic in `getTopLevelAwait` function

### DIFF
--- a/lib/compiler.test.ts
+++ b/lib/compiler.test.ts
@@ -1,7 +1,7 @@
 import {
   getCompilerScriptTarget,
   getCompilerSourceMapOptions,
-  getTopLevelAwait,
+  getTopLevelAwaitLocation,
   SourceMapOptions,
 } from "./compiler.ts";
 import { ts } from "./mod.deps.ts";
@@ -35,9 +35,21 @@ Deno.test("script target should have expected outputs", () => {
 Deno.test("get has top level await", () => {
   runTest("const some = code;class SomeOtherCode {}", undefined);
   runTest("async function test() { await 5; }", undefined);
+  runTest(
+    "async function test() { for await (const item of items) {} }",
+    undefined,
+  );
   runTest("await test();", {
     line: 0,
     character: 0,
+  });
+  runTest("for await (const item of items) {}", {
+    line: 0,
+    character: 0,
+  });
+  runTest("if (condition) { await test() }", {
+    line: 0,
+    character: 17,
   });
 
   function runTest(code: string, expected: ts.LineAndCharacter | undefined) {
@@ -46,7 +58,7 @@ Deno.test("get has top level await", () => {
       code,
       ts.ScriptTarget.Latest,
     );
-    assertEquals(getTopLevelAwait(sourceFile), expected);
+    assertEquals(getTopLevelAwaitLocation(sourceFile), expected);
   }
 });
 

--- a/lib/compiler.test.ts
+++ b/lib/compiler.test.ts
@@ -51,6 +51,10 @@ Deno.test("get has top level await", () => {
     line: 0,
     character: 17,
   });
+  runTest("const t = { prop: await test() };", {
+    line: 0,
+    character: 18,
+  });
 
   function runTest(code: string, expected: ts.LineAndCharacter | undefined) {
     const sourceFile = ts.createSourceFile(

--- a/lib/compiler.ts
+++ b/lib/compiler.ts
@@ -64,23 +64,20 @@ export function getTopLevelAwaitLocation(sourceFile: ts.SourceFile) {
 }
 
 function getTopLevelAwait(node: ts.Node): ts.Node | undefined {
-  if (ts.isExpressionStatement(node) && ts.isAwaitExpression(node.expression)) {
+  if (ts.isAwaitExpression(node)) {
     return node;
   }
   if (ts.isForOfStatement(node) && node.awaitModifier !== undefined) {
     return node;
   }
-  const topLevelAwait = ts.forEachChild(node, (child) => {
+  return ts.forEachChild(node, (child) => {
     if (
       !ts.isFunctionDeclaration(child) && !ts.isFunctionExpression(child) &&
       !ts.isArrowFunction(child) && !ts.isMethodDeclaration(child)
     ) {
-      const topLevelAwait = getTopLevelAwait(child);
-      if (topLevelAwait !== undefined) return topLevelAwait;
+      return getTopLevelAwait(child);
     }
   });
-
-  return topLevelAwait;
 }
 
 export function transformCodeToTarget(code: string, target: ts.ScriptTarget) {

--- a/lib/compiler.ts
+++ b/lib/compiler.ts
@@ -53,18 +53,34 @@ export function getCompilerSourceMapOptions(
   }
 }
 
-export function getTopLevelAwait(sourceFile: ts.SourceFile) {
-  for (const statement of sourceFile.statements) {
-    if (
-      ts.isExpressionStatement(statement) &&
-      ts.isAwaitExpression(statement.expression)
-    ) {
-      return sourceFile.getLineAndCharacterOfPosition(
-        statement.expression.getStart(sourceFile),
-      );
-    }
+export function getTopLevelAwaitLocation(sourceFile: ts.SourceFile) {
+  const topLevelAwait = getTopLevelAwait(sourceFile);
+  if (topLevelAwait !== undefined) {
+    return sourceFile.getLineAndCharacterOfPosition(
+      topLevelAwait.getStart(sourceFile),
+    );
   }
   return undefined;
+}
+
+function getTopLevelAwait(node: ts.Node): ts.Node | undefined {
+  if (ts.isExpressionStatement(node) && ts.isAwaitExpression(node.expression)) {
+    return node;
+  }
+  if (ts.isForOfStatement(node) && node.awaitModifier !== undefined) {
+    return node;
+  }
+  const topLevelAwait = ts.forEachChild(node, (child) => {
+    if (
+      !ts.isFunctionDeclaration(child) && !ts.isFunctionExpression(child) &&
+      !ts.isArrowFunction(child) && !ts.isMethodDeclaration(child)
+    ) {
+      const topLevelAwait = getTopLevelAwait(child);
+      if (topLevelAwait !== undefined) return topLevelAwait;
+    }
+  });
+
+  return topLevelAwait;
 }
 
 export function transformCodeToTarget(code: string, target: ts.ScriptTarget) {

--- a/mod.ts
+++ b/mod.ts
@@ -3,7 +3,7 @@
 import {
   getCompilerScriptTarget,
   getCompilerSourceMapOptions,
-  getTopLevelAwait,
+  getTopLevelAwaitLocation,
   outputDiagnostics,
   SourceMapOptions,
   transformCodeToTarget,
@@ -246,7 +246,7 @@ export async function build(options: BuildOptions): Promise<void> {
 
     if (options.scriptModule) {
       // cjs does not support TLA so error fast if we find one
-      const tlaLocation = getTopLevelAwait(sourceFile);
+      const tlaLocation = getTopLevelAwaitLocation(sourceFile);
       if (tlaLocation) {
         warn(
           `Top level await cannot be used when distributing CommonJS/UMD ` +


### PR DESCRIPTION
Currently `dnt` cannot detect TLA like
```ts
if (condition) {
  await test();
}
for await (const item of items){ }
```