### PR TITLE
chore: fix publish exclude

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -13,8 +13,14 @@
       ]
     }
   },
+  "format": {
+    "exclude": [
+      "!lib/pkg/"
+    ]
+  },
   "publish": {
     "exclude": [
+      "!lib/pkg/",
       "rs-lib/",
       "tests/",
       "Cargo.lock",


### PR DESCRIPTION
It was excluding files found in the module graph.