### PR TITLE
feat: update to latest deno_graph and ts-morph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
       - uses: denoland/setup-deno@v2
         with:
           deno-version: canary
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
@@ -53,7 +53,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
       - uses: denoland/setup-deno@v2
@@ -63,4 +63,4 @@ jobs:
       - name: Build
         run: deno task build
       - name: Publish on tag
-        run: deno run -A jsr:@david/publish-on-tag@0.2.0
+        run: deno run -A @david/publish-on-tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "20"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Format
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: 2.x
+          deno-version: canary
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -58,7 +58,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: 2.x
+          deno-version: canary
 
       - name: Build
         run: deno task build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: canary
+          deno-version: 2.x
       - uses: actions/setup-node@v7
         with:
           node-version: "20"
@@ -58,7 +58,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: canary
+          deno-version: 2.x
 
       - name: Build
         run: deno task build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,7 @@ dependencies = [
  "deno_config",
  "deno_error",
  "deno_graph",
+ "deno_lockfile",
  "deno_path_util",
  "deno_resolver",
  "deno_semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,12 +51,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,13 +58,12 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "ast_node"
-version = "3.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fb5864e2f5bf9fd9797b94b2dfd1554d4c3092b535008b27d7e15c86675a2f"
+checksum = "2eb025ef00a6da925cf40870b9c8d008526b6004ece399cb0974209720f0b194"
 dependencies = [
- "proc-macro2",
  "quote",
- "swc_macros_common 1.0.0",
+ "swc_macros_common",
  "syn",
 ]
 
@@ -123,22 +106,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base32"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -158,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "better_scoped_tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fd297a11c709be8348aec039c8b91de16075d2b2bdaee1bd562c0875993664"
+checksum = "7cd228125315b132eed175bf47619ac79b945b26e56b848ba203ae4ea8603609"
 dependencies = [
  "scoped-tls",
 ]
@@ -214,24 +185,28 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 dependencies = [
  "allocator-api2",
 ]
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
-name = "cache_control"
-version = "0.2.0"
+name = "bytes-str"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee"
+checksum = "577d2bf5650f8554d5a372af5ac93535110a0fc75b3e702bb853369febf227c2"
+dependencies = [
+ "bytes",
+ "serde",
+]
 
 [[package]]
 name = "capacity_builder"
@@ -280,12 +255,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.41"
+name = "cfg_aliases"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -310,6 +292,18 @@ dependencies = [
  "cfg-if",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
@@ -356,19 +350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,57 +373,55 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.48.1"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ced09fdb8884e29716cc0691e8510f9c655762bbb9da3111dacc0a2ef6e8960"
+checksum = "05792fb2b77938767ffeb0853289e86501fddc84b1cdba9e5dc860c52baa2ff7"
 dependencies = [
  "base64 0.22.1",
  "capacity_builder",
- "deno_error 0.6.1",
+ "deno_error",
  "deno_media_type",
  "deno_terminal",
  "dprint-swc-ext",
  "percent-encoding",
  "serde",
- "sourcemap",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_codegen_macros",
+ "swc_ecma_lexer",
  "swc_ecma_loader",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_eq_ignore_macros",
- "swc_macros_common 1.0.0",
+ "swc_macros_common",
+ "swc_sourcemap",
  "swc_visit",
- "swc_visit_macros",
  "text_lines",
  "thiserror",
- "unicode-width 0.2.0",
+ "unicode-width",
  "url",
 ]
 
 [[package]]
 name = "deno_cache_dir"
-version = "0.23.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7825da0551e670a270a3a20b92f8a0bffeb7d6120fa86b64e5daa969b8dd1a10"
+checksum = "8212647fded77a98bc45e8aba6cf72b73254583454e438f1dddc758d65056461"
 dependencies = [
  "async-trait",
- "base32",
- "base64 0.21.7",
+ "base64 0.22.1",
  "boxed_error",
- "cache_control",
  "chrono",
  "data-url",
- "deno_error 0.6.1",
+ "deno_error",
+ "deno_maybe_sync",
  "deno_media_type",
  "deno_path_util",
  "http",
- "indexmap",
  "log",
  "once_cell",
  "parking_lot",
@@ -456,21 +435,23 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.61.0"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8ce54588354b9149710db8439b8acb1f3c6722d3a007fcc39a651d0b00d15e"
+checksum = "c52d485b9cdd52a4da60248366d270f96c852dfddcd5f89993b26782c53225d3"
 dependencies = [
  "boxed_error",
  "capacity_builder",
- "deno_error 0.6.1",
+ "chrono",
+ "deno_error",
+ "deno_maybe_sync",
  "deno_package_json",
  "deno_path_util",
- "deno_semver 0.8.1",
+ "deno_semver",
  "glob",
  "ignore",
  "import_map",
  "indexmap",
- "jsonc-parser",
+ "jsonc-parser 0.32.4",
  "log",
  "serde",
  "serde_json",
@@ -481,21 +462,11 @@ dependencies = [
 
 [[package]]
 name = "deno_error"
-version = "0.5.6"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fae9fe305307b5ef3ee4e8244c79cffcca421ab0ce8634dea0c6b1342f220f"
+checksum = "bfafd2219b29886a71aecbb3449e462deed1b2c474dc5b12f855f0e58c478931"
 dependencies = [
- "deno_error_macro 0.5.6",
- "libc",
-]
-
-[[package]]
-name = "deno_error"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612ec3fc481fea759141b0c57810889b0a4fb6fee8f10748677bfe492fd30486"
-dependencies = [
- "deno_error_macro 0.6.1",
+ "deno_error_macro",
  "libc",
  "serde",
  "serde_json",
@@ -504,20 +475,9 @@ dependencies = [
 
 [[package]]
 name = "deno_error_macro"
-version = "0.5.6"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5abb2556e91848b66f562451fcbcdee2a3b7c88281828908dcf7cca355f5d997"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "deno_error_macro"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8380a4224d5d2c3f84da4d764c4326cac62e9a1e3d4960442d29136fc07be863"
+checksum = "1c28ede88783f14cd8aae46ca89f230c226b40e4a81ab06fa52ed72af84beb2f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -526,22 +486,22 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.96.2"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0733ed99295ebeddeb0fb33efa41ccd47ccd9481ab1ebe01f2ea8af80204479e"
+checksum = "18b1634ebdfde4f040b2c40f2510969e755e5b782319a01dc9cab88ef25b7e3f"
 dependencies = [
  "async-trait",
  "boxed_error",
  "capacity_builder",
+ "chrono",
  "data-url",
  "deno_ast",
- "deno_error 0.6.1",
+ "deno_error",
  "deno_media_type",
  "deno_path_util",
- "deno_semver 0.8.1",
+ "deno_semver",
  "deno_unsync",
  "futures",
- "import_map",
  "indexmap",
  "log",
  "monch",
@@ -559,22 +519,28 @@ dependencies = [
 
 [[package]]
 name = "deno_lockfile"
-version = "0.30.2"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4346e56cda020df5da35a3ec2624f09bd77c9f5ed18d903915007825fe9d3f"
+checksum = "21ff7d95e0dd52e86480e13d48d8f9b7dfe5f74c775146e53dc59f94b78e9ebe"
 dependencies = [
  "async-trait",
- "deno_semver 0.8.1",
+ "deno_semver",
  "serde",
  "serde_json",
  "thiserror",
 ]
 
 [[package]]
-name = "deno_media_type"
-version = "0.2.9"
+name = "deno_maybe_sync"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ec0dada9dc5ac4733b4175d36f6a150b7dd68fab46db35cb1ef00dd7366acb"
+checksum = "436bf225f77e5d1313a69b628a253596161e5da935a840df069b9e948253cb62"
+
+[[package]]
+name = "deno_media_type"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debab24ecd9f4fd64aa42fb18a02dff20a97d5830b2b85b98ce70b509f790763"
 dependencies = [
  "data-url",
  "encoding_rs",
@@ -592,14 +558,14 @@ dependencies = [
  "deno_ast",
  "deno_cache_dir",
  "deno_config",
- "deno_error 0.6.1",
+ "deno_error",
  "deno_graph",
  "deno_path_util",
  "deno_resolver",
- "deno_semver 0.7.1",
+ "deno_semver",
  "futures",
  "import_map",
- "jsonc-parser",
+ "jsonc-parser 0.26.2",
  "node_resolver",
  "once_cell",
  "pathdiff",
@@ -614,15 +580,17 @@ dependencies = [
 
 [[package]]
 name = "deno_npm"
-version = "0.35.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536a02c258d4a3fcbbbb898562e230bbe5939ac2eb7c2058718508304e4ab7cf"
+checksum = "63d483c8305ad1a45ae96de78157ed1252807d8e4c4da1f1d782b520736dbffb"
 dependencies = [
  "async-trait",
  "capacity_builder",
- "deno_error 0.6.1",
+ "chrono",
+ "deno_error",
  "deno_lockfile",
- "deno_semver 0.8.1",
+ "deno_package_json",
+ "deno_semver",
  "futures",
  "indexmap",
  "log",
@@ -630,19 +598,33 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "deno_npmrc"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d977172c9185a761c75e555d6117bb0df5f756b1c85c2521f446847b7b5129c"
+dependencies = [
+ "log",
+ "monch",
+ "sys_traits",
+ "thiserror",
  "url",
 ]
 
 [[package]]
 name = "deno_package_json"
-version = "0.13.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0ec78660b920021d97d158440f09455393b63c965b32d55a7e940a0e9a0a3e"
+checksum = "6e12b474d00a1aac1685f22b02d26f17b759b4463d7ec024d78bd5b69bbb0251"
 dependencies = [
  "boxed_error",
- "deno_error 0.6.1",
+ "capacity_builder",
+ "deno_error",
+ "deno_maybe_sync",
  "deno_path_util",
- "deno_semver 0.8.1",
+ "deno_semver",
  "indexmap",
  "serde",
  "serde_json",
@@ -653,11 +635,11 @@ dependencies = [
 
 [[package]]
 name = "deno_path_util"
-version = "0.4.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516f813389095889776b81cc9108ff6f336fd9409b4b12fc0138aea23d2708e1"
+checksum = "78c7e98943f0d068928906db0c7bde89de684fa32c6a8018caacc4cee2cdd72b"
 dependencies = [
- "deno_error 0.6.1",
+ "deno_error",
  "percent-encoding",
  "sys_traits",
  "thiserror",
@@ -666,63 +648,67 @@ dependencies = [
 
 [[package]]
 name = "deno_permissions"
-version = "0.70.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7609d9ec89c3018e9a4d14923cc0121da00c0241859c35a4bc8a0834f2a35d8e"
+checksum = "c4b8f61b3f439532277c4b313731391acdc930e1e12ce66f3fd3586b3a08f979"
 dependencies = [
  "capacity_builder",
- "deno_error 0.6.1",
+ "chrono",
+ "deno_error",
  "deno_path_util",
  "deno_terminal",
  "deno_unsync",
+ "dunce",
  "fqdn",
- "ipnetwork",
+ "ipnet",
  "libc",
  "log",
  "nix",
  "once_cell",
  "parking_lot",
- "percent-encoding",
  "serde",
  "serde_json",
  "sys_traits",
  "thiserror",
+ "unicode-normalization",
  "url",
  "which",
- "winapi",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "deno_resolver"
-version = "0.42.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1813a4562fd598fbb5e9d3112391f22382f9feff6573668dc768b5e65eca5cf9"
+checksum = "0cd6586e2cb556191cb40625dadd7318d80b1e5ab102065ede081944fc4d6cbb"
 dependencies = [
  "anyhow",
  "async-once-cell",
  "async-trait",
- "base32",
  "boxed_error",
+ "capacity_builder",
+ "chrono",
  "deno_cache_dir",
  "deno_config",
- "deno_error 0.6.1",
+ "deno_error",
  "deno_graph",
  "deno_lockfile",
+ "deno_maybe_sync",
  "deno_media_type",
  "deno_npm",
+ "deno_npmrc",
  "deno_package_json",
  "deno_path_util",
  "deno_permissions",
- "deno_semver 0.8.1",
+ "deno_semver",
  "deno_terminal",
  "deno_unsync",
- "dissimilar",
  "futures",
  "http",
+ "imara-diff",
  "import_map",
  "indexmap",
- "jsonc-parser",
+ "jsonc-parser 0.32.4",
  "log",
  "node_resolver",
  "once_cell",
@@ -734,33 +720,17 @@ dependencies = [
  "thiserror",
  "twox-hash",
  "url",
+ "yaml_parser",
 ]
 
 [[package]]
 name = "deno_semver"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4775271f9b5602482698f76d24ea9ed8ba27af7f587a7e9a876916300c542435"
+checksum = "147261611819fb4dfe339b53e3b45d6704c7e32c86ce33a88511d5bcebebaaa3"
 dependencies = [
  "capacity_builder",
- "deno_error 0.5.6",
- "ecow",
- "hipstr",
- "monch",
- "once_cell",
- "serde",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "deno_semver"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7123b11b66cf19e023372bfcb137498243ef32dd73c725b938c118ac9943f5"
-dependencies = [
- "capacity_builder",
- "deno_error 0.6.1",
+ "deno_error",
  "ecow",
  "hipstr",
  "monch",
@@ -772,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "deno_terminal"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f71c27009e0141dedd315f1dfa3ebb0a6ca4acce7c080fac576ea415a465f6"
+checksum = "f3ba8041ae7319b3ca6a64c399df4112badcbbe0868b4517637647614bede4be"
 dependencies = [
  "once_cell",
  "termcolor",
@@ -804,6 +774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -819,12 +790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dissimilar"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
-
-[[package]]
 name = "dnt-wasm"
 version = "0.0.0"
 dependencies = [
@@ -833,7 +798,7 @@ dependencies = [
  "console_error_panic_hook",
  "deno_cache_dir",
  "deno_config",
- "deno_error 0.6.1",
+ "deno_error",
  "deno_graph",
  "deno_node_transform",
  "deno_path_util",
@@ -849,20 +814,27 @@ dependencies = [
 
 [[package]]
 name = "dprint-swc-ext"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a09827d6db1a3af25e105553d674ee9019be58fa3d6745c2a2803f8ce8e3eb8"
+checksum = "33175ddb7a6d418589cab2966bd14a710b3b1139459d3d5ca9edf783c4833f4c"
 dependencies = [
  "allocator-api2",
  "bumpalo",
  "num-bigint",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_lexer",
  "swc_ecma_parser",
  "text_lines",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecow"
@@ -901,6 +873,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,18 +889,17 @@ dependencies = [
 
 [[package]]
 name = "fqdn"
-version = "0.3.12"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb540cf7bc4fe6df9d8f7f0c974cfd0dce8ed4e9e8884e73433b503ee78b4e7d"
+checksum = "886ac788f62d16d6b0f26b2fa762b34ef16ebfb4b624c2c15fbcadc9173c0f72"
 
 [[package]]
 name = "from_variant"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7ccf961415e7aa17ef93dcb6c2441faaa8e768abe09e659b908089546f74c5"
+checksum = "e5ff35a391aef949120a0340d690269b3d9f63460a6106e99bd07b961f345ea9"
 dependencies = [
- "proc-macro2",
- "swc_macros_common 1.0.0",
+ "swc_macros_common",
  "syn",
 ]
 
@@ -1084,6 +1061,9 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1110,15 +1090,15 @@ dependencies = [
 
 [[package]]
 name = "hstr"
-version = "1.0.0"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71399f53a92ef72ee336a4b30201c6e944827e14e0af23204c291aad9c24cc85"
+checksum = "83bb87e4b300d73412f6dcc7022ee7741452b51b155c2b06e5994d0770c2dbe2"
 dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
  "once_cell",
- "phf",
- "rustc-hash",
+ "rustc-hash 2.1.1",
+ "serde",
  "triomphe",
 ]
 
@@ -1295,13 +1275,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "import_map"
-version = "0.22.0"
+name = "imara-diff"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f315e535cb94a0e80704278d630990bb48834c8c8d976acf0a2f6bc8fede7c38"
+checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
+dependencies = [
+ "hashbrown 0.15.3",
+ "memchr",
+]
+
+[[package]]
+name = "import_map"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61dcb2ebdf4a4df8e6353c566f4b51ee2f602341538e41e77c8f861ac1bb16d5"
 dependencies = [
  "boxed_error",
- "deno_error 0.6.1",
+ "deno_error",
  "indexmap",
  "log",
  "percent-encoding",
@@ -1323,13 +1313,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnetwork"
-version = "0.20.0"
+name = "ipnet"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is-macro"
@@ -1369,6 +1356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonc-parser"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840785e1a8b4fdb27be18440a35a81af64820dc185c3973ff8b012d4c6282512"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "junction"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,12 +1398,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,15 +1421,24 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1463,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "monch"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52c1b33ff98142aecea13138bd399b68aa7ab5d9546c300988c345004001eea"
+checksum = "6bcc6ad3b93f756f2532d29f7c7291b8d246a2c460a99a3611327bb726830014"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -1475,36 +1474,39 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
 [[package]]
 name = "node_resolver"
-version = "0.49.0"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f7d49e392159082d2fe0081f14ba5b35705a782412beb559a9d1ef6b1463c0"
+checksum = "ce5a0fd58bd44f6a8b10bc79aae001645397f5d0bb001da338945b0a0df20ff2"
 dependencies = [
  "anyhow",
  "async-trait",
  "boxed_error",
- "dashmap",
- "deno_config",
- "deno_error 0.6.1",
+ "capacity_builder",
+ "deno_error",
  "deno_graph",
+ "deno_maybe_sync",
  "deno_media_type",
  "deno_package_json",
  "deno_path_util",
- "deno_semver 0.8.1",
+ "deno_semver",
  "futures",
  "lazy-regex",
+ "log",
  "once_cell",
  "path-clean",
+ "pretty_assertions",
  "regex",
  "serde",
  "serde_json",
@@ -1575,21 +1577,11 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "par-core"
-version = "1.0.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757892557993c69e82f9de0f9051e87144278aa342f03bf53617bbf044554484"
+checksum = "e96cbd21255b7fb29a5d51ef38a779b517a91abd59e2756c039583f43ef4c90f"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "par-iter"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b20f31e9ba82bfcbbb54a67aa40be6cebec9f668ba5753be138f9523c531a"
-dependencies = [
- "either",
- "par-core",
 ]
 
 [[package]]
@@ -1716,26 +1708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,10 +1776,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rowan"
+version = "0.15.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "memoffset",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -1855,11 +1846,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "seq-macro"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1884,10 +1882,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1982,24 +1989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sourcemap"
-version = "9.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22afbcb92ce02d23815b9795523c005cb9d3c214f8b7a66318541c240ea7935"
-dependencies = [
- "base64-simd",
- "bitvec",
- "data-encoding",
- "debugid",
- "if_chain",
- "rustc-hash",
- "serde",
- "serde_json",
- "unicode-id-start",
- "url",
-]
-
-[[package]]
 name = "sptr"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,83 +2021,77 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_enum"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fe66b8ee349846ce2f9557a26b8f1e74843c4a13fb381f9a3d73617a5f956a"
+checksum = "ae36a4951ca7bd1cfd991c241584a9824a70f6aff1e7d4f693fb3f2465e4030e"
 dependencies = [
- "proc-macro2",
  "quote",
- "swc_macros_common 1.0.0",
+ "swc_macros_common",
  "syn",
 ]
 
 [[package]]
 name = "swc_allocator"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b926f0d94bbb34031fe5449428cfa1268cdc0b31158d6ad9c97e0fc1e79dd"
+checksum = "9d7eefd2c8b228a8c73056482b2ae4b3a1071fbe07638e3b55ceca8570cc48bb"
 dependencies = [
  "allocator-api2",
  "bumpalo",
  "hashbrown 0.14.5",
- "ptr_meta",
- "rustc-hash",
- "triomphe",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
 name = "swc_atoms"
-version = "5.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7077ba879f95406459bc0c81f3141c529b34580bc64d7ab7bd15e7118a0391"
+checksum = "d4ccbe2ecad10ad7432100f878a107b1d972a8aee83ca53184d00c23a078bb8a"
 dependencies = [
  "hstr",
  "once_cell",
- "rustc-hash",
  "serde",
 ]
 
 [[package]]
 name = "swc_common"
-version = "9.2.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56b6f5a8e5affa271b56757a93badee6f44defcd28f3ba106bb2603afe40d3d"
+checksum = "259b675d633a26d24efe3802a9d88858c918e6e8f062d3222d3aa02d56a2cf4c"
 dependencies = [
  "anyhow",
  "ast_node",
  "better_scoped_tls",
- "cfg-if",
+ "bytes-str",
  "either",
  "from_variant",
  "new_debug_unreachable",
  "num-bigint",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "siphasher 0.3.11",
- "sourcemap",
- "swc_allocator",
  "swc_atoms",
  "swc_eq_ignore_macros",
+ "swc_sourcemap",
  "swc_visit",
  "tracing",
- "unicode-width 0.1.14",
+ "unicode-width",
  "url",
 ]
 
 [[package]]
 name = "swc_ecma_ast"
-version = "9.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0613d84468a6bb6d45d13c5a3368b37bd21f3067a089f69adac630dcb462a018"
+checksum = "a573a0c72850dec8d4d8085f152d5778af35a2520c3093b242d2d1d50776da7c"
 dependencies = [
  "bitflags",
  "is-macro",
  "num-bigint",
  "once_cell",
  "phf",
- "rustc-hash",
- "scoped-tls",
+ "rustc-hash 2.1.1",
  "serde",
  "string_enum",
  "swc_atoms",
@@ -2119,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "11.0.0"
+version = "20.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01b3de365a86b8f982cc162f257c82f84bda31d61084174a3be37e8ab15c0f4"
+checksum = "ff2a6ee1ec49dda8dedeac54e4147b4e8b3f278d9bb34ab28983257a393d34ed"
 dependencies = [
  "ascii",
  "compact_str",
@@ -2129,43 +2112,40 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
+ "ryu-js",
  "serde",
- "sourcemap",
  "swc_allocator",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen_macros",
+ "swc_sourcemap",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99e1931669a67c83e2c2b4375674f6901d1480994a76aa75b23f1389e6c5076"
+checksum = "e276dc62c0a2625a560397827989c82a93fd545fcf6f7faec0935a82cc4ddbb8"
 dependencies = [
  "proc-macro2",
- "quote",
- "swc_macros_common 1.0.0",
+ "swc_macros_common",
  "syn",
 ]
 
 [[package]]
 name = "swc_ecma_lexer"
-version = "12.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d11c8e71901401b9aae2ece4946eeb7674b14b8301a53768afbbeeb0e48b599"
+checksum = "5e82f7747e052c6ff6e111fa4adeb14e33b46ee6e94fe5ef717601f651db48fc"
 dependencies = [
- "arrayvec",
  "bitflags",
  "either",
- "new_debug_unreachable",
  "num-bigint",
- "num-traits",
- "phf",
- "rustc-hash",
+ "rustc-hash 2.1.1",
+ "seq-macro",
  "serde",
  "smallvec",
  "smartstring",
@@ -2173,19 +2153,19 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_parser",
  "tracing",
- "typed-arena",
 ]
 
 [[package]]
 name = "swc_ecma_loader"
-version = "9.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb574d660c05f3483c984107452b386e45b95531bdb1253794077edc986f413"
+checksum = "fbcababb48f0d46587a0a854b2c577eb3a56fa99687de558338021e93cd2c8f5"
 dependencies = [
  "anyhow",
  "pathdiff",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
  "swc_common",
@@ -2194,45 +2174,38 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "12.0.0"
+version = "27.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250786944fbc05f6484eda9213df129ccfe17226ae9ad51b62fce2f72135dbee"
+checksum = "7f1a51af1a92cd4904c073b293e491bbc0918400a45d58227b34c961dd6f52d7"
 dependencies = [
- "arrayvec",
  "bitflags",
  "either",
- "new_debug_unreachable",
  "num-bigint",
- "num-traits",
  "phf",
- "rustc-hash",
+ "rustc-hash 2.1.1",
+ "seq-macro",
  "serde",
- "smallvec",
  "smartstring",
  "stacker",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_lexer",
  "tracing",
- "typed-arena",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "13.0.0"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6856da3da598f4da001b7e4ce225ee8970bc9d5cbaafcaf580190cf0a6031ec5"
+checksum = "250f6f165578ca4fee47bd57585c1b9597c94bf4ea6591df47f2b5fa5b1883fe"
 dependencies = [
  "better_scoped_tls",
- "bitflags",
  "indexmap",
  "once_cell",
  "par-core",
  "phf",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
- "smallvec",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -2244,30 +2217,28 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "13.1.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ed837406d5dbbfbf5792b1dc90964245a0cf659753d4745fe177ffebe8598b9"
+checksum = "0fb99e179988cabd473779a4452ab942bcb777176983ca3cbaf22a8f056a65b0"
 dependencies = [
  "indexmap",
  "num_cpus",
  "once_cell",
  "par-core",
- "par-iter",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "ryu-js",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_visit",
  "tracing",
- "unicode-id",
 ]
 
 [[package]]
 name = "swc_ecma_visit"
-version = "9.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249dc9eede1a4ad59a038f9cfd61ce67845bd2c1392ade3586d714e7181f3c1a"
+checksum = "a9611a72a4008d62608547a394e5d72a5245413104db096d95a52368a8cc1d63"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -2280,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "swc_eq_ignore_macros"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96e15288bf385ab85eb83cff7f9e2d834348da58d0a31b33bdb572e66ee413e"
+checksum = "c16ce73424a6316e95e09065ba6a207eba7765496fed113702278b7711d4b632"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2291,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.14"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e18fbfe83811ffae2bb23727e45829a0d19c6870bced7c0f545cc99ad248dd"
+checksum = "aae1efbaa74943dc5ad2a2fb16cbd78b77d7e4d63188f3c5b4df2b4dcd2faaae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2301,37 +2272,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_macros_common"
-version = "1.0.0"
+name = "swc_sourcemap"
+version = "9.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a509f56fca05b39ba6c15f3e58636c3924c78347d63853632ed2ffcb6f5a0ac7"
+checksum = "de08ef00f816acdd1a58ee8a81c0e1a59eefef2093aefe5611f256fa6b64c4d7"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "base64-simd",
+ "bitvec",
+ "bytes-str",
+ "data-encoding",
+ "debugid",
+ "if_chain",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "unicode-id-start",
+ "url",
 ]
 
 [[package]]
 name = "swc_visit"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9138b6a36bbe76dd6753c4c0794f7e26480ea757bee499738bedbbb3ae3ec5f3"
+checksum = "62fb71484b486c185e34d2172f0eabe7f4722742aad700f426a494bb2de232a2"
 dependencies = [
  "either",
  "new_debug_unreachable",
-]
-
-[[package]]
-name = "swc_visit_macros"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92807d840959f39c60ce8a774a3f83e8193c658068e6d270dbe0a05e40e90b41"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "swc_macros_common 0.3.14",
- "syn",
 ]
 
 [[package]]
@@ -2358,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "sys_traits"
-version = "0.1.17"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f74a2c95f72e36fa6bd04a40d15623a9904bab1cc2fa6c6135b09d774a65088"
+checksum = "88826d6169418c98e8bc52a43f79d50907dfa3e87ba5161930d42c6f980b35ee"
 dependencies = [
  "getrandom",
  "js-sys",
@@ -2397,6 +2363,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "text_lines"
@@ -2436,6 +2408,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2514,22 +2501,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
 
 [[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "unicode-id"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10103c57044730945224467c09f71a4db0071c123a0648cc3e818913bde6b561"
 
 [[package]]
 name = "unicode-id-start"
@@ -2544,16 +2519,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.14"
+name = "unicode-normalization"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "url"
@@ -2688,11 +2666,11 @@ dependencies = [
 
 [[package]]
 name = "wasm_dep_analyzer"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51cf5f08b357e64cd7642ab4bbeb11aecab9e15520692129624fb9908b8df2c"
+checksum = "a10e6b67c951a84de7029487e0e0a496860dae49f6699edd279d5ff35b8fbf54"
 dependencies = [
- "deno_error 0.6.1",
+ "deno_error",
  "thiserror",
 ]
 
@@ -2713,22 +2691,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,12 +2698,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -2826,6 +2782,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,6 +2809,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yaml_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a6a39b6b5ba0d02c910d05d7fbc366a4befb8901ea107dcde9c1c97acb8a366"
+dependencies = [
+ "rowan",
+ "winnow",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ members = [
 
 [workspace.dependencies]
 async-trait = "0.1.88"
-deno_cache_dir = "0.23.0"
-deno_config = "0.61.0"
-deno_error = { version = "0.6.1", features = ["serde", "serde_json", "url"] }
-deno_graph = { version = "0.96.2", features = ["swc"], default-features = false }
-deno_path_util = "0.4.0"
-deno_resolver = { version = "0.42.0", features = ["graph"] }
+deno_cache_dir = "0.44.0"
+deno_config = "0.102.0"
+deno_error = { version = "0.7.1", features = ["serde", "serde_json", "url"] }
+deno_graph = { version = "0.109.0", features = ["swc"], default-features = false }
+deno_path_util = "0.6.4"
+deno_resolver = { version = "0.83.0", features = ["graph"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }
-sys_traits = { version = "0.1.17", features = ["real"] }
+sys_traits = { version = "0.1.28", features = ["real"] }
 url = { version = "2.5.4", features =["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ deno_cache_dir = "0.44.0"
 deno_config = "0.102.0"
 deno_error = { version = "0.7.1", features = ["serde", "serde_json", "url"] }
 deno_graph = { version = "0.109.0", features = ["swc"], default-features = false }
+deno_lockfile = "0.54.0"
 deno_path_util = "0.6.4"
 deno_resolver = { version = "0.83.0", features = ["graph"] }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }

--- a/README.md
+++ b/README.md
@@ -208,16 +208,15 @@ dntShim.Deno.readTextFileSync(...);
 If you want a shim to only be used in your test code as a dev dependency, then
 specify `"dev"` for the option.
 
-For example, to use the `Deno` namespace only for development and the
-`setTimeout` and `setInterval` browser/Deno compatible shims in the distributed
-code, you would do:
+For example, to use the `Deno` namespace only for development and the `crypto`
+shim in the distributed code, you would do:
 
 ```ts
 await build({
   // ...etc...
   shims: {
     deno: "dev",
-    timers: true,
+    crypto: true,
   },
 });
 ```
@@ -239,8 +238,6 @@ Set any of these properties to `true` (distribution and test) or `"dev"` (test
 only) to use them.
 
 - `deno` - Shim the `Deno` namespace.
-- `timers` - Shim the global `setTimeout` and `setInterval` functions with Deno
-  and browser compatible versions.
 - `prompts` - Shim the global `confirm`, `alert`, and `prompt` functions.
 - `blob` - Shim the `Blob` global with the one from the `"buffer"` module.
 - `crypto` - Shim the `crypto` global.
@@ -321,7 +318,7 @@ await build({
     }],
     // shims to only use in the tests
     customDev: [{
-      // this is what `timers: "dev"` does internally
+      // for example, shim `setTimeout` and `setInterval` in the tests only
       package: {
         name: "@deno/shim-timers",
         version: "~0.1.0",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -57,7 +57,7 @@
     "@std/fmt": "jsr:@std/fmt@1",
     "@std/fs": "jsr:@std/fs@1",
     "@std/path": "jsr:@std/path@1",
-    "@ts-morph/bootstrap": "jsr:@ts-morph/bootstrap@^0.27.0",
+    "@ts-morph/bootstrap": "jsr:@ts-morph/bootstrap@^0.29.0",
     "code-block-writer": "jsr:@david/code-block-writer@^13.0.3"
   },
   "exports": {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -58,6 +58,7 @@
     "tests/web_socket_project/npm"
   ],
   "imports": {
+    "@david/publish-on-tag": "jsr:@david/publish-on-tag@^0.2.0",
     "@std/assert": "jsr:@std/assert@1",
     "@std/fmt": "jsr:@std/fmt@1",
     "@std/fs": "jsr:@std/fs@1",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,6 +5,11 @@
     "build": "deno run -A jsr:@deno/wasmbuild@0.19.2 --out lib/pkg"
   },
   "lint": {
+    // the test fixtures intentionally use inline `https:`/`jsr:`/`npm:`
+    // specifiers to mimic real Deno code, so don't lint them
+    "exclude": [
+      "tests/"
+    ],
     "rules": {
       "exclude": [
         "no-explicit-any",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
   "name": "@deno/dnt",
   "tasks": {
     "test": "deno test -A",
-    "build": "deno run -A jsr:@deno/wasmbuild@0.19.2 --out lib/pkg"
+    "build": "deno run -A @deno/wasmbuild --out lib/pkg"
   },
   "lint": {
     // the test fixtures intentionally use inline `https:`/`jsr:`/`npm:`
@@ -59,6 +59,7 @@
   ],
   "imports": {
     "@david/publish-on-tag": "jsr:@david/publish-on-tag@^0.2.0",
+    "@deno/wasmbuild": "jsr:@deno/wasmbuild@0.19.2",
     "@std/assert": "jsr:@std/assert@1",
     "@std/fmt": "jsr:@std/fmt@1",
     "@std/fs": "jsr:@std/fs@1",

--- a/deno.lock
+++ b/deno.lock
@@ -2,6 +2,7 @@
   "version": "5",
   "specifiers": {
     "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
+    "jsr:@david/publish-on-tag@0.2": "0.2.0",
     "jsr:@std/assert@0.221": "0.221.0",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.4": "1.0.4",
@@ -14,6 +15,7 @@
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/path@1": "1.1.5",
     "jsr:@std/path@^1.1.5": "1.1.5",
+    "jsr:@std/semver@1": "1.0.8",
     "jsr:@ts-morph/bootstrap@0.29": "0.29.0",
     "jsr:@ts-morph/common@0.29": "0.29.0",
     "npm:@types/node@*": "18.16.19",
@@ -25,6 +27,12 @@
     },
     "@david/code-block-writer@13.0.3": {
       "integrity": "f98c77d320f5957899a61bfb7a9bead7c6d83ad1515daee92dbacc861e13bb7f"
+    },
+    "@david/publish-on-tag@0.2.0": {
+      "integrity": "6a4abcc352141e46e705041ca73836176d64cebc1080b6d915de630df9853dea",
+      "dependencies": [
+        "jsr:@std/semver"
+      ]
     },
     "@std/assert@0.221.0": {
       "integrity": "a5f1aa6e7909dbea271754fd4ab3f4e687aeff4873b4cef9a320af813adb489a",
@@ -99,6 +107,9 @@
         "jsr:@std/internal@^1.0.14"
       ]
     },
+    "@std/semver@1.0.8": {
+      "integrity": "dc830e8b8b6a380c895d53fbfd1258dc253704ca57bbe1629ac65fd7830179b7"
+    },
     "@ts-morph/bootstrap@0.29.0": {
       "integrity": "69f9b1b42b03423308a9f623f924174181ef20f6f2a8771799f216f561b9b7a6",
       "dependencies": [
@@ -145,6 +156,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@david/code-block-writer@^13.0.3",
+      "jsr:@david/publish-on-tag@0.2",
       "jsr:@std/assert@1",
       "jsr:@std/fmt@1",
       "jsr:@std/fs@1",

--- a/deno.lock
+++ b/deno.lock
@@ -2,20 +2,29 @@
   "version": "5",
   "specifiers": {
     "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
+    "jsr:@david/path@0.2": "0.2.0",
     "jsr:@david/publish-on-tag@0.2": "0.2.0",
+    "jsr:@david/temp@~0.1.1": "0.1.1",
+    "jsr:@deno/wasmbuild@0.19.2": "0.19.2",
     "jsr:@std/assert@0.221": "0.221.0",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.4": "1.0.4",
+    "jsr:@std/cli@^1.0.11": "1.0.32",
     "jsr:@std/csv@*": "1.0.6",
+    "jsr:@std/encoding@^1.0.6": "1.0.11",
     "jsr:@std/fmt@0.221": "0.221.0",
     "jsr:@std/fmt@1": "1.0.8",
+    "jsr:@std/fmt@^1.0.4": "1.0.8",
     "jsr:@std/fs@1": "1.0.24",
+    "jsr:@std/fs@^1.0.10": "1.0.24",
     "jsr:@std/internal@^1.0.1": "1.0.1",
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/path@1": "1.1.5",
     "jsr:@std/path@^1.1.5": "1.1.5",
     "jsr:@std/semver@1": "1.0.8",
+    "jsr:@std/streams@^1.0.17": "1.1.1",
+    "jsr:@std/tar@~0.1.4": "0.1.10",
     "jsr:@ts-morph/bootstrap@0.29": "0.29.0",
     "jsr:@ts-morph/common@0.29": "0.29.0",
     "npm:@types/node@*": "18.16.19",
@@ -28,10 +37,35 @@
     "@david/code-block-writer@13.0.3": {
       "integrity": "f98c77d320f5957899a61bfb7a9bead7c6d83ad1515daee92dbacc861e13bb7f"
     },
+    "@david/path@0.2.0": {
+      "integrity": "f2d7aa7f02ce5a55e27c09f9f1381794acb09d328f8d3c8a2e3ab3ffc294dccd",
+      "dependencies": [
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1"
+      ]
+    },
     "@david/publish-on-tag@0.2.0": {
       "integrity": "6a4abcc352141e46e705041ca73836176d64cebc1080b6d915de630df9853dea",
       "dependencies": [
         "jsr:@std/semver"
+      ]
+    },
+    "@david/temp@0.1.1": {
+      "integrity": "3974e3aa76536bd831294b72f5b70bfb67af3f4119ae334360e321f6ded18840",
+      "dependencies": [
+        "jsr:@david/path"
+      ]
+    },
+    "@deno/wasmbuild@0.19.2": {
+      "integrity": "f4a92beae788e2fd68189aefb6a6d8c3be79519c3ef8429a10519296379c33d1",
+      "dependencies": [
+        "jsr:@david/path",
+        "jsr:@david/temp",
+        "jsr:@std/cli",
+        "jsr:@std/encoding",
+        "jsr:@std/fmt@^1.0.4",
+        "jsr:@std/fs@^1.0.10",
+        "jsr:@std/tar"
       ]
     },
     "@std/assert@0.221.0": {
@@ -55,11 +89,17 @@
     "@std/bytes@1.0.4": {
       "integrity": "11a0debe522707c95c7b7ef89b478c13fb1583a7cfb9a85674cd2cc2e3a28abc"
     },
+    "@std/cli@1.0.32": {
+      "integrity": "188b3a100d6202d64e3f5bd3d799c7fa4f6d77f92cc65eb7f641c1fa0aa92a66"
+    },
     "@std/csv@1.0.1": {
       "integrity": "0704026df4361efa0fa7a278eb01cbc99f395fd0ac48f8df668fdc59cbd9f908"
     },
     "@std/csv@1.0.6": {
       "integrity": "52ef0e62799a0028d278fa04762f17f9bd263fad9a8e7f98c14fbd371d62d9fd"
+    },
+    "@std/encoding@1.0.11": {
+      "integrity": "e7cef2f0b3153bccc17431e7c864a1de03a4b6d9647389c43e08aaa775d37385"
     },
     "@std/fmt@0.221.0": {
       "integrity": "379fed69bdd9731110f26b9085aeb740606b20428ce6af31ef6bd45ef8efa62a"
@@ -110,6 +150,15 @@
     "@std/semver@1.0.8": {
       "integrity": "dc830e8b8b6a380c895d53fbfd1258dc253704ca57bbe1629ac65fd7830179b7"
     },
+    "@std/streams@1.1.1": {
+      "integrity": "92556d350e537e9dce527a6d08f6f15be3ff65e656079dea69d15252187c7613"
+    },
+    "@std/tar@0.1.10": {
+      "integrity": "6bf907f3a4bc8bfef42973ba132d946756a6161ef6b914a9e1c06debe664db17",
+      "dependencies": [
+        "jsr:@std/streams"
+      ]
+    },
     "@ts-morph/bootstrap@0.29.0": {
       "integrity": "69f9b1b42b03423308a9f623f924174181ef20f6f2a8771799f216f561b9b7a6",
       "dependencies": [
@@ -119,7 +168,7 @@
     "@ts-morph/common@0.29.0": {
       "integrity": "14e8f44c5e4297628cf756aed071787dc026c493e36c1cc29ce49dc95e493f8f",
       "dependencies": [
-        "jsr:@std/fs",
+        "jsr:@std/fs@1",
         "jsr:@std/path@1"
       ]
     }
@@ -157,6 +206,7 @@
     "dependencies": [
       "jsr:@david/code-block-writer@^13.0.3",
       "jsr:@david/publish-on-tag@0.2",
+      "jsr:@deno/wasmbuild@0.19.2",
       "jsr:@std/assert@1",
       "jsr:@std/fmt@1",
       "jsr:@std/fs@1",

--- a/deno.lock
+++ b/deno.lock
@@ -3,20 +3,19 @@
   "specifiers": {
     "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
     "jsr:@std/assert@0.221": "0.221.0",
-    "jsr:@std/assert@1": "1.0.13",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@^1.0.4": "1.0.4",
     "jsr:@std/csv@*": "1.0.6",
     "jsr:@std/fmt@0.221": "0.221.0",
     "jsr:@std/fmt@1": "1.0.8",
-    "jsr:@std/fs@1": "1.0.19",
+    "jsr:@std/fs@1": "1.0.24",
     "jsr:@std/internal@^1.0.1": "1.0.1",
-    "jsr:@std/internal@^1.0.6": "1.0.9",
-    "jsr:@std/internal@^1.0.9": "1.0.9",
-    "jsr:@std/path@1": "1.0.2",
-    "jsr:@std/path@^1.0.2": "1.0.2",
-    "jsr:@std/path@^1.1.1": "1.1.1",
-    "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
-    "jsr:@ts-morph/common@0.27": "0.27.0",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@1": "1.1.5",
+    "jsr:@std/path@^1.1.5": "1.1.5",
+    "jsr:@ts-morph/bootstrap@0.29": "0.29.0",
+    "jsr:@ts-morph/common@0.29": "0.29.0",
     "npm:@types/node@*": "18.16.19",
     "npm:using-statement@0.4": "0.4.2"
   },
@@ -39,10 +38,10 @@
         "jsr:@std/internal@^1.0.1"
       ]
     },
-    "@std/assert@1.0.13": {
-      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal@^1.0.6"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/bytes@1.0.4": {
@@ -66,20 +65,14 @@
     "@std/fmt@1.0.8": {
       "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
     },
-    "@std/fs@1.0.1": {
-      "integrity": "d6914ca2c21abe591f733b31dbe6331e446815e513e2451b3b9e472daddfefcb",
-      "dependencies": [
-        "jsr:@std/path@^1.0.2"
-      ]
-    },
     "@std/fs@1.0.10": {
       "integrity": "bf041f9d7a0a460817f0421be8946d0e06011b3433e6c83a215628de5e3c7c2c"
     },
-    "@std/fs@1.0.19": {
-      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
       "dependencies": [
-        "jsr:@std/internal@^1.0.9",
-        "jsr:@std/path@^1.1.1"
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.5"
       ]
     },
     "@std/internal@1.0.1": {
@@ -88,8 +81,8 @@
     "@std/internal@1.0.6": {
       "integrity": "9533b128f230f73bd209408bb07a4b12f8d4255ab2a4d22a1fd6d87304aca9a4"
     },
-    "@std/internal@1.0.9": {
-      "integrity": "bdfb97f83e4db7a13e8faab26fb1958d1b80cc64366501af78a0aee151696eb8"
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
     },
     "@std/io@0.225.1": {
       "integrity": "0a055fa523288d596f09ba11af5e006f17cecc75bab949b233ceba7eba40293e",
@@ -97,26 +90,23 @@
         "jsr:@std/bytes"
       ]
     },
-    "@std/path@1.0.2": {
-      "integrity": "a452174603f8c620bd278a380c596437a9eef50c891c64b85812f735245d9ec7"
-    },
     "@std/path@1.0.8": {
       "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
     },
-    "@std/path@1.1.1": {
-      "integrity": "fe00026bd3a7e6a27f73709b83c607798be40e20c81dde655ce34052fd82ec76",
+    "@std/path@1.1.5": {
+      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
       "dependencies": [
-        "jsr:@std/internal@^1.0.9"
+        "jsr:@std/internal@^1.0.14"
       ]
     },
-    "@ts-morph/bootstrap@0.27.0": {
-      "integrity": "b8d7bc8f7942ce853dde4161b28f9aa96769cef3d8eebafb379a81800b9e2448",
+    "@ts-morph/bootstrap@0.29.0": {
+      "integrity": "69f9b1b42b03423308a9f623f924174181ef20f6f2a8771799f216f561b9b7a6",
       "dependencies": [
         "jsr:@ts-morph/common"
       ]
     },
-    "@ts-morph/common@0.27.0": {
-      "integrity": "c7b73592d78ce8479b356fd4f3d6ec3c460d77753a8680ff196effea7a939052",
+    "@ts-morph/common@0.29.0": {
+      "integrity": "14e8f44c5e4297628cf756aed071787dc026c493e36c1cc29ce49dc95e493f8f",
       "dependencies": [
         "jsr:@std/fs",
         "jsr:@std/path@1"
@@ -159,7 +149,7 @@
       "jsr:@std/fmt@1",
       "jsr:@std/fs@1",
       "jsr:@std/path@1",
-      "jsr:@ts-morph/bootstrap@0.27"
+      "jsr:@ts-morph/bootstrap@0.29"
     ]
   }
 }

--- a/lib/shims.test.ts
+++ b/lib/shims.test.ts
@@ -7,7 +7,6 @@ import type { PackageShim } from "../transform.ts";
 Deno.test("should get when all true", () => {
   const result = shimOptionsToTransformShims({
     deno: true,
-    timers: true,
     prompts: true,
     blob: true,
     crypto: true,
@@ -31,14 +30,13 @@ Deno.test("should get when all true", () => {
     }],
   });
 
-  assertEquals(result.shims.length, 10);
-  assertEquals(result.testShims.length, 11);
+  assertEquals(result.shims.length, 9);
+  assertEquals(result.testShims.length, 10);
 });
 
 Deno.test("should get when all dev", () => {
   const result = shimOptionsToTransformShims({
     deno: "dev",
-    timers: "dev",
     prompts: "dev",
     blob: "dev",
     crypto: "dev",
@@ -49,13 +47,12 @@ Deno.test("should get when all dev", () => {
   });
 
   assertEquals(result.shims.length, 0);
-  assertEquals(result.testShims.length, 9);
+  assertEquals(result.testShims.length, 8);
 });
 
 Deno.test("should get when all false", () => {
   const result = shimOptionsToTransformShims({
     deno: false,
-    timers: false,
     prompts: false,
     blob: false,
     crypto: false,

--- a/lib/shims.ts
+++ b/lib/shims.ts
@@ -21,10 +21,6 @@ export interface ShimOptions {
   deno?: ShimValue | {
     test: ShimValue;
   };
-  /** Shim the global `setTimeout` and `setInterval` functions with
-   * Deno and browser compatible versions.
-   */
-  timers?: ShimValue;
   /** Shim the global `confirm`, `alert`, and `prompt` functions. */
   prompts?: ShimValue;
   /** Shim the `Blob` global with the one from the `"buffer"` module. */
@@ -70,7 +66,6 @@ export function shimOptionsToTransformShims(options: ShimOptions) {
   add(options.blob, getBlobShim);
   add(options.crypto, getCryptoShim);
   add(options.prompts, getPromptsShim);
-  add(options.timers, getTimersShim);
   add(options.domException, getDomExceptionShim);
   add(options.undici, getUndiciShim);
   add(options.weakRef, getWeakRefShim);
@@ -180,16 +175,6 @@ function getPromptsShim(): Shim {
       version: "~0.1.0",
     },
     globalNames: ["alert", "confirm", "prompt"],
-  };
-}
-
-function getTimersShim(): Shim {
-  return {
-    package: {
-      name: "@deno/shim-timers",
-      version: "~0.1.0",
-    },
-    globalNames: ["setInterval", "setTimeout"],
   };
 }
 

--- a/mod.ts
+++ b/mod.ts
@@ -264,6 +264,12 @@ export async function build(options: BuildOptions): Promise<void> {
   const scriptOutDir = path.join(options.outDir, "script");
   const typesOutDir = path.join(options.outDir, "types");
   const compilerScriptTarget = getCompilerScriptTarget(scriptTarget);
+  // TypeScript 6.0 no longer automatically discovers the `@types` packages
+  // installed in the output's node_modules, so resolve and include them
+  // explicitly here.
+  const ambientTypeNames = getInstalledAmbientTypeNames(
+    path.join(options.outDir, "node_modules", "@types"),
+  );
   const project = createProjectSync({
     compilerOptions: {
       outDir: typesOutDir,
@@ -287,6 +293,10 @@ export async function build(options: BuildOptions): Promise<void> {
       declaration: !!options.declaration,
       declarationMap,
       esModuleInterop: false,
+      // silence deprecation errors for the options below (ex. esModuleInterop:
+      // false, importsNotUsedAsValues) that still function in TypeScript 6.0
+      ignoreDeprecations: "6.0",
+      types: ambientTypeNames,
       isolatedModules: true,
       useDefineForClassFields: true,
       experimentalDecorators: options.compilerOptions?.experimentalDecorators ??
@@ -634,5 +644,20 @@ export async function build(options: BuildOptions): Promise<void> {
     // * or ending with `_test.{ts, mts, tsx, js, mjs, jsx}`
     return options.testPattern ??
       "**/{test.{ts,mts,tsx,js,mjs,jsx},*.test.{ts,mts,tsx,js,mjs,jsx},*_test.{ts,mts,tsx,js,mjs,jsx}}";
+  }
+}
+
+/** Gets the names of the `@types` packages installed in the provided directory
+ * (ex. `["node"]`), or `undefined` when none are installed. */
+function getInstalledAmbientTypeNames(typesDir: string): string[] | undefined {
+  try {
+    return Array.from(Deno.readDirSync(typesDir))
+      .filter((entry) =>
+        (entry.isDirectory || entry.isSymlink) && !entry.name.startsWith(".")
+      )
+      .map((entry) => entry.name);
+  } catch {
+    // no `@types` directory exists, so fall back to the default behaviour
+    return undefined;
   }
 }

--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -15,17 +15,17 @@ serialization = ["serde"]
 anyhow = "1.0.70"
 async-trait.workspace = true
 base64 = "0.13.1"
-deno_ast = { version = "0.48.1", features = ["transforms", "view", "visit", "utils"] }
+deno_ast = { version = "0.53.2", features = ["transforms", "view", "visit", "utils"] }
 deno_cache_dir.workspace = true
 deno_config.workspace = true
 deno_error.workspace = true
 deno_graph.workspace = true
 deno_path_util.workspace = true
 deno_resolver.workspace = true
-deno_semver = "0.7.1"
-node_resolver = "0.49.0"
+deno_semver = "=0.10.0"
+node_resolver = "0.90.0"
 futures = "0.3.25"
-import_map = { version = "0.22.0", features = ["ext"] }
+import_map = { version = "0.25.0", features = ["ext"] }
 jsonc-parser = { version = "0.26.2", features = ["serde"] }
 once_cell = "1.17.1"
 pathdiff = "0.2.1"

--- a/rs-lib/Cargo.toml
+++ b/rs-lib/Cargo.toml
@@ -20,6 +20,7 @@ deno_cache_dir.workspace = true
 deno_config.workspace = true
 deno_error.workspace = true
 deno_graph.workspace = true
+deno_lockfile.workspace = true
 deno_path_util.workspace = true
 deno_resolver.workspace = true
 deno_semver = "=0.10.0"

--- a/rs-lib/src/declaration_file_resolution.rs
+++ b/rs-lib/src/declaration_file_resolution.rs
@@ -199,6 +199,7 @@ fn is_declaration_file(media_type: deno_ast::MediaType) -> bool {
   match media_type {
     Dts | Dmts | Dcts => true,
     JavaScript | Jsx | Mjs | Cjs | TypeScript | Mts | Cts | Tsx | Json
-    | Wasm | Css | Html | Sql | SourceMap | Unknown => false,
+    | Jsonc | Json5 | Wasm | Css | Html | Markdown | Sql | SourceMap
+    | Unknown => false,
   }
 }

--- a/rs-lib/src/graph.rs
+++ b/rs-lib/src/graph.rs
@@ -70,6 +70,8 @@ impl ModuleGraph {
     let graph_resolver = resolver.as_graph_resolver(
       &options.cjs_tracker,
       &scoped_jsx_import_source_config,
+      None,
+      deno_resolver::graph::NpmTypesResolutionMode::FallbackToExecution,
     );
     graph
       .build(
@@ -92,10 +94,13 @@ impl ModuleGraph {
           npm_resolver: None,
           file_system: &RealSys,
           jsr_url_provider: Default::default(),
+          jsr_version_resolver: Default::default(),
+          jsr_metadata_store: None,
           executor: Default::default(),
           passthrough_jsr_specifiers: false,
           unstable_bytes_imports: false,
           unstable_text_imports: false,
+          unstable_css_imports: false,
         },
       )
       .await;

--- a/rs-lib/src/graph.rs
+++ b/rs-lib/src/graph.rs
@@ -40,6 +40,9 @@ pub struct ModuleGraphOptions<'a, TSys: WorkspaceFactorySys> {
   pub compiler_options_resolver: Rc<CompilerOptionsResolver>,
   pub cjs_tracker:
     Rc<deno_resolver::cjs::CjsTracker<DenoInNpmPackageChecker, TSys>>,
+  /// The project's deno lockfile, used to lock module versions and verify
+  /// remote module checksums while building the graph.
+  pub maybe_lockfile: Option<deno_resolver::lockfile::LockfileLockRc<TSys>>,
 }
 
 /// Wrapper around deno_graph::ModuleGraph.
@@ -67,6 +70,15 @@ impl ModuleGraph {
     let capturing_analyzer =
       CapturingModuleAnalyzer::new(Some(Box::new(source_parser)), None);
     let mut graph = deno_graph::ModuleGraph::new(deno_graph::GraphKind::All);
+    // seed the graph with the locked module versions and redirects so the
+    // same versions Deno resolved for the project are used
+    if let Some(lockfile) = &options.maybe_lockfile {
+      lockfile.fill_graph(&mut graph);
+    }
+    let mut locker = options
+      .maybe_lockfile
+      .as_ref()
+      .map(|lockfile| lockfile.as_deno_graph_locker());
     let graph_resolver = resolver.as_graph_resolver(
       &options.cjs_tracker,
       &scoped_jsx_import_source_config,
@@ -87,7 +99,9 @@ impl ModuleGraph {
           is_dynamic: false,
           skip_dynamic_deps: false,
           resolver: Some(&graph_resolver),
-          locker: None,
+          locker: locker
+            .as_mut()
+            .map(|l| l as &mut dyn deno_graph::source::Locker),
           module_analyzer: &capturing_analyzer,
           module_info_cacher: &NullModuleInfoCacher,
           reporter: None,

--- a/rs-lib/src/graph.rs
+++ b/rs-lib/src/graph.rs
@@ -198,9 +198,13 @@ impl ModuleGraph {
   }
 
   pub fn get(&self, specifier: &ModuleSpecifier) -> &Module {
-    self.graph.get(specifier).unwrap_or_else(|| {
+    self.try_get(specifier).unwrap_or_else(|| {
       panic!("dnt bug - Did not find specifier: {}", specifier);
     })
+  }
+
+  pub fn try_get(&self, specifier: &ModuleSpecifier) -> Option<&Module> {
+    self.graph.get(specifier)
   }
 
   pub fn get_parsed_source(

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -409,6 +409,11 @@ pub async fn transform(
   );
   let deno_resolver = resolver_factory.deno_resolver().await?;
   let cjs_tracker = resolver_factory.cjs_tracker()?.clone();
+  let maybe_lockfile = resolver_factory
+    .workspace_factory()
+    .maybe_lockfile(&NullNpmPackageInfoProvider)
+    .await?
+    .cloned();
 
   let loader = Rc::new(DenoGraphLoader::new(
     Rc::new(file_fetcher),
@@ -452,6 +457,7 @@ pub async fn transform(
         .compiler_options_resolver()?
         .clone(),
       cjs_tracker,
+      maybe_lockfile,
     })
     .await?;
 
@@ -645,6 +651,27 @@ pub async fn transform(
     test: test_env_context.environment,
     warnings,
   })
+}
+
+/// Provides npm package info when reading the lockfile.
+///
+/// dnt resolves npm specifiers via the specifier mappers rather than through
+/// the module graph, and never writes the lockfile back, so the only time this
+/// is consulted is when an older lockfile is migrated to the latest version in
+/// memory. Returning default info for each requested package is sufficient.
+struct NullNpmPackageInfoProvider;
+
+#[async_trait::async_trait(?Send)]
+impl deno_lockfile::NpmPackageInfoProvider for NullNpmPackageInfoProvider {
+  async fn get_npm_package_info(
+    &self,
+    values: &[deno_semver::package::PackageNv],
+  ) -> Result<
+    Vec<deno_lockfile::Lockfile5NpmInfo>,
+    Box<dyn std::error::Error + Send + Sync>,
+  > {
+    Ok(vec![Default::default(); values.len()])
+  }
 }
 
 fn add_shim_types_packages_to_test_environment<'a>(

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -338,8 +338,11 @@ pub async fn transform(
       is_package_manager_subcommand: false,
       // force no node_modules directory so that we resolve package.json deps as npm specifiers
       node_modules_dir: Some(deno_config::deno_json::NodeModulesDirMode::None),
+      node_modules_linker: None,
       no_npm: false,
+      import_npm_lockfile: false,
       npm_process_state: None,
+      root_node_modules_dir_override: None,
       vendor: None,
       frozen_lockfile: None,
       lock_arg: None,
@@ -352,6 +355,7 @@ pub async fn transform(
     NullBlobStore,
     Rc::new(factory.http_cache()?.clone()),
     http_client,
+    Rc::new(deno_resolver::loader::MemoryFiles::default()),
     factory.sys().clone(),
     PermissionedFileFetcherOptions {
       allow_remote: true,
@@ -376,7 +380,7 @@ pub async fn transform(
           import_conditions_override: None,
           require_conditions_override: None,
         },
-        prefer_browser_field: false,
+        is_browser_platform: false,
         bundle_mode: false,
       },
       node_resolution_cache: None,
@@ -387,14 +391,18 @@ pub async fn transform(
       specified_import_map: maybe_import_map_file.map(|file| {
         Box::new(ImportMapProvider(file)) as Box<dyn SpecifiedImportMapProvider>
       }),
-      bare_node_builtins: true,
       unstable_sloppy_imports: true,
       on_mapped_resolution_diagnostic: None,
       compiler_options_overrides: CompilerOptionsOverrides {
         no_transpile: true,
+        force_check_js: false,
         source_map_base: None,
         preserve_jsx: true,
+        force_disable_verbatim_module_syntax: false,
       },
+      newest_dependency_date: None,
+      allow_json_imports: deno_resolver::loader::AllowJsonImports::Always,
+      require_modules: Vec::new(),
       node_analysis_cache: None,
       node_code_translator_mode: NodeCodeTranslatorMode::ModuleLoader,
     },
@@ -412,7 +420,9 @@ pub async fn transform(
     resolver_factory.workspace_factory().sys().clone(),
     DenoGraphLoaderOptions {
       file_header_overrides: Default::default(),
+      include_npm_sources: false,
       permissions: None,
+      reporter: None,
     },
   ));
 

--- a/rs-lib/src/mappings.rs
+++ b/rs-lib/src/mappings.rs
@@ -125,7 +125,8 @@ impl Mappings {
       if !mappings.contains_key(key) {
         if let Some(path) = mappings.get(value).map(ToOwned::to_owned) {
           mappings.insert(key.clone(), path);
-        } else {
+        } else if !specifiers.has_mapped(value) {
+          // specifiers mapped to a package have no file in the output
           panic!("dnt bug - Could not find the mapping for {}", value);
         }
       }

--- a/rs-lib/src/mappings.rs
+++ b/rs-lib/src/mappings.rs
@@ -122,13 +122,20 @@ impl Mappings {
 
     // add the redirects in the graph to the mappings
     for (key, value) in module_graph.redirects() {
-      if !mappings.contains_key(key) {
-        if let Some(path) = mappings.get(value).map(ToOwned::to_owned) {
-          mappings.insert(key.clone(), path);
-        } else if !specifiers.has_mapped(value) {
-          // specifiers mapped to a package have no file in the output
-          panic!("dnt bug - Could not find the mapping for {}", value);
-        }
+      if mappings.contains_key(key) {
+        continue;
+      }
+      if let Some(path) = mappings.get(value).map(ToOwned::to_owned) {
+        mappings.insert(key.clone(), path);
+        continue;
+      }
+      // the graph is seeded with the lockfile's redirects, so it may contain
+      // redirects for modules that aren't part of this build, and specifiers
+      // mapped to a package have no file in the output
+      let has_output_file =
+        module_graph.try_get(value).is_some() && !specifiers.has_mapped(value);
+      if has_output_file {
+        panic!("dnt bug - Could not find the mapping for {}", value);
       }
     }
 

--- a/rs-lib/src/visitors/globals.rs
+++ b/rs-lib/src/visitors/globals.rs
@@ -198,7 +198,11 @@ fn should_ignore_global_this(ident: &Ident, context: &Context) -> bool {
         }
         MemberProp::Computed(computed) => {
           if let Expr::Lit(Lit::Str(str)) = computed.expr {
-            if !context.shim_global_names.contains(str.value().as_ref()) {
+            let is_shim = str
+              .value()
+              .as_str()
+              .is_some_and(|s| context.shim_global_names.contains(s));
+            if !is_shim {
               return true;
             }
           }

--- a/rs-lib/src/visitors/imports_exports.rs
+++ b/rs-lib/src/visitors/imports_exports.rs
@@ -118,7 +118,7 @@ fn visit_children(node: Node, context: &mut Context) -> Result<()> {
 }
 
 fn visit_module_specifier(str: &Str, context: &mut Context) {
-  let value = str.value().to_string();
+  let value = str.value().to_string_lossy().into_owned();
   let specifier = context
     .module_graph
     .resolve_dependency(&value, context.specifier);

--- a/rs-lib/tests/integration/in_memory_loader.rs
+++ b/rs-lib/tests/integration/in_memory_loader.rs
@@ -24,6 +24,7 @@ type RemoteFileResult = Result<(RemoteFileText, RemoteFileHeaders), String>;
 pub struct InMemoryLoader {
   pub sys: InMemorySys,
   remote_files: HashMap<ModuleSpecifier, RemoteFileResult>,
+  remote_redirects: HashMap<ModuleSpecifier, String>,
 }
 
 impl InMemoryLoader {
@@ -38,6 +39,7 @@ impl InMemoryLoader {
     Self {
       sys,
       remote_files: HashMap::new(),
+      remote_redirects: HashMap::new(),
     }
   }
 
@@ -87,6 +89,18 @@ impl InMemoryLoader {
     self
   }
 
+  pub fn add_remote_redirect(
+    &mut self,
+    specifier: impl AsRef<str>,
+    location: impl AsRef<str>,
+  ) -> &mut Self {
+    self.remote_redirects.insert(
+      ModuleSpecifier::parse(specifier.as_ref()).unwrap(),
+      location.as_ref().to_string(),
+    );
+    self
+  }
+
   pub fn add_remote_file_with_error(
     &mut self,
     specifier: impl AsRef<str>,
@@ -118,6 +132,12 @@ impl deno_cache_dir::file_fetcher::HttpClient for InMemoryLoader {
     specifier: &ModuleSpecifier,
     _headers: HeaderMap,
   ) -> Result<SendResponse, SendError> {
+    if let Some(location) = self.remote_redirects.get(specifier) {
+      return Ok(SendResponse::Redirect(to_headers(HashMap::from([(
+        "location".to_string(),
+        location.clone(),
+      )]))));
+    }
     let result = self
       .remote_files
       .get(&specifier)

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -2147,6 +2147,77 @@ async fn npm_specifier() {
   );
 }
 
+#[tokio::test]
+async fn transform_uses_lockfile_remote_checksum() {
+  // a deno.lock with a non-matching remote checksum should cause an
+  // integrity error, proving the lockfile is being used
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file("/deno.json", "{}")
+        .add_local_file(
+          "/deno.lock",
+          concat!(
+            "{\n",
+            "  \"version\": \"5\",\n",
+            "  \"remote\": {\n",
+            "    \"https://localhost/mod.ts\": \"0000000000000000000000000000000000000000000000000000000000000000\"\n",
+            "  }\n",
+            "}\n"
+          ),
+        )
+        .add_local_file("/mod.ts", "import 'https://localhost/mod.ts';")
+        .add_remote_file("https://localhost/mod.ts", "console.log(1);");
+    })
+    .transform()
+    .await
+    .err()
+    .unwrap();
+
+  assert!(
+    result
+      .to_string()
+      .to_lowercase()
+      .contains("integrity check failed"),
+    "unexpected error: {:#}",
+    result
+  );
+}
+
+#[tokio::test]
+async fn transform_uses_lockfile_matching_remote_checksum() {
+  // a deno.lock with a matching remote checksum should transform successfully
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file("/deno.json", "{}")
+        .add_local_file(
+          "/deno.lock",
+          concat!(
+            "{\n",
+            "  \"version\": \"5\",\n",
+            "  \"remote\": {\n",
+            "    \"https://localhost/mod.ts\": \"35c146f76e129477c64061bc84511e1090f3d4d8059713e6663dd4b35b1f7642\"\n",
+            "  }\n",
+            "}\n"
+          ),
+        )
+        .add_local_file("/mod.ts", "import 'https://localhost/mod.ts';")
+        .add_remote_file("https://localhost/mod.ts", "console.log(1);");
+    })
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[
+      ("mod.ts", "import './deps/localhost/mod.js';"),
+      ("deps/localhost/mod.ts", "console.log(1);"),
+    ]
+  );
+}
+
 fn get_shim_file_text(mut text: String) -> String {
   text.push('\n');
   text.push_str(

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -2257,6 +2257,34 @@ async fn transform_uses_lockfile_matching_remote_checksum() {
   );
 }
 
+#[tokio::test]
+async fn transform_ignores_unrelated_lockfile_redirects() {
+  // the lockfile is for the whole project, so it may have redirects for
+  // modules that aren't reachable from the entry points being transformed
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file("/deno.json", "{}")
+        .add_local_file(
+          "/deno.lock",
+          concat!(
+            "{\n",
+            "  \"version\": \"5\",\n",
+            "  \"redirects\": {\n",
+            "    \"https://localhost/unrelated.ts\": \"https://localhost/unrelated/mod.ts\"\n",
+            "  }\n",
+            "}\n"
+          ),
+        )
+        .add_local_file("/mod.ts", "console.log(1);");
+    })
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(result.main.files, &[("mod.ts", "console.log(1);")]);
+}
+
 fn get_shim_file_text(mut text: String) -> String {
   text.push('\n');
   text.push_str(

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1169,6 +1169,45 @@ async fn transform_specifier_mappings() {
 }
 
 #[tokio::test]
+async fn transform_specifier_mapping_of_redirected_specifier() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file(
+          "/mod.ts",
+          "import * as remote from 'http://localhost/mod.ts';",
+        )
+        .add_remote_redirect(
+          "http://localhost/mod.ts",
+          "http://localhost/redirected/mod.ts",
+        )
+        .add_remote_file("http://localhost/redirected/mod.ts", "");
+    })
+    .add_package_specifier_mapping(
+      "http://localhost/redirected/mod.ts",
+      "remote-module",
+      Some("1.0.0"),
+      None,
+    )
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[("mod.ts", "import * as remote from 'remote-module';")]
+  );
+  assert_eq!(
+    result.main.dependencies,
+    &[Dependency {
+      name: "remote-module".to_string(),
+      version: "1.0.0".to_string(),
+      peer_dependency: false,
+    }]
+  );
+}
+
+#[tokio::test]
 async fn transform_not_found_mappings() {
   let error_message = TestBuilder::new()
     .with_loader(|loader| {

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -834,10 +834,11 @@ async fn transform_parse_error() {
   assert_eq!(
     err_message.to_string(),
     concat!(
-      "The module's source code could not be parsed: Expected ';', '}' or <eof> at http://localhost/declarations.d.ts:1:6\n",
-      "\n",
-      "  test test test\n",
-      "       ~~~~",
+      "SyntaxError: Expected ';', '}' or <eof>\n",
+      "  |\n",
+      "1 | test test test\n",
+      "  |      ~~~~\n",
+      "    at http://localhost/declarations.d.ts:1:6",
     ),
   );
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.88.0"
 components = ["clippy", "rustfmt"]

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -12,7 +12,6 @@ const versions = {
   domExceptionShim: "^4.0.0",
   domExceptionShimTypes: "^4.0.0",
   promptsShim: "~0.1.0",
-  timersShim: "~0.1.0",
   weakRefSham: "~0.1.0",
   undici: "^6.0.0",
   picocolors: "^1.0.0",
@@ -744,7 +743,6 @@ Deno.test("should build shim project with everything enabled", async () => {
       "@deno/shim-crypto": versions.cryptoShim,
       "@deno/shim-deno": versions.denoShim,
       "@deno/shim-prompts": versions.promptsShim,
-      "@deno/shim-timers": versions.timersShim,
       "domexception": versions.domExceptionShim,
       "undici": versions.undici,
     });
@@ -804,7 +802,6 @@ Deno.test("should build shim project when using node-fetch", async () => {
       "@deno/shim-crypto": versions.cryptoShim,
       "@deno/shim-deno": versions.denoShim,
       "@deno/shim-prompts": versions.promptsShim,
-      "@deno/shim-timers": versions.timersShim,
       "domexception": versions.domExceptionShim,
       "undici": versions.undici,
       "node-fetch": "~3.1.0",
@@ -817,8 +814,6 @@ import { crypto } from "@deno/shim-crypto";
 export { crypto, type Crypto, type SubtleCrypto, type AlgorithmIdentifier, type Algorithm, type RsaOaepParams, type BufferSource, type AesCtrParams, type AesCbcParams, type AesGcmParams, type CryptoKey, type KeyAlgorithm, type KeyType, type KeyUsage, type EcdhKeyDeriveParams, type HkdfParams, type HashAlgorithmIdentifier, type Pbkdf2Params, type AesDerivedKeyParams, type HmacImportParams, type JsonWebKey, type RsaOtherPrimesInfo, type KeyFormat, type RsaHashedKeyGenParams, type RsaKeyGenParams, type BigInteger, type EcKeyGenParams, type NamedCurve, type CryptoKeyPair, type AesKeyGenParams, type HmacKeyGenParams, type RsaHashedImportParams, type EcKeyImportParams, type AesKeyAlgorithm, type RsaPssParams, type EcdsaParams } from "@deno/shim-crypto";
 import { alert, confirm, prompt } from "@deno/shim-prompts";
 export { alert, confirm, prompt } from "@deno/shim-prompts";
-import { setInterval, setTimeout } from "@deno/shim-timers";
-export { setInterval, setTimeout } from "@deno/shim-timers";
 import { default as DOMException } from "domexception";
 export { default as DOMException } from "domexception";
 import { File, FormData, Headers, Request, Response } from "undici";
@@ -835,8 +830,6 @@ const dntGlobals = {
   alert,
   confirm,
   prompt,
-  setInterval,
-  setTimeout,
   DOMException,
   File,
   FormData,
@@ -1347,7 +1340,6 @@ async function runTest(
 function getAllShimOptions(value: ShimValue): ShimOptions {
   return {
     deno: value,
-    timers: value,
     prompts: value,
     blob: value,
     crypto: value,

--- a/tests/shim_project/mod.test.ts
+++ b/tests/shim_project/mod.test.ts
@@ -1,18 +1,6 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 import { isDeno } from "https://deno.land/x/which_runtime@0.2.0/mod.ts";
-import {
-  addAsync,
-  getCryptoKeyPair,
-  localShimValue,
-  throwDomException,
-} from "./mod.ts";
-
-Deno.test("should add in test project", async () => {
-  const result = await addAsync(1, 2);
-  if (result !== 3) {
-    throw new Error(`Result fail: ${result}`);
-  }
-});
+import { getCryptoKeyPair, localShimValue, throwDomException } from "./mod.ts";
 
 Deno.test("should get crypto key pair", async () => {
   const value = await getCryptoKeyPair([

--- a/tests/shim_project/mod.ts
+++ b/tests/shim_project/mod.ts
@@ -1,26 +1,5 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
-export function addAsync(a: number, b: number) {
-  return new Promise<number>((resolve, reject) => {
-    // The shim should be injected here because setTimeout and setInterval
-    // return `Timeout` in node.js, but we want them to return `number`
-    const timeoutResult: number = setTimeout(
-      () => reject(new Error("fail")),
-      50,
-    );
-    const intervalResult: number = setInterval(
-      () => reject(new Error("fail")),
-      50,
-    );
-    clearTimeout(timeoutResult);
-    clearInterval(intervalResult);
-
-    setTimeout(() => {
-      resolve(a + b);
-    }, 100);
-  });
-}
-
 export function other() {
   type test1 = typeof globalThis.fetch;
   type test2 = typeof globalThis;


### PR DESCRIPTION
Updates `deno_graph` 0.96.2 → 0.109.0 along with the rest of the deno ecosystem crates (`deno_resolver`, `deno_config`, `deno_cache_dir`, `deno_ast`, `node_resolver`, `deno_path_util`, `import_map`, `sys_traits`, `deno_semver`, `deno_error`) to their latest mutually-compatible versions.

The new crates use let-chains, so the rust toolchain is bumped 1.86.0 → 1.88.0.

Also updates `@ts-morph/bootstrap` 0.27 → 0.29 (which bundles TypeScript 6.0):

- adds `ignoreDeprecations: "6.0"`, since TS 6.0 turns `esModuleInterop: false` and `importsNotUsedAsValues` into deprecation errors that abort the type check
- TS 6.0 no longer auto-discovers the `@types` packages installed in the output's `node_modules`, so they're now enumerated and included explicitly via the `types` compiler option

Removes the obsolete `timers` shim. Deno now returns the same `Timeout` type from `setTimeout`/`setInterval` as node, so coercing them back to `number` is no longer necessary.

### Notes
- The deprecated options silenced by `ignoreDeprecations` (notably `importsNotUsedAsValues: Remove`) will become hard errors in TS 7.0 — worth migrating in a future change.
- Tested locally: `cargo test` (rust) and `deno test -A` (type-check on) both pass.