### PR TITLE
fix: do not use `exports` for cjs only package

### DIFF
--- a/lib/package_json.test.ts
+++ b/lib/package_json.test.ts
@@ -155,13 +155,6 @@ Deno.test("single entrypoint", () => {
         "@types/node": versions.nodeTypes,
       },
       scripts: undefined,
-      exports: {
-        ".": {
-          import: undefined,
-          require: "./script/mod.js",
-          types: "./types/mod.d.ts",
-        },
-      },
     },
   );
 

--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -113,16 +113,21 @@ export function getPackageJson({
     ...packageJsonObj,
     ...deleteEmptyKeys({
       exports: {
+        ...(includeEsModule || exports.length > 1
+          ? {
+            ...(Object.fromEntries(exports.map((e) => [e.name, {
+              import: includeEsModule ? `./esm/${e.path}` : undefined,
+              require: includeScriptModule ? `./script/${e.path}` : undefined,
+              types: includeDeclarations
+                ? (e.name === "." ? packageJsonObj.types : undefined) ??
+                  `./types/${e.types}`
+                : undefined,
+              ...(packageJsonObj.exports?.[e.name] ?? {}),
+            }]))),
+          }
+          : {}),
+        // allow someone to override
         ...(packageJsonObj.exports ?? {}),
-        ...(Object.fromEntries(exports.map((e) => [e.name, {
-          import: includeEsModule ? `./esm/${e.path}` : undefined,
-          require: includeScriptModule ? `./script/${e.path}` : undefined,
-          types: includeDeclarations
-            ? (e.name === "." ? packageJsonObj.types : undefined) ??
-              `./types/${e.types}`
-            : undefined,
-          ...(packageJsonObj.exports?.[e.name] ?? {}),
-        }]))),
       },
       scripts,
       dependencies,

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -141,12 +141,6 @@ Deno.test("should build test project without esm", async () => {
       name: "add",
       version: "1.0.0",
       main: "./script/mod.js",
-      exports: {
-        ".": {
-          require: "./script/mod.js",
-          types: "./types/mod.d.ts",
-        },
-      },
       scripts: {
         test: "node test_runner.js",
       },

--- a/tests/json_module_project/mod.test.ts
+++ b/tests/json_module_project/mod.test.ts
@@ -2,7 +2,8 @@ import { getDynamicOutput, getOutput } from "./mod.ts";
 
 Deno.test("should get output", () => {
   // @ts-expect-error: not assignable to string
-  const _err: string = getOutput();
+  const invalidValue: string = getOutput();
+  console.log(invalidValue);
   // is assignable to number
   const value: number = getOutput();
 


### PR DESCRIPTION
The state of tooling understanding exports is still really bad, so don't include it.