### PR TITLE
feat: add option to generate test, without running them, improve integration tests

### DIFF
--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -12,7 +12,7 @@ export interface GetPackageJsonOptions {
   includeScriptModule: boolean | undefined;
   includeDeclarations: boolean | undefined;
   includeTsLib: boolean | undefined;
-  testEnabled: boolean | undefined;
+  testEnabled: boolean | "no-run" | undefined;
   shims: ShimOptions;
 }
 

--- a/mod.ts
+++ b/mod.ts
@@ -166,10 +166,11 @@ export interface BuildOptions {
   };
   /** Action to do after emitting and before running tests. */
   postBuild?: () => void | Promise<void>;
+  /** Override the log Info function, by default it's console.log */
   loggerInfo?: (message: string) => void;
+  /** Override the log Warn function, by default it's console.log */
   loggerWarn?: (message: string) => void;
 }
-
 
 /** Builds the specified Deno module to an npm package using the TypeScript compiler. */
 export async function build(options: BuildOptions): Promise<void> {
@@ -190,9 +191,13 @@ export async function build(options: BuildOptions): Promise<void> {
       : options.declaration ?? "inline",
   };
 
-  let loggerInfo = options.loggerInfo || ((message: string) => { console.log(`[dnt] ${message}`);});
-  let loggerWarn = options.loggerWarn || ((message: string) => { console.warn(colors.yellow(`[dnt] ${message}`)); });
-  
+  let loggerInfo = options.loggerInfo || ((message: string) => {
+    console.log(`[dnt] ${message}`);
+  });
+  let loggerWarn = options.loggerWarn || ((message: string) => {
+    console.warn(colors.yellow(`[dnt] ${message}`));
+  });
+
   const packageManager = options.packageManager ?? "npm";
   const scriptTarget = options.compilerOptions?.target ?? "ES2021";
   const entryPoints: EntryPoint[] = options.entryPoints.map((e, i) => {

--- a/mod.ts
+++ b/mod.ts
@@ -191,10 +191,10 @@ export async function build(options: BuildOptions): Promise<void> {
       : options.declaration ?? "inline",
   };
 
-  let loggerInfo = options.loggerInfo || ((message: string) => {
+  const loggerInfo = options.loggerInfo || ((message: string) => {
     console.log(`[dnt] ${message}`);
   });
-  let loggerWarn = options.loggerWarn || ((message: string) => {
+  const loggerWarn = options.loggerWarn || ((message: string) => {
     console.warn(colors.yellow(`[dnt] ${message}`));
   });
 

--- a/mod.ts
+++ b/mod.ts
@@ -59,9 +59,10 @@ export interface BuildOptions {
    */
   typeCheck?: "both" | "single" | false;
   /** Collect and run test files.
+   * if test is set to "no-run", the test task will be renerated but will not be execute.
    * @default true
    */
-  test?: boolean;
+  test?: "no-run" | boolean;
   /** Create declaration files.
    *
    * * `"inline"` - Emit declaration files beside the .js files in both
@@ -394,6 +395,7 @@ export async function build(options: BuildOptions): Promise<void> {
   if (options.test) {
     log("Running tests...");
     createTestLauncherScript();
+    if (options.test != "no-run")
     await runNpmCommand({
       bin: packageManager,
       args: ["run", "test"],

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1063,7 +1063,7 @@ async function runTest(
     ? path.fromFileUrl(options.outDir)
     : options.outDir;
   Deno.chdir(`./tests/${project}`);
-  let outputLogs: string[] = [];
+  const outputLogs: string[] = [];
   options.loggerInfo = (msg: string) => {
     outputLogs.push("I:" + msg);
   };

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -6,7 +6,7 @@ import {
   assertStringIncludes,
 } from "https://deno.land/std@0.182.0/testing/asserts.ts";
 import { ShimValue } from "../lib/shims.ts";
-import { build, BuildOptions, ShimOptions } from "../mod.ts";
+import { build, BuildOptions, PackageJson, ShimOptions } from "../mod.ts";
 import { path } from "../lib/mod.deps.ts";
 
 const versions = {
@@ -214,6 +214,7 @@ Deno.test("should build with all options off", async () => {
 
     output.assertNotExists("script/mod.js");
     output.assertNotExists("types/mod.js");
+    output.assertNotExists("test_runner.js");
 
     // This doesn't include the test files because they're not analyzed for in this scenario.
     assertEquals(
@@ -950,7 +951,7 @@ Deno.test("should build and type check declaration import project", async () => 
 });
 
 export interface Output {
-  packageJson: any;
+  packageJson: PackageJson;
   npmIgnore: string;
   getFileText(filePath: string): string;
   assertExists(filePath: string): void;


### PR DESCRIPTION
Hi, in my case I need to update the generated code, after the generation, then run the test.
if I set test to false these will not be generated.

to be able to do so I allow `test` to be set to "no-run".

To make the test able to check that the build process is as intended, I update the logged message to output `Creating tests...` instead of `Running tests...`.

Currently the log function is just a console.log();
I have also updated dnt options to be able to override the log function using 2 new options:

loggerInfo?: (message: string) => void;
loggerWarn?: (message: string) => void;

---
So now `integration.test.ts` drop the previous console.log call, save them in an string[], then check if it contains the proper output.

I did not integrate the test of build output in all test yet.

I also add (just one for the moment) `output.assertNotExists("test_runner.js");` to ensure test_runner.js is properly generated if it should.

so there is more update in test than in code in this PR.
I also start an other change in tests:

replacing test like:

```ts
    assertEquals(
      output.npmIgnore,
      `src/
test_runner.js
yarn.lock
pnpm-lock.yaml
`,
    );

```

by 
```ts
    assertEquals(
      output.npmIgnore,
      [ "src/", "test_runner.js", "yarn.lock", "pnpm-lock.yaml", ""],join("\n"),
    );
```
the the gold of this update, is: 
- improve readability, by improving code indentation.
- be able to have less duplicated filename string.
- be allow to reduce the size of the test files.

