### PR TITLE
:sparkles: add `wasmUrl` options

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -115,6 +115,8 @@ export interface BuildOptions {
   package: PackageJson;
   /** Path or url to import map. */
   importMap?: string;
+  /** Custom wasm file url */
+  wasmUrl?: string;
   /** Package manager used to install dependencies and run npm scripts.
    * This also can be an absolute path to the executable file of package manager.
    * @default "npm"
@@ -539,6 +541,7 @@ export async function build(options: BuildOptions): Promise<void> {
       mappings: options.mappings,
       target: scriptTarget,
       importMap: options.importMap,
+      wasmUrl: options.wasmUrl,
     });
   }
 

--- a/transform.ts
+++ b/transform.ts
@@ -68,6 +68,7 @@ export interface TransformOptions {
   target: ScriptTarget;
   /// Path or url to the import map.
   importMap?: string;
+  wasmUrl?: string;
 }
 
 /** Dependency in a package.json file. */
@@ -122,7 +123,9 @@ export async function transform(
       ? undefined
       : valueToUrl(options.importMap),
   };
-  const wasmFuncs = await instantiate();
+  const wasmFuncs = await instantiate({
+    url: options.wasmUrl ? new URL(options.wasmUrl) : undefined,
+  });
   return wasmFuncs.transform(newOptions);
 }
 


### PR DESCRIPTION
users can provide their own wasm path to meet the needs of some special situations.