### PR TITLE
fix: exports types resolution in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,22 +423,22 @@ This will create a package.json with these as exports:
   "exports": {
     ".": {
       "import": {
-        "default": "./esm/mod.js",
-        "types": "./types/mod.d.ts"
+        "types": "./types/mod.d.ts",
+        "default": "./esm/mod.js"
       },
       "require": {
-        "default": "./script/mod.js",
-        "types": "./types/mod.d.ts"
+        "types": "./types/mod.d.ts",
+        "default": "./script/mod.js"
       }
     },
     "./internal": {
       "import": {
-        "default": "./esm/internal.js",
-        "types": "./types/internal.d.ts"
+        "types": "./types/internal.d.ts",
+        "default": "./esm/internal.js"
       },
       "require": {
-        "default": "./script/internal.js",
-        "types": "./types/internal.d.ts"
+        "types": "./types/internal.d.ts",
+        "default": "./script/internal.js"
       }
     }
   }

--- a/lib/package_json.test.ts
+++ b/lib/package_json.test.ts
@@ -232,6 +232,50 @@ Deno.test("single entrypoint", () => {
   );
 });
 
+Deno.test("exports have default last", () => {
+  const props: GetPackageJsonOptions = {
+    transformOutput: {
+      main: {
+        files: [],
+        dependencies: [],
+        entryPoints: ["mod.ts"],
+      },
+      test: {
+        entryPoints: [],
+        files: [],
+        dependencies: [],
+      },
+      warnings: [],
+    },
+    entryPoints: [
+      {
+        name: ".",
+        path: "./mod.ts",
+      },
+    ],
+    package: {
+      name: "package",
+      version: "0.1.0",
+    },
+    testEnabled: true,
+    includeEsModule: true,
+    includeScriptModule: true,
+    includeDeclarations: true,
+    includeTsLib: false,
+    shims: {
+      deno: "dev",
+    },
+  };
+
+  const result: any = getPackageJson(props);
+  assertEquals(Object.keys(result.exports), ["."]);
+  assertEquals(Object.keys(result.exports["."]), ["import", "require"]);
+
+  // "default" must always be last: https://github.com/denoland/dnt/issues/228
+  assertEquals(Object.keys(result.exports["."].import), ["types", "default"]);
+  assertEquals(Object.keys(result.exports["."].require), ["types", "default"]);
+});
+
 Deno.test("multiple entrypoints", () => {
   const props: GetPackageJsonOptions = {
     transformOutput: {

--- a/lib/package_json.test.ts
+++ b/lib/package_json.test.ts
@@ -271,7 +271,7 @@ Deno.test("exports have default last", () => {
   assertEquals(Object.keys(result.exports), ["."]);
   assertEquals(Object.keys(result.exports["."]), ["import", "require"]);
 
-  // "default" must always be last: https://github.com/denoland/dnt/issues/228
+  // "types" must always be first: https://github.com/denoland/dnt/issues/228
   assertEquals(Object.keys(result.exports["."].import), ["types", "default"]);
   assertEquals(Object.keys(result.exports["."].require), ["types", "default"]);
 });

--- a/lib/package_json.test.ts
+++ b/lib/package_json.test.ts
@@ -69,12 +69,12 @@ Deno.test("single entrypoint", () => {
     exports: {
       ".": {
         import: {
-          default: "./esm/mod.js",
           types: "./types/mod.d.ts",
+          default: "./esm/mod.js",
         },
         require: {
-          default: "./script/mod.js",
           types: "./types/mod.d.ts",
+          default: "./script/mod.js",
         },
       },
     },
@@ -105,12 +105,12 @@ Deno.test("single entrypoint", () => {
       exports: {
         ".": {
           import: {
-            default: "./esm/mod.js",
             types: "./types/mod.d.ts",
+            default: "./esm/mod.js",
           },
           require: {
-            default: "./script/mod.js",
             types: "./types/mod.d.ts",
+            default: "./script/mod.js",
           },
         },
       },
@@ -139,8 +139,8 @@ Deno.test("single entrypoint", () => {
       exports: {
         ".": {
           import: {
-            default: "./esm/mod.js",
             types: "./types/mod.d.ts",
+            default: "./esm/mod.js",
           },
           require: undefined,
         },
@@ -328,22 +328,22 @@ Deno.test("multiple entrypoints", () => {
     exports: {
       ".": {
         import: {
-          default: "./esm/mod.js",
           types: "./types/mod.d.ts",
+          default: "./esm/mod.js",
         },
         require: {
-          default: "./script/mod.js",
           types: "./types/mod.d.ts",
+          default: "./script/mod.js",
         },
       },
       "./my-other-entrypoint.js": {
         import: {
-          default: "./esm/other.js",
           types: "./types/other.d.ts",
+          default: "./esm/other.js",
         },
         require: {
-          default: "./script/other.js",
           types: "./types/other.d.ts",
+          default: "./script/other.js",
         },
       },
     },
@@ -407,12 +407,12 @@ Deno.test("binary entrypoints", () => {
     exports: {
       ".": {
         import: {
-          default: "./esm/mod.js",
           types: "./types/mod.d.ts",
+          default: "./esm/mod.js",
         },
         require: {
-          default: "./script/mod.js",
           types: "./types/mod.d.ts",
+          default: "./script/mod.js",
         },
       },
     },
@@ -489,12 +489,12 @@ Deno.test("peer dependencies", () => {
     exports: {
       ".": {
         import: {
-          default: "./esm/mod.js",
           types: "./types/mod.d.ts",
+          default: "./esm/mod.js",
         },
         require: {
-          default: "./script/mod.js",
           types: "./types/mod.d.ts",
+          default: "./script/mod.js",
         },
       },
     },

--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -129,10 +129,10 @@ export function getPackageJson({
               function getPathOrTypesObject(path: string) {
                 if (includeDeclarations) {
                   return {
-                    default: path,
                     types:
                       (e.name === "." ? packageJsonObj.types : undefined) ??
                         `./types/${e.types}`,
+                    default: path,
                   };
                 } else {
                   return path;

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -70,12 +70,12 @@ Deno.test("should build test project", async () => {
       exports: {
         ".": {
           import: {
-            default: "./esm/mod.js",
             types: "./types/mod.d.ts",
+            default: "./esm/mod.js",
           },
           require: {
-            default: "./script/mod.js",
             types: "./types/mod.d.ts",
+            default: "./script/mod.js",
           },
         },
       },
@@ -453,12 +453,12 @@ Deno.test("should build with package mappings", async () => {
       exports: {
         ".": {
           import: {
-            default: "./esm/mod.js",
             types: "./types/mod.d.ts",
+            default: "./esm/mod.js",
           },
           require: {
-            default: "./script/mod.js",
             types: "./types/mod.d.ts",
+            default: "./script/mod.js",
           },
         },
       },
@@ -520,12 +520,12 @@ Deno.test("should build with peer depependencies in mappings", async () => {
       exports: {
         ".": {
           import: {
-            default: "./esm/mod.js",
             types: "./types/mod.d.ts",
+            default: "./esm/mod.js",
           },
           require: {
-            default: "./script/mod.js",
             types: "./types/mod.d.ts",
+            default: "./script/mod.js",
           },
         },
       },


### PR DESCRIPTION
Fixes https://github.com/denoland/dnt/issues/228.

>Webpack expects that the default property is always the last one inside of an exports object. (The Nodejs documentation for the exports field mentions that the order is important: look for "key order is signficant" in [https://nodejs.org/api/packages.html](https://nodejs.org/api/packages.html#:~:text=key%20order%20is%20significant). Here's an example of another project running into this issue and fixing it by reordering the properties: https://github.com/transitive-bullshit/chatgpt-api/pull/25.)

This PR is made up of three commits:
1. Adds a test for the fix.
2. Fixes the bug.
3. Cosmetic changes in the readme and multiple tests to always show the default key as last.