### PR TITLE
fix: support mapping `jsr:` specifiers to npm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,29 @@ Note that dnt will error if you specify a mapping and it is not found in the
 code. This is done to prevent the scenario where a remote specifier's version is
 bumped and the mapping isn't updated.
 
+#### Mapping a JSR package to an npm package
+
+A `jsr:` specifier may be mapped the same way:
+
+```ts
+await build({
+  // ...etc...
+  mappings: {
+    "jsr:@scope/name": {
+      name: "scope-name",
+      version: "^1.0.0",
+    },
+  },
+});
+```
+
+The version requirement is ignored when matching, so this maps
+`import ... from "jsr:@scope/name@^1.0.0"` as well as an import of a bare
+specifier that an import map points at `jsr:@scope/name@^1.0.0`.
+
+Sub paths are matched exactly though, so `jsr:@scope/name/sub` requires its own
+mapping.
+
 #### Mapping specifier to npm package subpath
 
 Say an npm package called `example` had a subpath at `sub_path.js` and you

--- a/README.md
+++ b/README.md
@@ -411,6 +411,29 @@ The version requirement is ignored when matching, so this maps
 `import ... from "jsr:@scope/name@^1.0.0"` as well as an import of a bare
 specifier that an import map points at `jsr:@scope/name@^1.0.0`.
 
+Leaving out `version` will use the version requirement of the specifier being
+mapped, which is useful when it's already specified in an import map:
+
+```json
+{
+  "imports": {
+    "@scope/name": "jsr:@scope/name@^1.0.0"
+  }
+}
+```
+
+```ts
+await build({
+  // ...etc...
+  mappings: {
+    // adds a dependency on "scope-name": "^1.0.0"
+    "jsr:@scope/name": {
+      name: "scope-name",
+    },
+  },
+});
+```
+
 Sub paths are matched exactly though, so `jsr:@scope/name/sub` requires its own
 mapping.
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,6 @@ await build({
   mappings: {
     "jsr:@scope/name": {
       name: "scope-name",
-      version: "^1.0.0",
     },
   },
 });
