### PR TITLE
feat: make declarationMap configurable and enable by default

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -73,6 +73,9 @@ export interface BuildOptions {
    * @default "inline"
    */
   declaration?: "inline" | "separate" | false;
+  /** Create declaration map files. Defaults to `true` if `declaration` is enabled and `skipSourceOutput` is `false`.
+   */
+  declarationMap?: boolean;
   /** Include a CommonJS or UMD module.
    * @default "cjs"
    */
@@ -196,6 +199,8 @@ export async function build(options: BuildOptions): Promise<void> {
       ? "inline"
       : options.declaration ?? "inline",
   };
+  const declarationMap = options.declarationMap ??
+    (!!options.declaration && !options.skipSourceOutput);
   const packageManager = options.packageManager ?? "npm";
   const scriptTarget = options.compilerOptions?.target ?? "ES2021";
   const entryPoints: EntryPoint[] = options.entryPoints.map((e, i) => {
@@ -269,6 +274,7 @@ export async function build(options: BuildOptions): Promise<void> {
       noUncheckedIndexedAccess:
         options.compilerOptions?.noUncheckedIndexedAccess ?? false,
       declaration: !!options.declaration,
+      declarationMap,
       esModuleInterop: false,
       isolatedModules: true,
       useDefineForClassFields: true,
@@ -356,6 +362,7 @@ export async function build(options: BuildOptions): Promise<void> {
     log("Emitting ESM package...");
     project.compilerOptions.set({
       declaration: options.declaration === "inline",
+      declarationMap: declarationMap ? options.declaration === "inline" : false,
       outDir: esmOutDir,
     });
     program = project.createProgram();
@@ -375,6 +382,7 @@ export async function build(options: BuildOptions): Promise<void> {
     log("Emitting script package...");
     project.compilerOptions.set({
       declaration: options.declaration === "inline",
+      declarationMap: declarationMap ? options.declaration === "inline" : false,
       esModuleInterop: true,
       outDir: scriptOutDir,
       module: options.scriptModule === "umd"

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -262,6 +262,7 @@ Deno.test("should build test project with declarations inline by default", async
       entryPoints: ["mod.ts"],
       outDir: "./npm",
       declaration,
+      declarationMap: false,
       shims: {
         deno: "dev",
       },
@@ -276,8 +277,11 @@ Deno.test("should build test project with declarations inline by default", async
       output.assertNotExists("script/mod.js.map");
       output.assertNotExists("esm/mod.js.map");
       output.assertNotExists("types/mod.d.ts");
+      output.assertNotExists("types/mod.d.ts.map");
       output.assertExists("script/mod.d.ts");
+      output.assertNotExists("script/mod.d.ts.map");
       output.assertExists("esm/mod.d.ts");
+      output.assertNotExists("esm/mod.d.ts.map");
       assertEquals(output.packageJson, {
         name: "add",
         version: "1.0.0",
@@ -304,6 +308,42 @@ Deno.test("should build test project with declarations inline by default", async
       });
     });
   }
+});
+
+Deno.test("should build test project with declaration maps by default", async () => {
+  await runTest("test_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    declaration: "inline",
+    shims: {
+      deno: "dev",
+    },
+    package: {
+      name: "add",
+      version: "1.0.0",
+    },
+  }, (output) => {
+    output.assertNotExists("types/mod.d.ts");
+    output.assertExists("script/mod.d.ts.map");
+    output.assertExists("esm/mod.d.ts.map");
+  });
+
+  await runTest("test_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    declaration: "separate",
+    shims: {
+      deno: "dev",
+    },
+    package: {
+      name: "add",
+      version: "1.0.0",
+    },
+  }, (output) => {
+    output.assertExists("types/mod.d.ts.map");
+    output.assertNotExists("script/mod.d.ts.map");
+    output.assertNotExists("esm/mod.d.ts.map");
+  });
 });
 
 Deno.test("should build bin project", async () => {


### PR DESCRIPTION
adds support for being able to configure the [`declarationMap`](https://www.typescriptlang.org/tsconfig#declarationMap) option. this is very useful when using go to definition in editors as it will take you directly to the `.ts` source code (if published) rather than the output `.d.ts` or `.js` files.