### PR TITLE
fix: local files at uneven dir depths

### DIFF
--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -461,7 +461,12 @@ pub async fn transform(
     })
     .await?;
 
-  let mappings = Mappings::new(&module_graph, &specifiers)?;
+  let mappings = Mappings::new(
+    &module_graph,
+    &specifiers,
+    &options.entry_points,
+    &options.test_entry_points,
+  )?;
   let all_package_specifier_mappings: HashMap<ModuleSpecifier, String> =
     specifiers
       .main

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -461,12 +461,7 @@ pub async fn transform(
     })
     .await?;
 
-  let mappings = Mappings::new(
-    &module_graph,
-    &specifiers,
-    &options.entry_points,
-    &options.test_entry_points,
-  )?;
+  let mappings = Mappings::new(&module_graph, &specifiers)?;
   let all_package_specifier_mappings: HashMap<ModuleSpecifier, String> =
     specifiers
       .main

--- a/rs-lib/src/mappings.rs
+++ b/rs-lib/src/mappings.rs
@@ -46,27 +46,67 @@ impl Mappings {
   pub fn new(
     module_graph: &ModuleGraph,
     specifiers: &Specifiers,
+    main_entry_points: &[ModuleSpecifier],
+    test_entry_points: &[ModuleSpecifier],
   ) -> Result<Self> {
     let mut mappings = HashMap::new();
     let mut mapped_filepaths_no_ext = HashSet::new();
-    let base_dir = get_base_dir(&specifiers.local)?;
+    let local_main_entry_points = local_entry_points(main_entry_points);
+    let local_test_entry_points = local_entry_points(test_entry_points);
+    let main_base_dir = if local_main_entry_points.is_empty() {
+      get_base_dir(&specifiers.local)?
+    } else {
+      get_base_dir(&local_main_entry_points)?
+    };
+    let mut test_base_dir_candidates = vec![main_base_dir.clone()];
+    for specifier in &local_test_entry_points {
+      let file_path = url_to_file_path(specifier)?;
+      test_base_dir_candidates.push(file_path.parent().unwrap().to_path_buf());
+    }
+    let test_base_dir = get_common_dir(test_base_dir_candidates);
+    ensure_nonempty_base_dir(&test_base_dir)?;
+    let mut external_base_dir_candidates =
+      vec![main_base_dir.clone(), test_base_dir.clone()];
+    for specifier in &specifiers.local {
+      let file_path = url_to_file_path(specifier)?;
+      let base_dir = if specifiers.test_modules.contains(specifier) {
+        &test_base_dir
+      } else {
+        &main_base_dir
+      };
+      if !file_path.starts_with(base_dir) {
+        external_base_dir_candidates
+          .push(file_path.parent().unwrap().to_path_buf());
+      }
+    }
+    let external_base_dir = get_common_dir(external_base_dir_candidates);
+    ensure_nonempty_base_dir(&external_base_dir)?;
     let mut root_local_dirs = HashSet::new();
 
     for specifier in specifiers.local.iter() {
       let file_path = url_to_file_path(specifier)?;
-      let relative_file_path =
-        file_path.strip_prefix(&base_dir).map_err(|_| {
-          anyhow::anyhow!(
-            "Error stripping prefix of {} with base {}",
-            file_path.display(),
-            base_dir.display()
-          )
-        })?;
+      let base_dir = if specifiers.test_modules.contains(specifier) {
+        &test_base_dir
+      } else {
+        &main_base_dir
+      };
+      let relative_file_path = match file_path.strip_prefix(base_dir) {
+        Ok(path) => path.to_path_buf(),
+        Err(_) => PathBuf::from("deps").join(
+          file_path.strip_prefix(&external_base_dir).map_err(|_| {
+            anyhow::anyhow!(
+              "Error stripping prefix of {} with base {}",
+              file_path.display(),
+              external_base_dir.display()
+            )
+          })?,
+        ),
+      };
       mappings.insert(
         specifier.clone(),
         get_mapped_file_path(
-          MediaType::from_path(relative_file_path),
-          relative_file_path,
+          MediaType::from_path(&relative_file_path),
+          &relative_file_path,
           &mut mapped_filepaths_no_ext,
         ),
       );
@@ -185,6 +225,16 @@ impl Mappings {
       panic!("Could not find file path for specifier: {}", specifier,);
     })
   }
+}
+
+fn local_entry_points(
+  entry_points: &[ModuleSpecifier],
+) -> Vec<ModuleSpecifier> {
+  entry_points
+    .iter()
+    .filter(|specifier| specifier.scheme() == "file")
+    .cloned()
+    .collect()
 }
 
 /// Takes a group of remote specifiers for the provided base directory
