### PR TITLE
fix: Support custom shim w/ node scheme

### DIFF
--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -186,7 +186,11 @@ pub struct ModuleShim {
 
 impl ModuleShim {
   pub fn maybe_specifier(&self) -> Option<ModuleSpecifier> {
-    ModuleSpecifier::parse(&self.module).ok()
+    if self.module.starts_with("node:") {
+      None
+    } else {
+      ModuleSpecifier::parse(&self.module).ok()
+    }
   }
 }
 

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -301,32 +301,45 @@ async fn transform_shim_custom_shims() {
 async fn transform_shim_node_custom_shims() {
   let result = TestBuilder::new()
     .with_loader(|loader| {
-      loader.add_local_file("/mod.ts", "const readableStream = new ReadableStream();");
+      loader.add_local_file(
+        "/mod.ts",
+        "const readableStream = new ReadableStream();",
+      );
     })
     .add_shim(Shim::Module(ModuleShim {
       module: "node:stream/web".to_string(),
       global_names: vec![GlobalName {
         name: "ReadableStream".to_string(),
         export_name: None,
-        type_only: false
-      }]
-    })).transform().await.unwrap();
+        type_only: false,
+      }],
+    }))
+    .transform()
+    .await
+    .unwrap();
 
-  assert_files!(result.main.files, &[(
-    "_dnt.shims.ts",
-    get_shim_file_text(
-      concat!(
-        "import { ReadableStream } from \"node:stream/web\";\n",
-        "export { ReadableStream } from \"node:stream/web\";\n",
-        "\n",
-        "const dntGlobals = {\n",
-        "  ReadableStream,\n",
-        "};\n",
-        "export const dntGlobalThis = createMergeProxy(globalThis, dntGlobals);\n",
-      ).to_string(),
+  assert_files!(result.main.files, &[
+    (
+      "_dnt.shims.ts",
+      get_shim_file_text(
+        concat!(
+          "import { ReadableStream } from \"node:stream/web\";\n",
+          "export { ReadableStream } from \"node:stream/web\";\n",
+          "\n",
+          "const dntGlobals = {\n",
+          "  ReadableStream,\n",
+          "};\n",
+          "export const dntGlobalThis = createMergeProxy(globalThis, dntGlobals);\n",
+        ).to_string(),
+      ),
     ),
-  ),
-  ("mod.ts", concat!("import * as dntShim from \"./_dnt.shims.js\";\n","const readableStream = new dntShim.ReadableStream();").to_string())
+    (
+      "mod.ts",
+      concat!(
+        "import * as dntShim from \"./_dnt.shims.js\";\n",
+        "const readableStream = new dntShim.ReadableStream();"
+      ).to_string()
+    )
   ]);
 }
 

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -298,6 +298,39 @@ async fn transform_shim_custom_shims() {
 }
 
 #[tokio::test]
+async fn transform_shim_node_custom_shims() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader.add_local_file("/mod.ts", "const readableStream = new ReadableStream();");
+    })
+    .add_shim(Shim::Module(ModuleShim {
+      module: "node:stream/web".to_string(),
+      global_names: vec![GlobalName {
+        name: "ReadableStream".to_string(),
+        export_name: None,
+        type_only: false
+      }]
+    })).transform().await.unwrap();
+
+  assert_files!(result.main.files, &[(
+    "_dnt.shims.ts",
+    get_shim_file_text(
+      concat!(
+        "import { ReadableStream } from \"node:stream/web\";\n",
+        "export { ReadableStream } from \"node:stream/web\";\n",
+        "\n",
+        "const dntGlobals = {\n",
+        "  ReadableStream,\n",
+        "};\n",
+        "export const dntGlobalThis = createMergeProxy(globalThis, dntGlobals);\n",
+      ).to_string(),
+    ),
+  ),
+  ("mod.ts", concat!("import * as dntShim from \"./_dnt.shims.js\";\n","const readableStream = new dntShim.ReadableStream();").to_string())
+  ]);
+}
+
+#[tokio::test]
 async fn no_transform_deno_ignored() {
   assert_identity_transforms(vec!["// dnt-shim-ignore\nDeno.readTextFile();"])
     .await;


### PR DESCRIPTION
Web Stream API can be used in the latest nodejs with `node:stream/web` import. (https://nodejs.org/api/webstreams.html#web-streams-api)
But the module name with node scheme in custom shims option occurs error because it can be parsed to Url (which is `ModuleSpecifier`. 
So I changed `ModuleShim::maybe_specifier` not to allow URL with `node` scheme.