@@ -409,30 +408,9 @@ await build({
 
 The version requirement is ignored when matching, so this maps
 `import ... from "jsr:@scope/name@^1.0.0"` as well as an import of a bare
-specifier that an import map points at `jsr:@scope/name@^1.0.0`.
-
-Leaving out `version` will use the version requirement of the specifier being
-mapped, which is useful when it's already specified in an import map:
-
-```json
-{
-  "imports": {
-    "@scope/name": "jsr:@scope/name@^1.0.0"
-  }
-}
-```
-
-```ts
-await build({
-  // ...etc...
-  mappings: {
-    // adds a dependency on "scope-name": "^1.0.0"
-    "jsr:@scope/name": {
-      name: "scope-name",
-    },
-  },
-});
-```
+specifier that an import map points at `jsr:@scope/name@^1.0.0`. That version
+requirement is used for the dependency, but specifying a `version` on the
+mapping will override it.
 
 Sub paths are matched exactly though, so `jsr:@scope/name/sub` requires its own
 mapping.

--- a/rs-lib/src/graph.rs
+++ b/rs-lib/src/graph.rs
@@ -22,13 +22,18 @@ use deno_graph::ast::EsParser;
 use deno_graph::ast::ParseOptions;
 use deno_graph::ast::ParsedSourceStore;
 use deno_graph::source::NullModuleInfoCacher;
+use deno_graph::source::ResolutionKind;
+use deno_graph::source::ResolveError;
+use deno_graph::source::Resolver;
 use deno_graph::JsModule;
 use deno_graph::Module;
+use deno_graph::Range;
 use deno_resolver::deno_json::CompilerOptionsResolver;
 use deno_resolver::deno_json::JsxImportSourceConfigResolver;
 use deno_resolver::factory::WorkspaceFactorySys;
 use deno_resolver::graph::DefaultDenoResolverRc;
 use deno_resolver::npm::DenoInNpmPackageChecker;
+use deno_semver::jsr::JsrPackageReqReference;
 use sys_traits::impls::RealSys;
 
 pub struct ModuleGraphOptions<'a, TSys: WorkspaceFactorySys> {
@@ -57,10 +62,17 @@ impl ModuleGraph {
   ) -> Result<(Self, Specifiers)> {
     let resolver = options.resolver;
     let loader = options.loader;
+    // mapped jsr specifiers don't keep their scheme in the graph, so the
+    // loader needs to look them up by the specifier they're resolved to
+    let graph_specifier_mappings = options
+      .specifier_mappings
+      .iter()
+      .map(|(k, v)| (mapped_specifier_key(k), v.clone()))
+      .collect::<HashMap<_, _>>();
     let loader = SourceLoader::new(
       loader,
       get_all_specifier_mappers(),
-      options.specifier_mappings,
+      &graph_specifier_mappings,
     );
     let scoped_jsx_import_source_config =
       JsxImportSourceConfigResolver::from_compiler_options_resolver(
@@ -85,6 +97,12 @@ impl ModuleGraph {
       None,
       deno_resolver::graph::NpmTypesResolutionMode::FallbackToExecution,
     );
+    let jsr_specifier_mappings =
+      JsrSpecifierMappings::new(options.specifier_mappings);
+    let graph_resolver = MappedJsrSpecifierResolver {
+      inner: &graph_resolver,
+      mappings: &jsr_specifier_mappings,
+    };
     graph
       .build(
         options
@@ -151,7 +169,11 @@ impl ModuleGraph {
         MappedSpecifier::Package(_) => None,
         MappedSpecifier::Module(_) => Some(k),
       })
-      .filter(|s| !loader_specifiers.mapped_modules.contains_key(s))
+      .filter(|s| {
+        !loader_specifiers
+          .mapped_modules
+          .contains_key(&mapped_specifier_key(s))
+      })
       .collect::<Vec<_>>();
     if !not_found_module_mappings.is_empty() {
       bail!(
@@ -174,7 +196,7 @@ impl ModuleGraph {
         MappedSpecifier::Package(_) => Some(k),
         MappedSpecifier::Module(_) => None,
       })
-      .filter(|s| !specifiers.has_mapped(s))
+      .filter(|s| !specifiers.has_mapped(&mapped_specifier_key(s)))
       .collect::<Vec<_>>();
     if !not_found_package_specifiers.is_empty() {
       bail!(
@@ -257,6 +279,111 @@ impl ModuleGraph {
   }
 }
 
+/// Resolves `jsr:` specifiers that the user has provided a mapping for to
+/// [`MAPPED_JSR_SCHEME`] so that they make it to the loader.
+///
+/// deno_graph resolves `jsr:` specifiers against the registry itself, so
+/// without this the loader never sees the specifier the mapping is keyed on
+/// and the package ends up vendored instead of mapped.
+#[derive(Debug)]
+struct MappedJsrSpecifierResolver<'a> {
+  inner: &'a dyn Resolver,
+  mappings: &'a JsrSpecifierMappings,
+}
+
+impl Resolver for MappedJsrSpecifierResolver<'_> {
+  fn default_jsx_import_source(
+    &self,
+    referrer: &ModuleSpecifier,
+  ) -> Option<String> {
+    self.inner.default_jsx_import_source(referrer)
+  }
+
+  fn default_jsx_import_source_types(
+    &self,
+    referrer: &ModuleSpecifier,
+  ) -> Option<String> {
+    self.inner.default_jsx_import_source_types(referrer)
+  }
+
+  fn jsx_import_source_module(&self, referrer: &ModuleSpecifier) -> &str {
+    self.inner.jsx_import_source_module(referrer)
+  }
+
+  fn resolve(
+    &self,
+    specifier_text: &str,
+    referrer_range: &Range,
+    kind: ResolutionKind,
+  ) -> Result<ModuleSpecifier, ResolveError> {
+    let specifier = self.inner.resolve(specifier_text, referrer_range, kind)?;
+    Ok(match self.mappings.get(&specifier) {
+      Some(mapped) => mapped.clone(),
+      None => specifier,
+    })
+  }
+
+  fn resolve_types(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Result<Option<(ModuleSpecifier, Option<Range>)>, ResolveError> {
+    self.inner.resolve_types(specifier)
+  }
+}
+
+/// The user's `jsr:` specifier mappings stored by package name and sub path
+/// so that a mapping is found no matter what version requirement the
+/// specifier being resolved has.
+#[derive(Debug, Default)]
+struct JsrSpecifierMappings {
+  by_name_and_sub_path: HashMap<(String, Option<String>), ModuleSpecifier>,
+}
+
+impl JsrSpecifierMappings {
+  pub fn new(mappings: &HashMap<ModuleSpecifier, MappedSpecifier>) -> Self {
+    let mut by_name_and_sub_path = HashMap::new();
+    for specifier in mappings.keys() {
+      if let Some(key) = jsr_name_and_sub_path(specifier) {
+        by_name_and_sub_path.insert(key, mapped_specifier_key(specifier));
+      }
+    }
+    Self {
+      by_name_and_sub_path,
+    }
+  }
+
+  pub fn get(&self, specifier: &ModuleSpecifier) -> Option<&ModuleSpecifier> {
+    self
+      .by_name_and_sub_path
+      .get(&jsr_name_and_sub_path(specifier)?)
+  }
+}
+
+/// Scheme mapped `jsr:` specifiers are resolved to within the module graph.
+const MAPPED_JSR_SCHEME: &str = "dnt-jsr";
+
+/// Gets the specifier a mapping key has within the module graph.
+fn mapped_specifier_key(specifier: &ModuleSpecifier) -> ModuleSpecifier {
+  if specifier.scheme() != "jsr" {
+    return specifier.clone();
+  }
+  ModuleSpecifier::parse(&format!("{}:{}", MAPPED_JSR_SCHEME, specifier.path()))
+    .unwrap_or_else(|_| specifier.clone())
+}
+
+fn jsr_name_and_sub_path(
+  specifier: &ModuleSpecifier,
+) -> Option<(String, Option<String>)> {
+  if specifier.scheme() != "jsr" {
+    return None;
+  }
+  let req_ref = JsrPackageReqReference::from_specifier(specifier).ok()?;
+  Some((
+    req_ref.req().name.to_string(),
+    req_ref.sub_path().map(ToOwned::to_owned),
+  ))
+}
+
 fn format_specifiers_for_message(
   mut specifiers: Vec<&ModuleSpecifier>,
 ) -> String {
@@ -266,4 +393,79 @@ fn format_specifiers_for_message(
     .map(|s| format!("  * {}", s))
     .collect::<Vec<_>>()
     .join("\n")
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use crate::PackageMappedSpecifier;
+
+  #[test]
+  fn test_mapped_specifier_key() {
+    // non-jsr specifiers keep their scheme
+    run_test("https://localhost/mod.ts", "https://localhost/mod.ts");
+    run_test("npm:package@^1.0.0", "npm:package@^1.0.0");
+    // jsr specifiers get a scheme deno_graph won't resolve itself
+    run_test("jsr:@scope/name", "dnt-jsr:@scope/name");
+    run_test(
+      "jsr:@scope/name@^1.0.0/sub",
+      "dnt-jsr:@scope/name@^1.0.0/sub",
+    );
+
+    fn run_test(specifier: &str, expected: &str) {
+      assert_eq!(
+        mapped_specifier_key(&ModuleSpecifier::parse(specifier).unwrap())
+          .as_str(),
+        expected
+      );
+    }
+  }
+
+  #[test]
+  fn test_jsr_specifier_mappings() {
+    let mappings = JsrSpecifierMappings::new(&HashMap::from([
+      (parse("jsr:@scope/name"), mapping()),
+      (parse("jsr:@scope/other@^1.0.0/sub"), mapping()),
+      (parse("https://localhost/mod.ts"), mapping()),
+    ]));
+
+    // the version requirement is ignored when matching
+    assert_eq!(
+      get(&mappings, "jsr:@scope/name"),
+      Some("dnt-jsr:@scope/name")
+    );
+    assert_eq!(
+      get(&mappings, "jsr:@scope/name@^1.0.0"),
+      Some("dnt-jsr:@scope/name")
+    );
+    assert_eq!(
+      get(&mappings, "jsr:@scope/other/sub"),
+      Some("dnt-jsr:@scope/other@^1.0.0/sub")
+    );
+    // ...but the sub path is not
+    assert_eq!(get(&mappings, "jsr:@scope/name/sub"), None);
+    assert_eq!(get(&mappings, "jsr:@scope/other"), None);
+    assert_eq!(get(&mappings, "jsr:@scope/not-mapped"), None);
+    assert_eq!(get(&mappings, "https://localhost/mod.ts"), None);
+
+    fn get<'a>(
+      mappings: &'a JsrSpecifierMappings,
+      specifier: &str,
+    ) -> Option<&'a str> {
+      mappings.get(&parse(specifier)).map(ModuleSpecifier::as_str)
+    }
+
+    fn parse(specifier: &str) -> ModuleSpecifier {
+      ModuleSpecifier::parse(specifier).unwrap()
+    }
+
+    fn mapping() -> MappedSpecifier {
+      MappedSpecifier::Package(PackageMappedSpecifier {
+        name: "package".to_string(),
+        version: None,
+        sub_path: None,
+        peer_dependency: false,
+      })
+    }
+  }
 }

--- a/rs-lib/src/graph.rs
+++ b/rs-lib/src/graph.rs
@@ -62,17 +62,13 @@ impl ModuleGraph {
   ) -> Result<(Self, Specifiers)> {
     let resolver = options.resolver;
     let loader = options.loader;
-    // mapped jsr specifiers don't keep their scheme in the graph, so the
-    // loader needs to look them up by the specifier they're resolved to
-    let graph_specifier_mappings = options
-      .specifier_mappings
-      .iter()
-      .map(|(k, v)| (mapped_specifier_key(k), v.clone()))
-      .collect::<HashMap<_, _>>();
+    let jsr_specifier_mappings =
+      JsrSpecifierMappings::new(options.specifier_mappings);
     let loader = SourceLoader::new(
       loader,
       get_all_specifier_mappers(),
-      &graph_specifier_mappings,
+      options.specifier_mappings,
+      &jsr_specifier_mappings,
     );
     let scoped_jsx_import_source_config =
       JsxImportSourceConfigResolver::from_compiler_options_resolver(
@@ -97,8 +93,6 @@ impl ModuleGraph {
       None,
       deno_resolver::graph::NpmTypesResolutionMode::FallbackToExecution,
     );
-    let jsr_specifier_mappings =
-      JsrSpecifierMappings::new(options.specifier_mappings);
     let graph_resolver = MappedJsrSpecifierResolver {
       inner: &graph_resolver,
       mappings: &jsr_specifier_mappings,
@@ -170,9 +164,8 @@ impl ModuleGraph {
         MappedSpecifier::Module(_) => Some(k),
       })
       .filter(|s| {
-        !loader_specifiers
-          .mapped_modules
-          .contains_key(&mapped_specifier_key(s))
+        !jsr_specifier_mappings
+          .was_found(s, loader_specifiers.mapped_modules.keys())
       })
       .collect::<Vec<_>>();
     if !not_found_module_mappings.is_empty() {
@@ -196,7 +189,16 @@ impl ModuleGraph {
         MappedSpecifier::Package(_) => Some(k),
         MappedSpecifier::Module(_) => None,
       })
-      .filter(|s| !specifiers.has_mapped(&mapped_specifier_key(s)))
+      .filter(|s| {
+        !jsr_specifier_mappings.was_found(
+          s,
+          specifiers
+            .main
+            .mapped
+            .keys()
+            .chain(specifiers.test.mapped.keys()),
+        )
+      })
       .collect::<Vec<_>>();
     if !not_found_package_specifiers.is_empty() {
       bail!(
@@ -317,8 +319,8 @@ impl Resolver for MappedJsrSpecifierResolver<'_> {
     kind: ResolutionKind,
   ) -> Result<ModuleSpecifier, ResolveError> {
     let specifier = self.inner.resolve(specifier_text, referrer_range, kind)?;
-    Ok(match self.mappings.get(&specifier) {
-      Some(mapped) => mapped.clone(),
+    Ok(match self.mappings.graph_specifier(&specifier) {
+      Some(specifier) => specifier,
       None => specifier,
     })
   }
@@ -335,45 +337,86 @@ impl Resolver for MappedJsrSpecifierResolver<'_> {
 /// so that a mapping is found no matter what version requirement the
 /// specifier being resolved has.
 #[derive(Debug, Default)]
-struct JsrSpecifierMappings {
-  by_name_and_sub_path: HashMap<(String, Option<String>), ModuleSpecifier>,
+pub struct JsrSpecifierMappings {
+  by_name_and_sub_path: HashMap<JsrMappingKey, MappedSpecifier>,
 }
 
 impl JsrSpecifierMappings {
   pub fn new(mappings: &HashMap<ModuleSpecifier, MappedSpecifier>) -> Self {
-    let mut by_name_and_sub_path = HashMap::new();
-    for specifier in mappings.keys() {
-      if let Some(key) = jsr_name_and_sub_path(specifier) {
-        by_name_and_sub_path.insert(key, mapped_specifier_key(specifier));
-      }
-    }
     Self {
-      by_name_and_sub_path,
+      by_name_and_sub_path: mappings
+        .iter()
+        .filter_map(|(specifier, mapping)| {
+          Some((jsr_mapping_key(specifier)?, mapping.clone()))
+        })
+        .collect(),
     }
   }
 
-  pub fn get(&self, specifier: &ModuleSpecifier) -> Option<&ModuleSpecifier> {
-    self
+  /// Gets the specifier to use in the module graph for a mapped `jsr:`
+  /// specifier.
+  pub fn graph_specifier(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<ModuleSpecifier> {
+    if !self
       .by_name_and_sub_path
-      .get(&jsr_name_and_sub_path(specifier)?)
+      .contains_key(&jsr_mapping_key(specifier)?)
+    {
+      return None;
+    }
+    ModuleSpecifier::parse(&format!(
+      "{}:{}",
+      MAPPED_JSR_SCHEME,
+      specifier.path()
+    ))
+    .ok()
+  }
+
+  /// Gets the mapping for a specifier in the module graph, filling in the
+  /// version of the package from the specifier when the mapping doesn't
+  /// specify one.
+  pub fn get(&self, specifier: &ModuleSpecifier) -> Option<MappedSpecifier> {
+    let specifier = from_graph_specifier(specifier)?;
+    let mapping = self
+      .by_name_and_sub_path
+      .get(&jsr_mapping_key(&specifier)?)?;
+    let MappedSpecifier::Package(package) = mapping else {
+      return Some(mapping.clone());
+    };
+    let mut package = package.clone();
+    if package.version.is_none() {
+      package.version = jsr_version_req(&specifier);
+    }
+    Some(MappedSpecifier::Package(package))
+  }
+
+  /// Whether the graph contained a specifier that the provided mapping
+  /// applied to.
+  pub fn was_found<'a>(
+    &self,
+    mapping_specifier: &ModuleSpecifier,
+    mut graph_specifiers: impl Iterator<Item = &'a ModuleSpecifier>,
+  ) -> bool {
+    let Some(key) = jsr_mapping_key(mapping_specifier) else {
+      return graph_specifiers.any(|s| s == mapping_specifier);
+    };
+    graph_specifiers.any(|s| {
+      from_graph_specifier(s)
+        .and_then(|s| jsr_mapping_key(&s))
+        .is_some_and(|s| s == key)
+    })
   }
 }
 
-/// Scheme mapped `jsr:` specifiers are resolved to within the module graph.
+/// Scheme mapped `jsr:` specifiers have within the module graph.
 const MAPPED_JSR_SCHEME: &str = "dnt-jsr";
 
-/// Gets the specifier a mapping key has within the module graph.
-fn mapped_specifier_key(specifier: &ModuleSpecifier) -> ModuleSpecifier {
-  if specifier.scheme() != "jsr" {
-    return specifier.clone();
-  }
-  ModuleSpecifier::parse(&format!("{}:{}", MAPPED_JSR_SCHEME, specifier.path()))
-    .unwrap_or_else(|_| specifier.clone())
-}
+/// A `jsr:` mapping is keyed on the package name and sub path so that the
+/// version requirement doesn't need to be repeated in the mapping.
+type JsrMappingKey = (String, Option<String>);
 
-fn jsr_name_and_sub_path(
-  specifier: &ModuleSpecifier,
-) -> Option<(String, Option<String>)> {
+fn jsr_mapping_key(specifier: &ModuleSpecifier) -> Option<JsrMappingKey> {
   if specifier.scheme() != "jsr" {
     return None;
   }
@@ -382,6 +425,25 @@ fn jsr_name_and_sub_path(
     req_ref.req().name.to_string(),
     req_ref.sub_path().map(ToOwned::to_owned),
   ))
+}
+
+fn jsr_version_req(specifier: &ModuleSpecifier) -> Option<String> {
+  let req_ref = JsrPackageReqReference::from_specifier(specifier).ok()?;
+  let version_text = req_ref.req().version_req.version_text();
+  // no version requirement, so leave it up to the mapping
+  if version_text == "*" {
+    return None;
+  }
+  Some(version_text.to_string())
+}
+
+fn from_graph_specifier(
+  specifier: &ModuleSpecifier,
+) -> Option<ModuleSpecifier> {
+  if specifier.scheme() != MAPPED_JSR_SCHEME {
+    return None;
+  }
+  ModuleSpecifier::parse(&format!("jsr:{}", specifier.path())).ok()
 }
 
 fn format_specifiers_for_message(
@@ -401,71 +463,96 @@ mod test {
   use crate::PackageMappedSpecifier;
 
   #[test]
-  fn test_mapped_specifier_key() {
-    // non-jsr specifiers keep their scheme
-    run_test("https://localhost/mod.ts", "https://localhost/mod.ts");
-    run_test("npm:package@^1.0.0", "npm:package@^1.0.0");
-    // jsr specifiers get a scheme deno_graph won't resolve itself
-    run_test("jsr:@scope/name", "dnt-jsr:@scope/name");
-    run_test(
-      "jsr:@scope/name@^1.0.0/sub",
-      "dnt-jsr:@scope/name@^1.0.0/sub",
-    );
+  fn test_jsr_mappings_graph_specifier() {
+    // the version requirement is ignored when matching, but kept on the
+    // specifier so that the version can be used for the dependency
+    run_test("jsr:@scope/name", Some("dnt-jsr:@scope/name"));
+    run_test("jsr:@scope/name@^1.0.0", Some("dnt-jsr:@scope/name@^1.0.0"));
+    run_test("jsr:@scope/other/sub", Some("dnt-jsr:@scope/other/sub"));
+    // ...but the sub path is not ignored
+    run_test("jsr:@scope/name/sub", None);
+    run_test("jsr:@scope/other", None);
+    // not mapped
+    run_test("jsr:@scope/not-mapped", None);
+    run_test("https://localhost/mod.ts", None);
 
-    fn run_test(specifier: &str, expected: &str) {
+    fn run_test(specifier: &str, expected: Option<&str>) {
       assert_eq!(
-        mapped_specifier_key(&ModuleSpecifier::parse(specifier).unwrap())
-          .as_str(),
+        mappings()
+          .graph_specifier(&parse(specifier))
+          .as_ref()
+          .map(ModuleSpecifier::as_str),
         expected
       );
     }
   }
 
   #[test]
-  fn test_jsr_specifier_mappings() {
-    let mappings = JsrSpecifierMappings::new(&HashMap::from([
-      (parse("jsr:@scope/name"), mapping()),
-      (parse("jsr:@scope/other@^1.0.0/sub"), mapping()),
-      (parse("https://localhost/mod.ts"), mapping()),
-    ]));
+  fn test_jsr_mappings_get() {
+    // the version of the specifier is used when the mapping has none
+    run_test("dnt-jsr:@scope/name@^1.0.0", Some(Some("^1.0.0")));
+    // ...but the mapping's version wins when it has one
+    run_test("dnt-jsr:@scope/other@^1.0.0/sub", Some(Some("~2.0.0")));
+    // no version anywhere means no dependency
+    run_test("dnt-jsr:@scope/name", Some(None));
+    // not mapped
+    run_test("dnt-jsr:@scope/not-mapped", None);
+    run_test("jsr:@scope/name", None);
 
-    // the version requirement is ignored when matching
-    assert_eq!(
-      get(&mappings, "jsr:@scope/name"),
-      Some("dnt-jsr:@scope/name")
-    );
-    assert_eq!(
-      get(&mappings, "jsr:@scope/name@^1.0.0"),
-      Some("dnt-jsr:@scope/name")
-    );
-    assert_eq!(
-      get(&mappings, "jsr:@scope/other/sub"),
-      Some("dnt-jsr:@scope/other@^1.0.0/sub")
-    );
-    // ...but the sub path is not
-    assert_eq!(get(&mappings, "jsr:@scope/name/sub"), None);
-    assert_eq!(get(&mappings, "jsr:@scope/other"), None);
-    assert_eq!(get(&mappings, "jsr:@scope/not-mapped"), None);
-    assert_eq!(get(&mappings, "https://localhost/mod.ts"), None);
-
-    fn get<'a>(
-      mappings: &'a JsrSpecifierMappings,
-      specifier: &str,
-    ) -> Option<&'a str> {
-      mappings.get(&parse(specifier)).map(ModuleSpecifier::as_str)
+    fn run_test(specifier: &str, expected: Option<Option<&str>>) {
+      let mapping = mappings().get(&parse(specifier));
+      assert_eq!(
+        mapping.as_ref().map(|m| match m {
+          MappedSpecifier::Package(p) => p.version.as_deref(),
+          MappedSpecifier::Module(_) => unreachable!(),
+        }),
+        expected
+      );
     }
+  }
 
-    fn parse(specifier: &str) -> ModuleSpecifier {
-      ModuleSpecifier::parse(specifier).unwrap()
-    }
+  #[test]
+  fn test_jsr_mappings_was_found() {
+    let mappings = mappings();
 
-    fn mapping() -> MappedSpecifier {
-      MappedSpecifier::Package(PackageMappedSpecifier {
-        name: "package".to_string(),
-        version: None,
-        sub_path: None,
-        peer_dependency: false,
-      })
-    }
+    // matched by package name and sub path, not the specifier
+    assert!(mappings.was_found(
+      &parse("jsr:@scope/name"),
+      [parse("dnt-jsr:@scope/name@^1.0.0")].iter()
+    ));
+    assert!(!mappings.was_found(
+      &parse("jsr:@scope/name"),
+      [parse("dnt-jsr:@scope/name/sub")].iter()
+    ));
+    // non-jsr mappings are matched on the specifier
+    assert!(mappings.was_found(
+      &parse("https://localhost/mod.ts"),
+      [parse("https://localhost/mod.ts")].iter()
+    ));
+    assert!(!mappings.was_found(
+      &parse("https://localhost/mod.ts"),
+      [parse("https://localhost/other.ts")].iter()
+    ));
+  }
+
+  fn mappings() -> JsrSpecifierMappings {
+    JsrSpecifierMappings::new(&HashMap::from([
+      (parse("jsr:@scope/name"), mapping(None)),
+      (parse("jsr:@scope/other/sub"), mapping(Some("~2.0.0"))),
+      (parse("https://localhost/mod.ts"), mapping(None)),
+    ]))
+  }
+
+  fn mapping(version: Option<&str>) -> MappedSpecifier {
+    MappedSpecifier::Package(PackageMappedSpecifier {
+      name: "package".to_string(),
+      version: version.map(ToOwned::to_owned),
+      sub_path: None,
+      peer_dependency: false,
+    })
+  }
+
+  fn parse(specifier: &str) -> ModuleSpecifier {
+    ModuleSpecifier::parse(specifier).unwrap()
   }
 }

--- a/rs-lib/src/loader/mod.rs
+++ b/rs-lib/src/loader/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -12,6 +13,7 @@ mod specifier_mappers;
 
 pub use specifier_mappers::*;
 
+use crate::graph::JsrSpecifierMappings;
 use crate::MappedSpecifier;
 use crate::PackageMappedSpecifier;
 
@@ -26,6 +28,7 @@ pub struct SourceLoader<'a> {
   specifiers: RefCell<LoaderSpecifiers>,
   specifier_mappers: Vec<Box<dyn SpecifierMapper>>,
   specifier_mappings: &'a HashMap<ModuleSpecifier, MappedSpecifier>,
+  jsr_specifier_mappings: &'a JsrSpecifierMappings,
 }
 
 impl<'a> SourceLoader<'a> {
@@ -33,17 +36,33 @@ impl<'a> SourceLoader<'a> {
     loader: Rc<dyn deno_graph::source::Loader>,
     specifier_mappers: Vec<Box<dyn SpecifierMapper>>,
     specifier_mappings: &'a HashMap<ModuleSpecifier, MappedSpecifier>,
+    jsr_specifier_mappings: &'a JsrSpecifierMappings,
   ) -> Self {
     Self {
       loader,
       specifiers: Default::default(),
       specifier_mappers,
       specifier_mappings,
+      jsr_specifier_mappings,
     }
   }
 
   pub fn into_specifiers(self) -> LoaderSpecifiers {
     self.specifiers.take()
+  }
+
+  /// Gets the mapping the user provided for a specifier, if any.
+  ///
+  /// Mapped `jsr:` specifiers don't keep their scheme in the graph, so they
+  /// are looked up by the specifier they were resolved to instead.
+  fn mapping(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<Cow<MappedSpecifier>> {
+    match self.specifier_mappings.get(specifier) {
+      Some(mapping) => Some(Cow::Borrowed(mapping)),
+      None => self.jsr_specifier_mappings.get(specifier).map(Cow::Owned),
+    }
   }
 }
 
@@ -53,7 +72,8 @@ impl deno_graph::source::Loader for SourceLoader<'_> {
     specifier: &ModuleSpecifier,
     load_options: deno_graph::source::LoadOptions,
   ) -> deno_graph::source::LoadFuture {
-    let specifier = match self.specifier_mappings.get(specifier) {
+    let mapping = self.mapping(specifier);
+    let specifier = match mapping.as_deref() {
       Some(MappedSpecifier::Package(mapping)) => {
         self
           .specifiers

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1176,12 +1176,13 @@ async fn transform_jsr_specifier_mappings() {
         "/mod.ts",
         concat!(
           "import * as pkg from 'jsr:@scope/name@^1.0.0';\n",
-          "import * as sub from 'jsr:@scope/name/sub';\n",
+          "import * as sub from 'jsr:@scope/name@^1.0.0/sub';\n",
+          "import * as inherited from 'jsr:@scope/inherited@~2.0.0';\n",
           "import * as other from 'jsr:@scope/other';\n",
         ),
       );
     })
-    // no version requirement on the mapping, so it should match any
+    // the mapping's version requirement doesn't need to match the specifier's
     .add_package_specifier_mapping(
       "jsr:@scope/name",
       "scope-name",
@@ -1194,7 +1195,14 @@ async fn transform_jsr_specifier_mappings() {
       Some("^1.0.0"),
       Some("sub"),
     )
-    // a mapping without a version shouldn't add a dependency
+    // no version on the mapping, so the specifier's is used
+    .add_package_specifier_mapping(
+      "jsr:@scope/inherited",
+      "scope-inherited",
+      None,
+      None,
+    )
+    // no version anywhere, so no dependency is added
     .add_package_specifier_mapping(
       "jsr:@scope/other",
       "scope-other",
@@ -1212,17 +1220,25 @@ async fn transform_jsr_specifier_mappings() {
       concat!(
         "import * as pkg from 'scope-name';\n",
         "import * as sub from 'scope-name/sub';\n",
+        "import * as inherited from 'scope-inherited';\n",
         "import * as other from 'scope-other';\n",
       )
     )]
   );
   assert_eq!(
     result.main.dependencies,
-    &[Dependency {
-      name: "scope-name".to_string(),
-      version: "^1.0.0".to_string(),
-      peer_dependency: false,
-    }]
+    &[
+      Dependency {
+        name: "scope-inherited".to_string(),
+        version: "~2.0.0".to_string(),
+        peer_dependency: false,
+      },
+      Dependency {
+        name: "scope-name".to_string(),
+        version: "^1.0.0".to_string(),
+        peer_dependency: false,
+      }
+    ]
   );
 }
 
@@ -1242,12 +1258,8 @@ async fn transform_jsr_specifier_mapping_via_import_map() {
         );
     })
     .set_config_file("file:///deno.json")
-    .add_package_specifier_mapping(
-      "jsr:@scope/name",
-      "scope-name",
-      Some("^1.0.0"),
-      None,
-    )
+    // the version requirement comes from the import map
+    .add_package_specifier_mapping("jsr:@scope/name", "scope-name", None, None)
     .transform()
     .await
     .unwrap();

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1169,6 +1169,130 @@ async fn transform_specifier_mappings() {
 }
 
 #[tokio::test]
+async fn transform_jsr_specifier_mappings() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader.add_local_file(
+        "/mod.ts",
+        concat!(
+          "import * as pkg from 'jsr:@scope/name@^1.0.0';\n",
+          "import * as sub from 'jsr:@scope/name/sub';\n",
+          "import * as other from 'jsr:@scope/other';\n",
+        ),
+      );
+    })
+    // no version requirement on the mapping, so it should match any
+    .add_package_specifier_mapping(
+      "jsr:@scope/name",
+      "scope-name",
+      Some("^1.0.0"),
+      None,
+    )
+    .add_package_specifier_mapping(
+      "jsr:@scope/name/sub",
+      "scope-name",
+      Some("^1.0.0"),
+      Some("sub"),
+    )
+    // a mapping without a version shouldn't add a dependency
+    .add_package_specifier_mapping(
+      "jsr:@scope/other",
+      "scope-other",
+      None,
+      None,
+    )
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[(
+      "mod.ts",
+      concat!(
+        "import * as pkg from 'scope-name';\n",
+        "import * as sub from 'scope-name/sub';\n",
+        "import * as other from 'scope-other';\n",
+      )
+    )]
+  );
+  assert_eq!(
+    result.main.dependencies,
+    &[Dependency {
+      name: "scope-name".to_string(),
+      version: "^1.0.0".to_string(),
+      peer_dependency: false,
+    }]
+  );
+}
+
+#[tokio::test]
+async fn transform_jsr_specifier_mapping_via_import_map() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file("/mod.ts", "import * as pkg from '@scope/name';")
+        .add_local_file(
+          "/deno.json",
+          r#"{
+  "imports": {
+    "@scope/name": "jsr:@scope/name@^1.0.0"
+  }
+}"#,
+        );
+    })
+    .set_config_file("file:///deno.json")
+    .add_package_specifier_mapping(
+      "jsr:@scope/name",
+      "scope-name",
+      Some("^1.0.0"),
+      None,
+    )
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[("mod.ts", "import * as pkg from 'scope-name';")]
+  );
+  assert_eq!(
+    result.main.dependencies,
+    &[Dependency {
+      name: "scope-name".to_string(),
+      version: "^1.0.0".to_string(),
+      peer_dependency: false,
+    }]
+  );
+}
+
+#[tokio::test]
+async fn transform_jsr_specifier_mapping_not_found() {
+  let error_message = TestBuilder::new()
+    .with_loader(|loader| {
+      loader.add_local_file("/mod.ts", "console.log(1);");
+    })
+    .add_package_specifier_mapping(
+      "jsr:@scope/name",
+      "scope-name",
+      Some("^1.0.0"),
+      None,
+    )
+    .transform()
+    .await
+    .err()
+    .unwrap();
+
+  assert_eq!(
+    error_message.to_string(),
+    concat!(
+      "The following specifiers were indicated to be mapped to a package, but were not found:\n",
+      "  * jsr:@scope/name",
+    )
+  );
+}
+
+#[tokio::test]
 async fn transform_specifier_mapping_of_redirected_specifier() {
   let result = TestBuilder::new()
     .with_loader(|loader| {


### PR DESCRIPTION
`mappings` entries keyed on a `jsr:` specifier always failed with:

```
The following specifiers were indicated to be mapped to a package, but were not found:
  * jsr:@hqtsm/dataview
```

Every mapping is applied in `SourceLoader::load`, but deno_graph resolves `jsr:` specifiers against the registry itself and only calls the loader with the resulting `https://jsr.io/...` URLs. The specifier the mapping is keyed on never reaches the loader, so the package got vendored and the mapping was reported as unused.

`MappedJsrSpecifierResolver` now wraps the graph resolver and, when a resolved specifier has a mapping, resolves it to the same specifier under a `dnt-jsr:` scheme instead. deno_graph doesn't recognize that scheme, so it hands the specifier to the loader like any other URL and the existing mapping machinery takes over — the package is never fetched, and the import is rewritten to the npm bare specifier.

Mappings are matched on the JSR package name and sub path, ignoring the version requirement, so a single entry covers a direct `jsr:@scope/name@^1.0.0` import as well as a bare specifier that an import map points at the same package. Sub paths still need their own entry, matching how URL mappings work today.

Covered by unit tests for the matching and specifier rewriting, plus integration tests for a direct `jsr:` import, an import-map-resolved import, and the not-found error still firing for an unused mapping. Note that the integration tests never stub jsr.io — nothing is fetched for a mapped package, which is the point.

Closes #437