@@ -499,20 +549,37 @@ fn get_base_dir(specifiers: &[ModuleSpecifier]) -> Result<PathBuf> {
   if specifiers.is_empty() {
     bail!("Did not find any local files. Specifying only remote files is not currently supported.");
   }
+  let base_dir = get_common_dir(
+    specifiers
+      .iter()
+      .map(|specifier| {
+        Ok(url_to_file_path(specifier)?.parent().unwrap().into())
+      })
+      .collect::<Result<Vec<PathBuf>>>()?,
+  );
+  ensure_nonempty_base_dir(&base_dir)?;
+  Ok(base_dir)
+}
+
+fn ensure_nonempty_base_dir(base_dir: &Path) -> Result<()> {
+  if base_dir.as_os_str().is_empty() {
+    bail!("Local files span different filesystem roots.");
+  }
+  Ok(())
+}
+
+fn get_common_dir(dirs: impl IntoIterator<Item = PathBuf>) -> PathBuf {
   // todo(dsherret): should maybe error on windows when the files
   // span different drives...
-  let mut base_dir = url_to_file_path(&specifiers[0])?
-    .parent()
-    .unwrap()
-    .to_path_buf();
-  for specifier in specifiers {
-    let file_path = url_to_file_path(specifier)?;
-    let parent_dir = file_path.parent().unwrap();
+  let mut dirs = dirs.into_iter();
+  let Some(mut base_dir) = dirs.next() else {
+    return PathBuf::new();
+  };
+  for parent_dir in dirs {
     if base_dir != parent_dir {
-      if base_dir.starts_with(parent_dir) {
-        base_dir = parent_dir.to_path_buf();
-      } else if base_dir.components().count() == parent_dir.components().count()
-      {
+      if base_dir.starts_with(&parent_dir) {
+        base_dir = parent_dir;
+      } else {
         let mut final_path = PathBuf::new();
         for (a, b) in base_dir.components().zip(parent_dir.components()) {
           if a == b {
@@ -525,7 +592,7 @@ fn get_base_dir(specifiers: &[ModuleSpecifier]) -> Result<PathBuf> {
       }
     }
   }
-  Ok(base_dir)
+  base_dir
 }
 
 #[cfg(test)]
@@ -552,6 +619,13 @@ mod test {
     run_test(
       vec!["file:///project/b/other.ts", "file:///project/a/other.ts"],
       "/project",
+    );
+    run_test(
+      vec![
+        "file:///project-one/mod.ts",
+        "file:///project-two/deeper/mod.ts",
+      ],
+      "/",
     );
 
     fn run_test(urls: Vec<&str>, expected: &str) {

--- a/rs-lib/src/mappings.rs
+++ b/rs-lib/src/mappings.rs
@@ -46,41 +46,35 @@ impl Mappings {
   pub fn new(
     module_graph: &ModuleGraph,
     specifiers: &Specifiers,
-    main_entry_points: &[ModuleSpecifier],
-    test_entry_points: &[ModuleSpecifier],
   ) -> Result<Self> {
     let mut mappings = HashMap::new();
     let mut mapped_filepaths_no_ext = HashSet::new();
-    let local_main_entry_points = local_entry_points(main_entry_points);
-    let local_test_entry_points = local_entry_points(test_entry_points);
-    let main_base_dir = if local_main_entry_points.is_empty() {
+    // the main files keep their paths relative to the main files' root so that
+    // where the tests happen to live doesn't shift the distributed code
+    let main_specifiers = specifiers
+      .local
+      .iter()
+      .filter(|s| !specifiers.test_modules.contains(s))
+      .cloned()
+      .collect::<Vec<_>>();
+    let main_base_dir = if main_specifiers.is_empty() {
       get_base_dir(&specifiers.local)?
     } else {
-      get_base_dir(&local_main_entry_points)?
+      get_base_dir(&main_specifiers)?
     };
+    // the tests may be in a directory outside the main files' root, so they get
+    // a root that encompasses both
     let mut test_base_dir_candidates = vec![main_base_dir.clone()];
-    for specifier in &local_test_entry_points {
+    for specifier in specifiers
+      .local
+      .iter()
+      .filter(|s| specifiers.test_modules.contains(s))
+    {
       let file_path = url_to_file_path(specifier)?;
       test_base_dir_candidates.push(file_path.parent().unwrap().to_path_buf());
     }
     let test_base_dir = get_common_dir(test_base_dir_candidates);
     ensure_nonempty_base_dir(&test_base_dir)?;
-    let mut external_base_dir_candidates =
-      vec![main_base_dir.clone(), test_base_dir.clone()];
-    for specifier in &specifiers.local {
-      let file_path = url_to_file_path(specifier)?;
-      let base_dir = if specifiers.test_modules.contains(specifier) {
-        &test_base_dir
-      } else {
-        &main_base_dir
-      };
-      if !file_path.starts_with(base_dir) {
-        external_base_dir_candidates
-          .push(file_path.parent().unwrap().to_path_buf());
-      }
-    }
-    let external_base_dir = get_common_dir(external_base_dir_candidates);
-    ensure_nonempty_base_dir(&external_base_dir)?;
     let mut root_local_dirs = HashSet::new();
 
     for specifier in specifiers.local.iter() {
@@ -90,23 +84,19 @@ impl Mappings {
       } else {
         &main_base_dir
       };
-      let relative_file_path = match file_path.strip_prefix(base_dir) {
-        Ok(path) => path.to_path_buf(),
-        Err(_) => PathBuf::from("deps").join(
-          file_path.strip_prefix(&external_base_dir).map_err(|_| {
-            anyhow::anyhow!(
-              "Error stripping prefix of {} with base {}",
-              file_path.display(),
-              external_base_dir.display()
-            )
-          })?,
-        ),
-      };
+      let relative_file_path =
+        file_path.strip_prefix(base_dir).map_err(|_| {
+          anyhow::anyhow!(
+            "Error stripping prefix of {} with base {}",
+            file_path.display(),
+            base_dir.display()
+          )
+        })?;
       mappings.insert(
         specifier.clone(),
         get_mapped_file_path(
-          MediaType::from_path(&relative_file_path),
-          &relative_file_path,
+          MediaType::from_path(relative_file_path),
+          relative_file_path,
           &mut mapped_filepaths_no_ext,
         ),
       );
@@ -225,16 +215,6 @@ impl Mappings {
       panic!("Could not find file path for specifier: {}", specifier,);
     })
   }
-}
-
-fn local_entry_points(
-  entry_points: &[ModuleSpecifier],
-) -> Vec<ModuleSpecifier> {
-  entry_points
-    .iter()
-    .filter(|specifier| specifier.scheme() == "file")
-    .cloned()
-    .collect()
 }
 
 /// Takes a group of remote specifiers for the provided base directory

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1450,7 +1450,7 @@ async fn transform_import_map() {
 }
 
 #[tokio::test]
-async fn transform_import_map_places_uneven_siblings_in_deps() {
+async fn transform_import_map_uneven_sibling_depths() {
   let result = TestBuilder::new()
     .entry_point("file:///project-one/mod.ts")
     .with_loader(|loader| {
@@ -1477,23 +1477,27 @@ async fn transform_import_map_places_uneven_siblings_in_deps() {
     .await
     .unwrap();
 
+  // the sibling is at a different depth, so the shared root moves up to
+  // encompass both projects, the same as it already does for siblings at
+  // equal depths
   assert_files!(
     result.main.files,
     &[
       (
-        "mod.ts",
-        "import value from './deps/project-two/deeper/mod.js';",
+        "project-one/mod.ts",
+        "import value from '../project-two/deeper/mod.js';",
       ),
-      (
-        "deps/project-two/deeper/mod.ts",
-        "export default 'hello world';",
-      ),
+      ("project-two/deeper/mod.ts", "export default 'hello world';",),
     ]
+  );
+  assert_eq!(
+    result.main.entry_points,
+    &[PathBuf::from("project-one/mod.ts")]
   );
 }
 
 #[tokio::test]
-async fn transform_import_map_keeps_entry_point_root_for_local_siblings() {
+async fn transform_import_map_local_sibling_and_remote() {
   let result = TestBuilder::new()
     .entry_point("file:///example-project/mod.ts")
     .with_loader(|loader| {
@@ -1522,22 +1526,61 @@ async fn transform_import_map_keeps_entry_point_root_for_local_siblings() {
     .await
     .unwrap();
 
+  // the local sibling shares a root with the project, while the remote module
+  // keeps going to `deps`
   assert_files!(
     result.main.files,
     &[
-      ("mod.ts", "export * from './src/mod.js';"),
       (
-        "src/mod.ts",
-        "export * from '../deps/example-shared/mod.js';\nexport * from '../deps_2/example.com/mod.js';",
+        "example-project/mod.ts",
+        "export * from './src/mod.js';",
       ),
-      ("deps/example-shared/mod.ts", "export const shared = 'shared';"),
       (
-        "deps_2/example.com/mod.ts",
+        "example-project/src/mod.ts",
+        "export * from '../../example-shared/mod.js';\nexport * from '../../deps/example.com/mod.js';",
+      ),
+      (
+        "example-shared/mod.ts",
+        "export const shared = 'shared';",
+      ),
+      (
+        "deps/example.com/mod.ts",
         "export const remote = 'remote';",
       ),
     ]
   );
-  assert_eq!(result.main.entry_points, &[PathBuf::from("mod.ts")]);
+  assert_eq!(
+    result.main.entry_points,
+    &[PathBuf::from("example-project/mod.ts")]
+  );
+}
+
+#[tokio::test]
+async fn transform_entry_point_with_sibling_dir_in_project() {
+  let result = TestBuilder::new()
+    .entry_point("file:///project/src/mod.ts")
+    .with_loader(|loader| {
+      loader
+        .add_local_file(
+          "/project/src/mod.ts",
+          "export * from '../lib/util.ts';",
+        )
+        .add_local_file("/project/lib/util.ts", "export const util = 1;");
+    })
+    .transform()
+    .await
+    .unwrap();
+
+  // a sibling directory of the entry point is still part of the project, so
+  // it must not be treated as a dependency
+  assert_files!(
+    result.main.files,
+    &[
+      ("src/mod.ts", "export * from '../lib/util.js';"),
+      ("lib/util.ts", "export const util = 1;"),
+    ]
+  );
+  assert_eq!(result.main.entry_points, &[PathBuf::from("src/mod.ts")]);
 }
 
 #[tokio::test]
@@ -1548,33 +1591,22 @@ async fn transform_test_entry_point_uses_test_root_without_moving_main() {
       loader
         .add_local_file(
           "/example-project/src/mod.ts",
-          "export * from 'example-shared/mod.ts';",
+          "export const value = 'value';",
         )
         .add_local_file(
           "/example-project/tests/integration/functions/mod.test.ts",
           "import '../../../src/mod.ts';",
-        )
-        .add_local_file(
-          "/example-project/deno.json",
-          r#"{
-  "imports": {
-    "example-shared/": "../example-shared/"
-  }
-}"#,
-        )
-        .add_local_file(
-          "/example-shared/mod.ts",
-          "export const shared = 'shared';",
         );
     })
     .add_test_entry_point(
       "file:///example-project/tests/integration/functions/mod.test.ts",
     )
-    .set_import_map("file:///example-project/deno.json")
     .transform()
     .await
     .unwrap();
 
+  // the tests are in a directory outside the main files' root, which must not
+  // push the main files down a directory
   assert_eq!(result.main.entry_points, &[PathBuf::from("mod.ts")]);
   assert_eq!(
     result.test.entry_points,

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1450,6 +1450,146 @@ async fn transform_import_map() {
 }
 
 #[tokio::test]
+async fn transform_import_map_places_uneven_siblings_in_deps() {
+  let result = TestBuilder::new()
+    .entry_point("file:///project-one/mod.ts")
+    .with_loader(|loader| {
+      loader
+        .add_local_file(
+          "/project-one/mod.ts",
+          "import value from 'project-two/deeper/mod.ts';",
+        )
+        .add_local_file(
+          "/project-one/deno.json",
+          r#"{
+  "imports": {
+    "project-two/": "../project-two/"
+  }
+}"#,
+        )
+        .add_local_file(
+          "/project-two/deeper/mod.ts",
+          "export default 'hello world';",
+        );
+    })
+    .set_import_map("file:///project-one/deno.json")
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[
+      (
+        "mod.ts",
+        "import value from './deps/project-two/deeper/mod.js';",
+      ),
+      (
+        "deps/project-two/deeper/mod.ts",
+        "export default 'hello world';",
+      ),
+    ]
+  );
+}
+
+#[tokio::test]
+async fn transform_import_map_keeps_entry_point_root_for_local_siblings() {
+  let result = TestBuilder::new()
+    .entry_point("file:///example-project/mod.ts")
+    .with_loader(|loader| {
+      loader
+        .add_local_file(
+          "/example-project/mod.ts",
+          "export * from './src/mod.ts';",
+        )
+        .add_local_file(
+          "/example-project/src/mod.ts",
+          "export * from 'example-shared/mod.ts';\nexport * from 'https://example.com/mod.ts';",
+        )
+        .add_local_file(
+          "/example-project/deno.json",
+          r#"{
+  "imports": {
+    "example-shared/": "../example-shared/"
+  }
+}"#,
+        )
+        .add_local_file("/example-shared/mod.ts", "export const shared = 'shared';")
+        .add_remote_file("https://example.com/mod.ts", "export const remote = 'remote';");
+    })
+    .set_import_map("file:///example-project/deno.json")
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[
+      ("mod.ts", "export * from './src/mod.js';"),
+      (
+        "src/mod.ts",
+        "export * from '../deps/example-shared/mod.js';\nexport * from '../deps_2/example.com/mod.js';",
+      ),
+      ("deps/example-shared/mod.ts", "export const shared = 'shared';"),
+      (
+        "deps_2/example.com/mod.ts",
+        "export const remote = 'remote';",
+      ),
+    ]
+  );
+  assert_eq!(result.main.entry_points, &[PathBuf::from("mod.ts")]);
+}
+
+#[tokio::test]
+async fn transform_test_entry_point_uses_test_root_without_moving_main() {
+  let result = TestBuilder::new()
+    .entry_point("file:///example-project/src/mod.ts")
+    .with_loader(|loader| {
+      loader
+        .add_local_file(
+          "/example-project/src/mod.ts",
+          "export * from 'example-shared/mod.ts';",
+        )
+        .add_local_file(
+          "/example-project/tests/integration/functions/mod.test.ts",
+          "import '../../../src/mod.ts';",
+        )
+        .add_local_file(
+          "/example-project/deno.json",
+          r#"{
+  "imports": {
+    "example-shared/": "../example-shared/"
+  }
+}"#,
+        )
+        .add_local_file(
+          "/example-shared/mod.ts",
+          "export const shared = 'shared';",
+        );
+    })
+    .add_test_entry_point(
+      "file:///example-project/tests/integration/functions/mod.test.ts",
+    )
+    .set_import_map("file:///example-project/deno.json")
+    .transform()
+    .await
+    .unwrap();
+
+  assert_eq!(result.main.entry_points, &[PathBuf::from("mod.ts")]);
+  assert_eq!(
+    result.test.entry_points,
+    &[PathBuf::from("tests/integration/functions/mod.test.ts")]
+  );
+  assert_files!(
+    result.test.files,
+    &[(
+      "tests/integration/functions/mod.test.ts",
+      "import '../../../mod.js';",
+    )]
+  );
+}
+
+#[tokio::test]
 async fn transform_config_file() {
   let result = TestBuilder::new()
     .with_loader(|loader| {


### PR DESCRIPTION
- Fixes https://github.com/denoland/dnt/issues/420
- Fixes https://github.com/denoland/dnt/issues/249

## The issue(s)

When local files were in sibling directories at different depths, `dnt` failed:

In https://github.com/denoland/dnt/issues/420, `project-one/mod.ts` imports `project-two/deeper/mod.ts` through an import map.

In https://github.com/denoland/dnt/issues/249, the entry point is in `src/` and the tests are in a separate `tests/` directory.

## A fix

The change in this PR makes `dnt` calculate separate roots for main files and test files. It keeps main output paths relative to the main entry points. It keeps separate test paths relative to the project. It emits local dependencies outside both roots under `deps/`.

The PR adds a regression test for each issue:

The test for issue #420 uses the layout from https://github.com/dylanpyle/dnt-repro. 

The test for issue #249 uses an entry point in `src/` and a nested test in `tests/`.

Another test checks output paths when a project imports both a local sibling and a remote module, which is the issue I had locally.

## Tests

I have successfully run these repository checks with Deno 2.9.4:

```bash
cargo fmt --check
deno task build
cargo test
deno task test
```

I also changed the reproduction I cloned from https://github.com/dylanpyle/dnt-repro (via #420), to import this checkout, and ran its test:

```bash
cd /tmp/opencode/dnt-repro/project-one && deno run -A compile.ts
```

For issue #249, gpt-5.6 created a minimal reproduction for me with an entry point at `src/mod.ts` and a test at `tests/integration/functions/function_handler_test.ts`. Also confirmed that the parent commit failed and this change passed.

Both the generated ESM and CommonJS tests passed in the reproductions when this fix was applied to `dnt`.

## AI disclosure

I used gpt-5.6 to investigate, write the fix+tests, refactor the new changes to make them easier for me to read, run the checks, and *draft* much of this PR description. I checked the code and tests to the best of my understanding, and ran the tests locally myself too. Please let me know if I missed anything or misunderstood how you want `dnt` to work!
