### PR TITLE
Update README.md for Deno 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are several steps done in a pipeline:
 
 ## Setup
 
-1. `deno add @deno/dnt`
+1. `deno add jsr:@deno/dnt`
 
 1. Create a build script file:
 


### PR DESCRIPTION
If following README.md instructions on Deno 2 you get an error

```bash
14>‍:deno add @deno/dnt
error: @deno/dnt is missing a prefix. Did you mean `deno add jsr:@deno/dnt`?
```

This PR addresses that. 

*Note I didn't feel there is a need to mention how to use it in Deno 1