### PR TITLE
feat: add `declaration: "inline"` option for emitting declaration files beside js files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dsherret/rust-toolchain-file@v1
     - uses: Swatinem/rust-cache@v1
     - uses: denoland/setup-deno@v1
       with:

--- a/mod.ts
+++ b/mod.ts
@@ -53,9 +53,12 @@ export interface BuildOptions {
    */
   test?: boolean;
   /** Create declaration files.
+   *
+   * Set this to "inline" in order to emit declaration files beside
+   * the .js files in both the esm and cjs folders.
    * @default true
    */
-  declaration?: boolean;
+  declaration?: boolean | "inline";
   /** Include a CommonJS or UMD module.
    * @default "cjs"
    */
@@ -229,7 +232,7 @@ export async function build(options: BuildOptions): Promise<void> {
       noImplicitThis: true,
       noStrictGenericChecks: false,
       noUncheckedIndexedAccess: false,
-      declaration: options.declaration,
+      declaration: !!options.declaration,
       esModuleInterop: false,
       isolatedModules: true,
       useDefineForClassFields: true,
@@ -325,7 +328,7 @@ export async function build(options: BuildOptions): Promise<void> {
   }
 
   // emit only the .d.ts files
-  if (options.declaration) {
+  if (options.declaration === true) {
     log("Emitting declaration files...");
     emit({ onlyDtsFiles: true });
   }
@@ -334,7 +337,7 @@ export async function build(options: BuildOptions): Promise<void> {
     // emit the esm files
     log("Emitting ESM package...");
     project.compilerOptions.set({
-      declaration: false,
+      declaration: options.declaration === "inline",
       outDir: esmOutDir,
     });
     program = project.createProgram();
@@ -349,7 +352,7 @@ export async function build(options: BuildOptions): Promise<void> {
   if (options.scriptModule) {
     log("Emitting script package...");
     project.compilerOptions.set({
-      declaration: false,
+      declaration: options.declaration === "inline",
       esModuleInterop: true,
       outDir: scriptOutDir,
       module: options.scriptModule === "umd"
@@ -419,7 +422,7 @@ export async function build(options: BuildOptions): Promise<void> {
       testEnabled: options.test,
       includeEsModule: options.esModule !== false,
       includeScriptModule: options.scriptModule !== false,
-      includeDeclarations: options.declaration,
+      includeDeclarations: options.declaration === true,
       includeTsLib: options.compilerOptions?.importHelpers,
       shims: options.shims,
     });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -250,6 +250,53 @@ Deno.test("should build umd module", async () => {
   });
 });
 
+Deno.test("should build test project with declarations inline", async () => {
+  await runTest("test_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    declaration: "inline",
+    shims: {
+      deno: "dev",
+    },
+    package: {
+      name: "add",
+      version: "1.0.0",
+    },
+    compilerOptions: {
+      importHelpers: true,
+    },
+  }, (output) => {
+    output.assertNotExists("script/mod.js.map");
+    output.assertNotExists("esm/mod.js.map");
+    output.assertNotExists("types/mod.d.ts");
+    output.assertExists("script/mod.d.ts");
+    output.assertExists("esm/mod.d.ts");
+    assertEquals(output.packageJson, {
+      name: "add",
+      version: "1.0.0",
+      main: "./script/mod.js",
+      module: "./esm/mod.js",
+      exports: {
+        ".": {
+          import: "./esm/mod.js",
+          require: "./script/mod.js",
+        },
+      },
+      scripts: {
+        test: "node test_runner.js",
+      },
+      dependencies: {
+        tslib: versions.tsLib,
+      },
+      devDependencies: {
+        "@types/node": versions.nodeTypes,
+        chalk: versions.chalk,
+        "@deno/shim-deno": versions.denoShim,
+      },
+    });
+  });
+});
+
 Deno.test("should build bin project", async () => {
   await runTest("test_project", {
     entryPoints: [{


### PR DESCRIPTION
This will emit the declaration files beside the .js files in both the esm and cjs folders.