### PR TITLE
fix: missing `scripts` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ There are several steps done in a pipeline:
        bugs: {
          url: "https://github.com/username/repo/issues",
        },
-       scripts: {}
+       scripts: {},
      },
      postBuild() {
        // steps to run after building and before running the tests

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ There are several steps done in a pipeline:
        bugs: {
          url: "https://github.com/username/repo/issues",
        },
-       scripts: {},
+       scripts: {}
      },
      postBuild() {
        // steps to run after building and before running the tests

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ There are several steps done in a pipeline:
        bugs: {
          url: "https://github.com/username/repo/issues",
        },
-       scripts: {}
      },
      postBuild() {
        // steps to run after building and before running the tests

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ There are several steps done in a pipeline:
        bugs: {
          url: "https://github.com/username/repo/issues",
        },
+       scripts: {}
      },
      postBuild() {
        // steps to run after building and before running the tests

--- a/lib/package_json.test.ts
+++ b/lib/package_json.test.ts
@@ -102,7 +102,7 @@ Deno.test("single entrypoint", () => {
       devDependencies: {
         "@types/node": versions.nodeTypes,
       },
-      scripts: undefined,
+      scripts: {},
       exports: {
         ".": {
           import: {
@@ -137,7 +137,7 @@ Deno.test("single entrypoint", () => {
       devDependencies: {
         "@types/node": versions.nodeTypes,
       },
-      scripts: undefined,
+      scripts: {},
       exports: {
         ".": {
           import: {
@@ -169,7 +169,7 @@ Deno.test("single entrypoint", () => {
       devDependencies: {
         "@types/node": versions.nodeTypes,
       },
-      scripts: undefined,
+      scripts: {},
       _generatedBy: "dnt@dev",
     },
   );
@@ -193,7 +193,7 @@ Deno.test("single entrypoint", () => {
       devDependencies: {
         "@types/node": versions.nodeTypes,
       },
-      scripts: undefined,
+      scripts: {},
       exports: {
         ".": {
           import: "./esm/mod.js",
@@ -226,7 +226,7 @@ Deno.test("single entrypoint", () => {
       devDependencies: {
         "@types/node": versions.nodeTypes,
       },
-      scripts: undefined,
+      scripts: {},
       exports: {
         ".": {
           import: "./esm/mod.js",
@@ -353,7 +353,7 @@ Deno.test("multiple entrypoints", () => {
         },
       },
     },
-    scripts: undefined,
+    scripts: {},
     _generatedBy: "dnt@dev",
   });
 });
@@ -423,7 +423,7 @@ Deno.test("binary entrypoints", () => {
         },
       },
     },
-    scripts: undefined,
+    scripts: {},
     _generatedBy: "dnt@dev",
   });
 });

--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -112,6 +112,7 @@ export function getPackageJson({
     ...mainExport,
     ...binaryExport,
     ...packageJsonObj,
+    scripts: {},
     ...deleteEmptyKeys({
       exports: {
         ...(includeEsModule || exports.length > 1

--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -94,7 +94,7 @@ export function getPackageJson({
       // override with specified scripts
       ...(packageJsonObj.scripts ?? {}),
     })
-    : packageJsonObj.scripts;
+    : packageJsonObj.scripts ?? {};
   const mainExport = exports.length > 0
     ? {
       module: includeEsModule ? `./esm/${exports[0].path}` : undefined,

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -214,6 +214,7 @@ Deno.test("should build with all options off", async () => {
       devDependencies: {
         "@types/node": versions.nodeTypes,
       },
+      scripts: {},
       _generatedBy: "dnt@dev",
     });
 


### PR DESCRIPTION
Without it, npm complains about it:
```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish Removed invalid "scripts"
```
via https://github.com/npm/cli/issues/6918 it looks like this is not going to be fixed, thus the change, which removes the warnings