### PR TITLE
feat: add skipNpmInstall option

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -233,8 +233,8 @@ export async function build(options: BuildOptions): Promise<void> {
   createNpmIgnore();
 
   // install dependencies in order to prepare for checking TS diagnostics
-  if (!options.skipInstallDeps) log(`Running ${packageManager} install...`);
-  const npmInstallPromise = options.skipInstallDeps
+  if (!options.skipNpmInstall) log(`Running ${packageManager} install...`);
+  const npmInstallPromise = options.skipNpmInstall
     ? Promise.resolve()
     : runNpmCommand({
       bin: packageManager,

--- a/mod.ts
+++ b/mod.ts
@@ -85,6 +85,10 @@ export interface BuildOptions {
    * @default false
    */
   skipSourceOutput?: boolean;
+  /** Skip installing dependencies
+   * @default false
+   */
+  skipInstallDeps?: boolean;
   /** Root directory to find test files in. Defaults to the cwd. */
   rootTestDir?: string;
   /** Glob pattern to use to find tests files. Defaults to `deno test`'s pattern. */
@@ -229,12 +233,14 @@ export async function build(options: BuildOptions): Promise<void> {
   createNpmIgnore();
 
   // install dependencies in order to prepare for checking TS diagnostics
-  log(`Running ${packageManager} install...`);
-  const npmInstallPromise = runNpmCommand({
-    bin: packageManager,
-    args: ["install"],
-    cwd: options.outDir,
-  });
+  if (!options.skipInstallDeps) log(`Running ${packageManager} install...`);
+  const npmInstallPromise = options.skipInstallDeps
+    ? Promise.resolve()
+    : runNpmCommand({
+      bin: packageManager,
+      args: ["install"],
+      cwd: options.outDir,
+    });
   if (options.typeCheck || options.declaration) {
     // Unfortunately this can't be run in parallel to building the project
     // in this case because TypeScript will resolve the npm packages when

--- a/mod.ts
+++ b/mod.ts
@@ -85,10 +85,10 @@ export interface BuildOptions {
    * @default false
    */
   skipSourceOutput?: boolean;
-  /** Skip installing dependencies
+  /** Skip running `npm install`
    * @default false
    */
-  skipInstallDeps?: boolean;
+  skipNpmInstall?: boolean;
   /** Root directory to find test files in. Defaults to the cwd. */
   rootTestDir?: string;
   /** Glob pattern to use to find tests files. Defaults to `deno test`'s pattern. */


### PR DESCRIPTION
This PR adds a `skipInstallDeps` option (`false` by default), which allows to skip the `npm install` step (or whatever package manager you're using).
 
## Motivation
I would like to include a `prepare`-script in an npm package. This `prepare`-script runs automatically during `npm install`, which I would like to avoid.