### PR TITLE
Fix not to add mapped declaration file in `specifier.types`

### DIFF
--- a/rs-lib/src/declaration_file_resolution.rs
+++ b/rs-lib/src/declaration_file_resolution.rs
@@ -8,8 +8,10 @@ use deno_ast::ModuleSpecifier;
 use deno_graph::Module;
 use deno_graph::ModuleKind;
 use deno_graph::Resolved;
+use reqwest::Url;
 
 use crate::graph::ModuleGraph;
+use crate::PackageMappedSpecifier;
 
 #[derive(Debug)]
 pub struct DeclarationFileResolution {
@@ -29,6 +31,7 @@ pub struct TypesDependency {
 pub fn resolve_declaration_file_mappings(
   module_graph: &ModuleGraph,
   modules: &[&Module],
+  mapped_specifiers: &BTreeMap<Url, PackageMappedSpecifier>,
 ) -> Result<BTreeMap<ModuleSpecifier, DeclarationFileResolution>> {
   let mut type_dependencies = BTreeMap::new();
 
@@ -39,6 +42,11 @@ pub fn resolve_declaration_file_mappings(
   // get the resolved type dependencies
   let mut mappings = BTreeMap::new();
   for (code_specifier, deps) in type_dependencies.into_iter() {
+    // if this type_dependency is mapped, then pass it.
+    if mapped_specifiers.contains_key(&code_specifier) {
+      continue;
+    }
+
     let deps = deps.into_iter().collect::<Vec<_>>();
     let selected_dep =
       select_best_types_dep(module_graph, &code_specifier, &deps);

--- a/rs-lib/src/specifiers.rs
+++ b/rs-lib/src/specifiers.rs
@@ -112,7 +112,11 @@ pub fn get_specifiers(
     }
   }
 
-  let types = resolve_declaration_file_mappings(module_graph, &all_modules)?;
+  let types = resolve_declaration_file_mappings(
+    module_graph,
+    &all_modules,
+    &found_mapped_specifiers,
+  )?;
   let mut declaration_specifiers = HashSet::new();
   for value in types.values() {
     declaration_specifiers.insert(&value.selected.specifier);


### PR DESCRIPTION
`deno-types` with skypack dts (using ?dts option) does not throw error because its' `media_type` is Javascript, not Dts.
When using esm.sh instead, the Dts file is correctly labeled using their extension.
So, I remove mapped declaration specifiers from `declaration_file_mappings` to resolve errors related to finding mapped declaration specifiers in `mapping`.

If you have a better idea or plan, feel free to comment because I am a newcomer to this repo and rustlang. thanks 😊

resolves #139