### PR TITLE
fix: remove needless semi-colon in fromAsync.ts

### DIFF
--- a/rs-lib/src/polyfills/scripts/esnext.array-fromAsync.ts
+++ b/rs-lib/src/polyfills/scripts/esnext.array-fromAsync.ts
@@ -137,7 +137,7 @@ async function fromAsync(this: any, items: any, mapfn: any, thisArg: any) {
     result.length = i;
     return result;
   }
-};
+}
 
 if (!Array.fromAsync) {
   (Array as any).fromAsync = fromAsync;


### PR DESCRIPTION
The "exclude" in deno.json is nice, but not so nice in this scenario as it prevents formatting.

I didn't bother running a wasm build because this is not a big deal.