### PR TITLE
feat: add jsx compiler options

### DIFF
--- a/lib/compiler.ts
+++ b/lib/compiler.ts
@@ -47,6 +47,31 @@ export function getCompilerScriptTarget(target: ScriptTarget) {
   }
 }
 
+/** How JSX constructs are emitted. See https://www.typescriptlang.org/tsconfig/#jsx */
+export type JsxEmit =
+  | "preserve"
+  | "react"
+  | "react-native"
+  | "react-jsx"
+  | "react-jsxdev";
+
+export function getCompilerJsxEmit(jsx: JsxEmit) {
+  switch (jsx) {
+    case "preserve":
+      return ts.JsxEmit.Preserve;
+    case "react":
+      return ts.JsxEmit.React;
+    case "react-native":
+      return ts.JsxEmit.ReactNative;
+    case "react-jsx":
+      return ts.JsxEmit.ReactJSX;
+    case "react-jsxdev":
+      return ts.JsxEmit.ReactJSXDev;
+    default:
+      throw new Error(`Unknown jsx compiler option: ${jsx}`);
+  }
+}
+
 // Created from https://github.com/microsoft/TypeScript/blob/v5.2.2/src/compiler/commandLineParser.ts
 // then aligned with tsconfig.json's casing
 export type LibName =

--- a/mod.ts
+++ b/mod.ts
@@ -4,10 +4,12 @@ import * as colors from "@std/fmt/colors";
 import * as path from "@std/path";
 import { createProjectSync, ts } from "@ts-morph/bootstrap";
 import {
+  getCompilerJsxEmit,
   getCompilerLibOption,
   getCompilerScriptTarget,
   getCompilerSourceMapOptions,
   getTopLevelAwaitLocation,
+  type JsxEmit,
   type LibName,
   libNamesToCompilerOption,
   outputDiagnostics,
@@ -29,7 +31,7 @@ import { getTestRunnerCode } from "./lib/test_runner/get_test_runner_code.ts";
 
 export { emptyDir } from "@std/fs/empty-dir";
 export type { PackageJson } from "./lib/types.ts";
-export type { LibName, SourceMapOptions } from "./lib/compiler.ts";
+export type { JsxEmit, LibName, SourceMapOptions } from "./lib/compiler.ts";
 export type { ShimOptions } from "./lib/shims.ts";
 
 export interface EntryPoint {
@@ -187,17 +189,25 @@ export interface BuildOptions {
      * Controls how JSX constructs are emitted in JavaScript files.
      *
      * See more: https://www.typescriptlang.org/tsconfig/#jsx
-     * @default ts.JsxEmit.React
+     * @default "react"
      */
-    jsx: ts.JsxEmit;
+    jsx?: JsxEmit;
     /**
      * @default "React.createElement"
      */
-    jsxFactory: string;
+    jsxFactory?: string;
     /**
      * @default "React.Fragment"
      */
-    jsxFragmentFactory: string;
+    jsxFragmentFactory?: string;
+    /**
+     * Module specifier to import the JSX factory functions from when using
+     * the automatic runtime (`jsx: "react-jsx"` or `"react-jsxdev"`).
+     *
+     * See more: https://www.typescriptlang.org/tsconfig/#jsxImportSource
+     * @default "react"
+     */
+    jsxImportSource?: string;
   };
   /** Filter out diagnostics that you want to ignore during type checking and emitting.
    * @returns `true` to surface the diagnostic or `false` to ignore it.
@@ -319,10 +329,11 @@ export async function build(options: BuildOptions): Promise<void> {
         false,
       emitDecoratorMetadata: options.compilerOptions?.emitDecoratorMetadata ??
         false,
-      jsx: options.compilerOptions?.jsx ?? ts.JsxEmit.React,
+      jsx: getCompilerJsxEmit(options.compilerOptions?.jsx ?? "react"),
       jsxFactory: options.compilerOptions?.jsxFactory ?? "React.createElement",
       jsxFragmentFactory: options.compilerOptions?.jsxFragmentFactory ??
         "React.Fragment",
+      jsxImportSource: options.compilerOptions?.jsxImportSource,
       importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
       module: ts.ModuleKind.ESNext,
       moduleResolution: ts.ModuleResolutionKind.Bundler,

--- a/mod.ts
+++ b/mod.ts
@@ -182,6 +182,22 @@ export interface BuildOptions {
      */
     experimentalDecorators?: boolean;
     useUnknownInCatchVariables?: boolean;
+
+    /**
+     * Controls how JSX constructs are emitted in JavaScript files.
+     *
+     * See more: https://www.typescriptlang.org/tsconfig/#jsx
+     * @default ts.JsxEmit.React
+     */
+    jsx: ts.JsxEmit;
+    /**
+     * @default "React.createElement"
+     */
+    jsxFactory: string;
+    /**
+     * @default "React.Fragment"
+     */
+    jsxFragmentFactory: string;
   };
   /** Filter out diagnostics that you want to ignore during type checking and emitting.
    * @returns `true` to surface the diagnostic or `false` to ignore it.
@@ -293,9 +309,10 @@ export async function build(options: BuildOptions): Promise<void> {
         false,
       emitDecoratorMetadata: options.compilerOptions?.emitDecoratorMetadata ??
         false,
-      jsx: ts.JsxEmit.React,
-      jsxFactory: "React.createElement",
-      jsxFragmentFactory: "React.Fragment",
+      jsx: options.compilerOptions?.jsx ?? ts.JsxEmit.React,
+      jsxFactory: options.compilerOptions?.jsxFactory ?? "React.createElement",
+      jsxFragmentFactory: options.compilerOptions?.jsxFragmentFactory ??
+        "React.Fragment",
       importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
       module: ts.ModuleKind.ESNext,
       moduleResolution: ts.ModuleResolutionKind.Bundler,


### PR DESCRIPTION
## Summary
I added JSX-related compiler options to the build function

## Details
This allows specifying the JSX transpilation method during the build process.

## Refs
Fixes #384 

