### PR TITLE
fix: fetch https dependencies with retries

### DIFF
--- a/lib/pkg/dnt_wasm.generated.js
+++ b/lib/pkg/dnt_wasm.generated.js
@@ -1,7 +1,7 @@
 // @generated file from wasmbuild -- do not edit
 // deno-lint-ignore-file
 // deno-fmt-ignore-file
-// source-hash: 58aa2224d6132527015f21adde12f0ec130c02be
+// source-hash: 3ee96b32ff7c942bd78417f61a381a5dc1f1de57
 let wasm;
 
 import { fetch_specifier } from "./snippets/dnt-wasm-a15ef721fa5290c5/helpers.js";
@@ -300,13 +300,13 @@ const imports = {
       const ret = new Error(getStringFromWasm0(arg0, arg1));
       return addHeapObject(ret);
     },
-    __wbg_fetchspecifier_a6bda29173284144: function (arg0, arg1) {
+    __wbg_fetchspecifier_a6bda29173284144: function (arg0, arg1, arg2) {
       let deferred0_0;
       let deferred0_1;
       try {
         deferred0_0 = arg0;
         deferred0_1 = arg1;
-        const ret = fetch_specifier(getStringFromWasm0(arg0, arg1));
+        const ret = fetch_specifier(getStringFromWasm0(arg0, arg1), arg2);
         return addHeapObject(ret);
       } finally {
         wasm.__wbindgen_free(deferred0_0, deferred0_1, 1);

--- a/lib/pkg/snippets/dnt-wasm-a15ef721fa5290c5/helpers.js
+++ b/lib/pkg/snippets/dnt-wasm-a15ef721fa5290c5/helpers.js
@@ -1,7 +1,20 @@
-import { createCache } from "https://deno.land/x/deno_cache@0.6.1/mod.ts";
+import { createCache } from "https://deno.land/x/deno_cache@0.6.2/mod.ts";
 
 const fileFetcher = createCache();
 
-export function fetch_specifier(specifier) {
-  return fileFetcher.load(new URL(specifier));
+export function fetch_specifier(specifier, cacheSettingVal) {
+  return fileFetcher.load(new URL(specifier), getCacheSetting(cacheSettingVal));
+}
+
+function getCacheSetting(val) {
+  // WARNING: ensure this matches wasm/src/lib.rs
+  switch (val) {
+    case 1:
+      return "use";
+    case 2:
+      return "reload";
+    case 0:
+    default:
+      return "only";
+  }
 }

--- a/rs-lib/src/graph.rs
+++ b/rs-lib/src/graph.rs
@@ -19,6 +19,7 @@ use anyhow::Context;
 use anyhow::Result;
 use deno_ast::ModuleSpecifier;
 use deno_ast::ParsedSource;
+use deno_graph::source::CacheSetting;
 use deno_graph::source::ResolutionMode;
 use deno_graph::source::ResolveError;
 use deno_graph::CapturingModuleAnalyzer;
@@ -231,7 +232,7 @@ impl ImportMapResolver {
     loader: &dyn Loader,
   ) -> Result<Self> {
     let response = loader
-      .load(import_map_url.clone())
+      .load(import_map_url.clone(), CacheSetting::Use)
       .await?
       .ok_or_else(|| anyhow!("Could not find {}", import_map_url))?;
     let value = jsonc_parser::parse_to_serde_value(

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -39,6 +39,7 @@ use visitors::GetGlobalTextChangesParams;
 use visitors::GetImportExportsTextChangesParams;
 
 pub use deno_ast::ModuleSpecifier;
+pub use deno_graph::source::CacheSetting;
 pub use loader::LoadResponse;
 pub use loader::Loader;
 pub use utils::url_to_file_path;

--- a/rs-lib/src/loader/default_loader.rs
+++ b/rs-lib/src/loader/default_loader.rs
@@ -5,6 +5,7 @@ use std::pin::Pin;
 
 use anyhow::Result;
 use deno_ast::ModuleSpecifier;
+use deno_graph::source::CacheSetting;
 use futures::Future;
 
 use crate::utils::url_to_file_path;
@@ -23,6 +24,7 @@ impl Loader for DefaultLoader {
   fn load(
     &self,
     specifier: ModuleSpecifier,
+    _cache_setting: CacheSetting,
   ) -> Pin<Box<dyn Future<Output = Result<Option<LoadResponse>>> + 'static>> {
     Box::pin(async move {
       if specifier.scheme() == "file" {

--- a/rs-lib/src/loader/mod.rs
+++ b/rs-lib/src/loader/mod.rs
@@ -35,6 +35,7 @@ pub trait Loader {
   fn load(
     &self,
     url: ModuleSpecifier,
+    cache_setting: CacheSetting,
   ) -> Pin<Box<dyn Future<Output = Result<Option<LoadResponse>>> + 'static>>;
 }
 
@@ -75,8 +76,7 @@ impl<'a> deno_graph::source::Loader for SourceLoader<'a> {
     &mut self,
     specifier: &ModuleSpecifier,
     _is_dynamic: bool,
-    // todo: handle this for the new registry
-    _cache_setting: CacheSetting,
+    cache_setting: CacheSetting,
   ) -> deno_graph::source::LoadFuture {
     let specifier = match self.specifier_mappings.get(specifier) {
       Some(MappedSpecifier::Package(mapping)) => {
@@ -112,7 +112,7 @@ impl<'a> deno_graph::source::Loader for SourceLoader<'a> {
     let loader = self.loader.clone();
     let specifier = specifier.to_owned();
     Box::pin(async move {
-      let resp = loader.load(specifier.clone()).await;
+      let resp = loader.load(specifier.clone(), cache_setting).await;
       resp.map(|r| {
         r.map(|r| deno_graph::source::LoadResponse::Module {
           specifier: r.specifier,

--- a/rs-lib/tests/integration/in_memory_loader.rs
+++ b/rs-lib/tests/integration/in_memory_loader.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 
 use anyhow::anyhow;
 use anyhow::Result;
+use deno_graph::source::CacheSetting;
 use futures::Future;
 
 use deno_node_transform::url_to_file_path;
@@ -89,6 +90,7 @@ impl Loader for InMemoryLoader {
   fn load(
     &self,
     specifier: ModuleSpecifier,
+    _cache_setting: CacheSetting,
   ) -> Pin<Box<dyn Future<Output = Result<Option<LoadResponse>>> + 'static>> {
     if specifier.scheme() == "file" {
       let file_path = url_to_file_path(&specifier).unwrap();

--- a/wasm/helpers.js
+++ b/wasm/helpers.js
@@ -1,7 +1,20 @@
-import { createCache } from "https://deno.land/x/deno_cache@0.6.1/mod.ts";
+import { createCache } from "https://deno.land/x/deno_cache@0.6.2/mod.ts";
 
 const fileFetcher = createCache();
 
-export function fetch_specifier(specifier) {
-  return fileFetcher.load(new URL(specifier));
+export function fetch_specifier(specifier, cacheSettingVal) {
+  return fileFetcher.load(new URL(specifier), getCacheSetting(cacheSettingVal));
+}
+
+function getCacheSetting(val) {
+  // WARNING: ensure this matches wasm/src/lib.rs
+  switch (val) {
+    case 1:
+      return "use";
+    case 2:
+      return "reload";
+    case 0:
+    default:
+      return "only";
+  }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -23,7 +23,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[wasm_bindgen(module = "/helpers.js")]
 extern "C" {
-  async fn fetch_specifier(specifier: String) -> JsValue;
+  async fn fetch_specifier(specifier: String, cache_setting: u8) -> JsValue;
 }
 
 struct JsLoader {}
@@ -32,11 +32,21 @@ impl dnt::Loader for JsLoader {
   fn load(
     &self,
     url: dnt::ModuleSpecifier,
+    cache_setting: dnt::CacheSetting,
   ) -> std::pin::Pin<
     Box<dyn Future<Output = Result<Option<dnt::LoadResponse>>> + 'static>,
   > {
     Box::pin(async move {
-      let resp = fetch_specifier(url.to_string()).await;
+      let resp = fetch_specifier(
+        url.to_string(),
+        // WARNING: Ensure this matches wasm/helpers.js
+        match cache_setting {
+          dnt::CacheSetting::Only => 0,
+          dnt::CacheSetting::Use => 1,
+          dnt::CacheSetting::Reload => 2,
+        },
+      )
+      .await;
       if resp.is_null() || resp.is_undefined() {
         return Ok(None);
       }


### PR DESCRIPTION
Fix here is to upgrade to the latest deno_cache. The cache setting stuff is just bonus that hooks this up for the replacement registry.

Closes https://github.com/denoland/dnt/issues/340