### PR TITLE
feat: add `experimentalDecorators` compiler option

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -171,6 +171,14 @@ export interface BuildOptions {
      * @default false
      */
     emitDecoratorMetadata?: boolean;
+    /**
+     * Enable experimental support for legacy experimental decorators.
+     *
+     * See more: https://www.typescriptlang.org/tsconfig#experimentalDecorators
+     * @remarks This is true by default for backwards compatibility. To use the new decorators, set this to `false`.
+     * @default true
+     */
+    experimentalDecorators?: boolean;
     useUnknownInCatchVariables?: boolean;
   };
   /** Filter out diagnostics that you want to ignore during type checking and emitting.
@@ -280,7 +288,8 @@ export async function build(options: BuildOptions): Promise<void> {
       esModuleInterop: false,
       isolatedModules: true,
       useDefineForClassFields: true,
-      experimentalDecorators: true,
+      experimentalDecorators: options.compilerOptions?.experimentalDecorators ??
+        true,
       emitDecoratorMetadata: options.compilerOptions?.emitDecoratorMetadata ??
         false,
       jsx: ts.JsxEmit.React,


### PR DESCRIPTION
## Description of the Change
This PR introduces the `experimentalDecorators` option to the TypeScript compiler in the dnt project. This allows disabling legacy decorators, which are currently hardcoded as true

## Problem
Currently, dnt enforces the use of legacy decorators, which conflicts with modern decorators. This causes errors both at compile time and runtime. For example:

![image](https://github.com/user-attachments/assets/2d29b67c-36da-4b89-b66a-4541a386ad4a)

This issue occurs because the emitted JavaScript relies on legacy decorators, which are incompatible with the expected behavior and types of modern decorators.

## Solution
- Adds support for explicitly configuring the `experimentalDecorators` compiler option.
- The default behavior remains unchanged (legacy decorators enabled) to avoid breaking existing projects, but developers can now disable it as needed.