### PR TITLE
fix: allow jsr packages to be mapped

### DIFF
--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -22,6 +22,7 @@ Deno.test({
 Deno.test("valueToUrl", () => {
   assertEquals(valueToUrl("npm:test"), "npm:test");
   assertEquals(valueToUrl("node:path"), "node:path");
+  assertEquals(valueToUrl("jsr:@scope/package"), "jsr:@scope/package");
   assertEquals(valueToUrl("https://deno.land"), "https://deno.land");
   assertEquals(valueToUrl("http://deno.land"), "http://deno.land");
   assertEquals(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -95,6 +95,7 @@ export function valueToUrl(value: string) {
     lowerCaseValue.startsWith("http:") ||
     lowerCaseValue.startsWith("https:") ||
     lowerCaseValue.startsWith("npm:") ||
+    lowerCaseValue.startsWith("jsr:") ||
     lowerCaseValue.startsWith("node:") ||
     lowerCaseValue.startsWith("file:")
   ) {


### PR DESCRIPTION
When wanting to map jsr packages to npm it would be nice to not crash.

example

```ts
await build({
  // ...
  mappings: {
    'jsr:@mr/object-identity': {
      name: 'object-identity',
      version: '^1'
    }
  } 
});
```

```shell
$ deno task build
error: Uncaught (in promise) "The following specifiers were indicated to be mapped to a package, but were not found:\n  * file:///Users/stuff/jsr:@mr/object-identity"
```

I am not 100% sure this will fix the issue, but sounds promising 🙏🏻 