### PR TITLE
Update picocolors and @types/node version dependency

### DIFF
--- a/lib/package_json.test.ts
+++ b/lib/package_json.test.ts
@@ -3,9 +3,12 @@
 import { assertEquals } from "@std/assert";
 import { getPackageJson, type GetPackageJsonOptions } from "./package_json.ts";
 
+/**
+ * versions must be sync with versions from ./package_json.ts
+ */
 const versions = {
-  picocolors: "^1.0.1",
-  nodeTypes: "^20.12.12",
+  picocolors: "^1.1.0",
+  nodeTypes: "^20.16.5",
   tsLib: "^2.6.2",
 };
 

--- a/lib/package_json.test.ts
+++ b/lib/package_json.test.ts
@@ -4,8 +4,8 @@ import { assertEquals } from "@std/assert";
 import { getPackageJson, type GetPackageJsonOptions } from "./package_json.ts";
 
 const versions = {
-  picocolors: "^1.0.0",
-  nodeTypes: "^20.9.0",
+  picocolors: "^1.0.1",
+  nodeTypes: "^20.12.12",
   tsLib: "^2.6.2",
 };
 

--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -4,6 +4,14 @@ import type { EntryPoint, ShimOptions } from "../mod.ts";
 import type { TransformOutput } from "../transform.ts";
 import type { PackageJson } from "./types.ts";
 import { getDntVersion } from "./utils.ts";
+/**
+ * versions must be sync with versions from ./package_json.test.ts
+ */
+const versions = {
+  picocolors: "^1.1.0",
+  nodeTypes: "^20.16.5",
+  tsLib: "^2.6.2",
+};
 
 export interface GetPackageJsonOptions {
   transformOutput: TransformOutput;
@@ -41,7 +49,7 @@ export function getPackageJson({
     // typescript helpers library (https://www.npmjs.com/package/tslib)
     ...(includeTsLib
       ? {
-        tslib: "^2.6.2",
+        tslib: versions.tsLib,
       }
       : {}),
     // add dependencies from transform
@@ -67,7 +75,7 @@ export function getPackageJson({
     ? ({
       ...(!Object.keys(dependencies).includes("picocolors")
         ? {
-          "picocolors": "^1.0.0",
+          "picocolors": versions.picocolors,
         }
         : {}),
       // add dependencies from transform
@@ -81,7 +89,7 @@ export function getPackageJson({
   const devDependencies = {
     ...(shouldIncludeTypesNode()
       ? {
-        "@types/node": "^20.9.0",
+        "@types/node": versions.nodeTypes,
       }
       : {}),
     ...testDevDependencies,

--- a/lib/shims.ts
+++ b/lib/shims.ts
@@ -103,7 +103,7 @@ function getDenoShim(): Shim {
   return {
     package: {
       name: "@deno/shim-deno",
-      version: "~0.18.0",
+      version: "~0.19.1",
     },
     globalNames: ["Deno"],
   };

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -15,8 +15,8 @@ const versions = {
   timersShim: "~0.1.0",
   weakRefSham: "~0.1.0",
   undici: "^6.0.0",
-  picocolors: "^1.0.1",
-  nodeTypes: "^20.12.12",
+  picocolors: "^1.1.0",
+  nodeTypes: "^20.16.5",
   tsLib: "^2.6.2",
 };
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -6,7 +6,7 @@ import type { ShimValue } from "../lib/shims.ts";
 import { build, type BuildOptions, type ShimOptions } from "../mod.ts";
 
 const versions = {
-  denoShim: "~0.18.0",
+  denoShim: "~0.19.1",
   denoTestShim: "~0.5.0",
   cryptoShim: "~0.3.1",
   domExceptionShim: "^4.0.0",
@@ -15,8 +15,8 @@ const versions = {
   timersShim: "~0.1.0",
   weakRefSham: "~0.1.0",
   undici: "^6.0.0",
-  picocolors: "^1.0.0",
-  nodeTypes: "^20.9.0",
+  picocolors: "^1.0.1",
+  nodeTypes: "^20.12.12",
   tsLib: "^2.6.2",
 };
 


### PR DESCRIPTION
Picocolors used to not receive any updates, but last week it was updated to version 1.0.1. [See changelog](https://github.com/alexeyraspopov/picocolors/blob/main/CHANGELOG.md).

Having up-to-date dependencies improves the npm quality score. Since the deno + dnt project aims to be better than other projects, maintaining a good score is essential. 👯

By the way, I also updated the versions of `@types/node` and `@deno/shim-deno`.
