### PR TITLE
build: add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+export DIRENV_WARN_TIMEOUT=2m
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .vscode
 tests/*/npm
 lib/pkg
+.direnv

--- a/README.md
+++ b/README.md
@@ -768,3 +768,18 @@ let output_result = transform(TransformOptions {
   specifier_mappings: None,
 }).await?;
 ```
+
+## Developing on DNT
+You'll need `Deno`, `rustup` and `Cargo`. If you're a [Nix](https://nixos.org/) user you can just run:
+```shell
+nix develop
+```
+in this folder to get a shell with all dependencies satisfied.
+You can then build DNT via:
+```shell
+deno task build
+```
+and run the tests after via
+```
+deno task test
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,57 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1718717814,
+        "narHash": "sha256-xB7AzKY4BP7yypo6g+sk1tnVK54sBIJMeEBB5CdbhT4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "88af533d8ae8d1e7e4648decf7817ebff91abf56",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1717284937,
+        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Dnt dev";
+
+  nixConfig.bash-prompt = "[dnt-dev]> ";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs";
+  };
+
+  outputs = inputs@{ self, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems =
+        [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, ... }: {
+        # Per-system attributes can be defined here. The self' and inputs'
+        # module parameters provide easy access to attributes of the same
+        # system.
+
+        # NOTE: You can also use `config.pre-commit.devShell`
+        devShells.default = pkgs.mkShell {
+          shellHook = ''
+            echo 1>&2 "Welcome to the DNT development shell!"
+          '';
+          buildInputs = with pkgs; [
+            deno
+            rustup
+            cargo
+          ];
+        };
+      };
+    };
+}


### PR DESCRIPTION
This adds a nix flake to this repo, allowing anyone to develop on DNT without having to install the whole rust toolchain, Deno, etc. ahead of time.

I understand that Nix might still be flying under the radar a bit - in that case I am happy to close this PR and other Nixians can hopefully find it via search.