### PR TITLE
docs: update GitHub Action instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ that the deno.json is not auto-discovered—you must explicitly specify it.
      if: startsWith(github.ref, 'refs/tags/')
      id: get_tag_version
      run: echo ::set-output name=TAG_VERSION::${GITHUB_REF/refs\/tags\//}
-   - uses: actions/setup-node@v2
+   - uses: actions/setup-node@v3
      with:
        node-version: '16.x'
        registry-url: 'https://registry.npmjs.org'

--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ that the deno.json is not auto-discovered—you must explicitly specify it.
    - name: Get tag version
      if: startsWith(github.ref, 'refs/tags/')
      id: get_tag_version
-     run: echo ::set-output name=TAG_VERSION::${GITHUB_REF/refs\/tags\//}
+     run: echo TAG_VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
    - uses: actions/setup-node@v3
      with:
        node-version: '18.x'

--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ that the deno.json is not auto-discovered—you must explicitly specify it.
      run: echo ::set-output name=TAG_VERSION::${GITHUB_REF/refs\/tags\//}
    - uses: actions/setup-node@v3
      with:
-       node-version: '16.x'
+       node-version: '18.x'
        registry-url: 'https://registry.npmjs.org'
    - name: npm build
      run: deno run -A ./scripts/build_npm.ts ${{steps.get_tag_version.outputs.TAG_VERSION}}


### PR DESCRIPTION
This PR updates the readme with up-to-date instructions for setting up a GitHub Action to trigger publishing of package to npm when tags are created in a repo.

The current instructions still work as of today, but they produce deprecation warnings by GitHub Actions.
The proposed updates in this PR fixes all current warnings.

See
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/