### PR TITLE
feat: replace import.meta.main in CJS

### DIFF
--- a/lib/compiler_transforms.test.ts
+++ b/lib/compiler_transforms.test.ts
@@ -31,6 +31,6 @@ Deno.test("transform import.meta.main expressions", () => {
     "if (import.meta.main) { console.log('main'); }",
     `if ((require.main === module)) {
     console.log("main");
-}\n`);
+}\n`,
+  );
 });
-

--- a/lib/compiler_transforms.test.ts
+++ b/lib/compiler_transforms.test.ts
@@ -4,10 +4,10 @@ import { assertEquals } from "./test.deps.ts";
 import { ts } from "./mod.deps.ts";
 import { transformImportMeta } from "./compiler_transforms.ts";
 
-Deno.test("transform import.meta.url expressions", () => {
+function testImportReplacements(input: string, output: string) {
   const sourceFile = ts.createSourceFile(
     "file.ts",
-    "function test() { new URL(import.meta.url); }",
+    input,
     ts.ScriptTarget.Latest,
   );
   const newSourceFile =
@@ -16,8 +16,21 @@ Deno.test("transform import.meta.url expressions", () => {
     newLine: ts.NewLineKind.LineFeed,
   }).printFile(newSourceFile);
 
-  assertEquals(
-    text,
+  assertEquals(text, output);
+}
+
+Deno.test("transform import.meta.url expressions", () => {
+  testImportReplacements(
+    "function test() { new URL(import.meta.url); }",
     `function test() { new URL(require("url").pathToFileURL(__filename).href); }\n`,
   );
 });
+
+Deno.test("transform import.meta.main expressions", () => {
+  testImportReplacements(
+    "if (import.meta.main) { console.log('main'); }",
+    `if ((require.main === module)) {
+    console.log("main");
+}\n`);
+});
+

--- a/lib/compiler_transforms.ts
+++ b/lib/compiler_transforms.ts
@@ -54,10 +54,10 @@ export const transformImportMeta: ts.TransformerFactory<ts.SourceFile> = (
     return factory.createParenthesizedExpression(factory.createBinaryExpression(
       factory.createPropertyAccessExpression(
         factory.createIdentifier("require"),
-        factory.createIdentifier("main")
+        factory.createIdentifier("main"),
       ),
       factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
-      factory.createIdentifier("module")
-    ))
+      factory.createIdentifier("module"),
+    ));
   }
 };


### PR DESCRIPTION
closes #106 

This PR replaces `import.meta.main` with `(require.main === module)`.