### PR TITLE
Fixes incorrect path to test files in `test_runner.js`

### DIFF
--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -24,7 +24,7 @@ export function getTestRunnerCode(options: {
   writer.writeLine("const filePaths = [");
   writer.indent(() => {
     for (const entryPoint of options.testEntryPoints) {
-      writer.quote("./src/" + entryPoint.replace(/\.ts$/, ".js")).write(",").newLine();
+      writer.quote("src/" + entryPoint.replace(/\.ts$/, ".js")).write(",").newLine();
     }
   });
   writer.writeLine("];").newLine();

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -24,7 +24,7 @@ export function getTestRunnerCode(options: {
   writer.writeLine("const filePaths = [");
   writer.indent(() => {
     for (const entryPoint of options.testEntryPoints) {
-      writer.quote(entryPoint.replace(/\.ts$/, ".js")).write(",").newLine();
+      writer.quote("./src/" + entryPoint.replace(/\.ts$/, ".js")).write(",").newLine();
     }
   });
   writer.writeLine("];").newLine();

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -24,7 +24,8 @@ export function getTestRunnerCode(options: {
   writer.writeLine("const filePaths = [");
   writer.indent(() => {
     for (const entryPoint of options.testEntryPoints) {
-      writer.quote("src/" + entryPoint.replace(/\.ts$/, ".js")).write(",").newLine();
+      writer.quote("src/" + entryPoint.replace(/\.ts$/, ".js")).write(",")
+        .newLine();
     }
   });
   writer.writeLine("];").newLine();


### PR DESCRIPTION
## Issue

Test files matching the glob pattern `./tests/**/*.test.ts` are placed under `./npm/script/src/tests/` but the generated `test_runner.js` is looking for tests under the original path (ie. not nested within the `./src` directory).

From `test_runner.js`:
```
const filePaths = [
    "tests/lib/math-utils.test.js",
   ...
];
```

Error:
![Screenshot 2023-05-24 172606](https://github.com/denoland/dnt/assets/9361948/39627ffc-f7c8-46b0-bdde-ba42c49f3fdb)

Expected test paths:
```
const filePaths = [
     "src/tests/lib/math-utils.test.js",
    ...
];
```

## Solution

Prefix the output test file paths in `get_test_runner_code.ts` to match the generated folder structure.


NOTE:
This has been tested against my own package. I will try and add some test cases this week.