### PR TITLE
fix: do not map `https://esm.sh/jsr/` specifiers to npm packages

### DIFF
--- a/rs-lib/src/loader/specifier_mappers.rs
+++ b/rs-lib/src/loader/specifier_mappers.rs
@@ -107,6 +107,14 @@ impl SpecifierMapper for EsmShMapper {
       return None;
     }
 
+    // Ignore esm.sh imports of jsr packages. These are only published to
+    // npm under the `@jsr` scope on the jsr registry, which would require
+    // the output package to be configured with a custom registry, so just
+    // vendor the remote module instead.
+    if specifier.path().starts_with("/jsr/") {
+      return None;
+    }
+
     let captures = ESMSH_MAPPING_RE.captures(specifier.as_str())?;
 
     let sub_path = captures.get(4).map(|m| m.as_str().to_owned());
@@ -241,6 +249,21 @@ mod test {
     assert_eq!(
       mapper
         .map(&ModuleSpecifier::parse("https://esm.sh/gh/owner/repo").unwrap()),
+      None,
+    );
+    assert_eq!(
+      mapper.map(
+        &ModuleSpecifier::parse("https://esm.sh/jsr/@cross/fs@0.1.11").unwrap()
+      ),
+      None,
+    );
+    assert_eq!(
+      mapper.map(
+        &ModuleSpecifier::parse(
+          "https://esm.sh/jsr/@std/path@1.0.8/resolve.ts"
+        )
+        .unwrap()
+      ),
       None,
     );
   }


### PR DESCRIPTION
The esm.sh specifier mapper regex assumes a path of `[v<N>/]<name>@<version>[/subpath]`, so it split `https://esm.sh/jsr/@cross/fs@0.1.11` on the scope's `@` rather than the version's:

| URL | name | version | sub_path |
| --- | --- | --- | --- |
| `https://esm.sh/jsr/@cross/fs@0.1.11` | `jsr/` | `cross` | `fs@0.1.11` |
| `https://esm.sh/jsr/@std/path@1.0.8/resolve.ts` | `jsr/` | `std` | `path@1.0.8/resolve.ts` |

Both then mapped to the same bogus package name `jsr/` with different "versions", which tripped the duplicate-version check and produced the confusing error in the issue:

```
Specifier https://esm.sh/jsr/@cross/fs@0.1.11 with version cross did not match specifier https://esm.sh/jsr/@std/path@1.0.8/resolve.ts with version std.
```

Now `/jsr/` URLs bail out of the mapper the same way `/gh/` ones do, and get vendored as regular remote modules. Mapping them to their real npm equivalents (`@jsr/cross__fs`) isn't done here because those are only published to the JSR npm registry, which would require the output package to configure a custom registry.

Closes #451