### PR TITLE
feat: allows us to map some JSR things

### DIFF
--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1067,6 +1067,58 @@ Deno.test("using declaration project", async () => {
   });
 });
 
+Deno.test("should build jsr mapped project", async () => {
+  await runTest("jsr_map_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    typeCheck: "both",
+    shims: {
+      deno: {
+        test: true,
+      },
+    },
+    package: {
+      name: "add",
+      version: "1.0.0",
+    },
+    mappings: {
+      "jsr:@std/csv/parse": {
+        name: "csv-parse",
+        version: "*",
+      },
+    },
+  }, (output) => {
+    output.assertNotExists("script/mod.js.map");
+    output.assertNotExists("esm/mod.js.map");
+    assertEquals(output.packageJson, {
+      name: "add",
+      version: "1.0.0",
+      main: "./script/mod.js",
+      module: "./esm/mod.js",
+      exports: {
+        ".": {
+          import: "./esm/mod.js",
+          require: "./script/mod.js",
+        },
+      },
+      scripts: {
+        test: "node test_runner.js",
+      },
+      dependencies: {
+        tslib: versions.tsLib,
+        "@deno/sham-weakref": versions.weakRefSham,
+        "assert": "*"
+      },
+      devDependencies: {
+        "@types/node": versions.nodeTypes,
+        picocolors: versions.picocolors,
+        "@deno/shim-deno": versions.denoShim,
+      },
+      _generatedBy: "dnt@dev",
+    });
+  });
+})
+
 Deno.test("should build jsr project", async () => {
   await runTest("jsr_project", {
     entryPoints: ["mod.ts"],
@@ -1144,6 +1196,7 @@ async function runTest(
     | "declaration_import_project"
     | "import_map_project"
     | "json_module_project"
+    | "jsr_map_project"
     | "jsr_project"
     | "package_mappings_project"
     | "polyfill_project"

--- a/tests/jsr_map_project/mod.ts
+++ b/tests/jsr_map_project/mod.ts
@@ -1,0 +1,12 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { parse } from "jsr:@std/csv/parse";
+import { assertEquals } from "jsr:@std/assert@0.221/assert-equals";
+import * as fs from "node:fs";
+
+export function add(a: number, b: number) {
+  console.log(fs.readFileSync);
+  const result = parse("a,b,c\n1,2,3\n4,5,6");
+  assertEquals(result[0], ["a", "b", "c"]);
+  return a + b;
+}


### PR DESCRIPTION
Following #398 the change looked like not quite complete, I feel this change might be it.

The issue really comes from specifies not able to map correctly. Maybe because `jsr` is seen as _external_, and thus gets converted into "paths". Like: `host: jsr.io, path: /@std/assert/1.2.3/mod.ts`, so package mappings are never able to find it.

https://github.com/denoland/dnt/blob/00b9ab70716668ab781d0d99141e52a19e15e756/rs-lib/src/graph.rs#L138

I've written tests, that are currently _failing_. But until we land https://github.com/denoland/deno_graph/pull/490 I am not able to verify that it'll work.