### PR TITLE
fix: make `Promise.withResolvers` polyfill file a module

### DIFF
--- a/rs-lib/src/polyfills/mod.rs
+++ b/rs-lib/src/polyfills/mod.rs
@@ -179,3 +179,23 @@ impl PolyfillTester {
     })
   }
 }
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn polyfill_scripts_are_modules() {
+    // a polyfill may end up being the only one in the output file, so each
+    // must be a module on its own for `declare global` to be valid
+    for polyfill in all_polyfills() {
+      let text = polyfill.get_file_text();
+      assert!(
+        text.lines().any(
+          |line| line.starts_with("export ") || line.starts_with("import ")
+        ),
+        "polyfill script was not a module: {text}"
+      );
+    }
+  }
+}

--- a/rs-lib/src/polyfills/scripts/es2021.promise-withResolvers.ts
+++ b/rs-lib/src/polyfills/scripts/es2021.promise-withResolvers.ts
@@ -20,3 +20,5 @@ if (Promise.withResolvers === undefined) {
     return out;
   };
 }
+
+export {};

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -927,6 +927,25 @@ Deno.test("should build and test polyfill project", async () => {
   });
 });
 
+Deno.test("should build and test the promise with resolvers polyfill project", async () => {
+  // this polyfill ends up alone in the polyfill file, so ensure the generated
+  // file is still a module and thus type checks (see #440)
+  await runTest("polyfill_promise_with_resolvers_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    shims: {
+      ...getAllShimOptions(false),
+      deno: "dev",
+    },
+    package: {
+      name: "polyfill-package",
+      version: "1.0.0",
+    },
+  }, (output) => {
+    output.assertExists("esm/_dnt.polyfills.js");
+  });
+});
+
 Deno.test("should build and test the array find last polyfill project", async () => {
   await runTest("polyfill_array_find_last_project", {
     entryPoints: ["mod.ts"],
@@ -1316,6 +1335,7 @@ async function runTest(
     | "polyfill_project"
     | "polyfill_array_from_async_project"
     | "polyfill_array_find_last_project"
+    | "polyfill_promise_with_resolvers_project"
     | "polyfill_import_meta_project"
     | "module_mappings_project"
     | "node_types_project"

--- a/tests/polyfill_promise_with_resolvers_project/mod.ts
+++ b/tests/polyfill_promise_with_resolvers_project/mod.ts
@@ -1,0 +1,5 @@
+// this project must only use the `Promise.withResolvers` polyfill so that it
+// ends up alone in the generated polyfill file (see #440)
+export function withResolvers<T>() {
+  return Promise.withResolvers<T>();
+}

--- a/tests/polyfill_promise_with_resolvers_project/mod_test.ts
+++ b/tests/polyfill_promise_with_resolvers_project/mod_test.ts
@@ -1,0 +1,24 @@
+import { withResolvers } from "./mod.ts";
+
+function assertEquals(a: unknown, b: unknown) {
+  if (a !== b) {
+    throw new Error(`${a} did not equal ${b}`);
+  }
+}
+
+Deno.test("should resolve", async () => {
+  const { promise, resolve } = withResolvers<number>();
+  setTimeout(() => resolve(5), 10);
+  assertEquals(await promise, 5);
+});
+
+Deno.test("should reject", async () => {
+  const { promise, reject } = withResolvers<number>();
+  setTimeout(() => reject(new Error("test")), 10);
+  try {
+    await promise;
+    throw new Error("Did not throw.");
+  } catch (err) {
+    assertEquals((err as Error).message, "test");
+  }
+});


### PR DESCRIPTION
Closes #440

## Problem

`build_polyfill_file` concatenates the file text of every triggered polyfill into `_dnt.polyfills.ts` / `_dnt.test_polyfills.ts`. `declare global` is only legal inside a *module*, so each script must be a module on its own — otherwise a project that triggers only that one polyfill gets a non-module output file.

`es2021.promise-withResolvers.ts` was the only script missing a trailing `export {};`:

```
src/_dnt.test_polyfills.ts:1:9 - error TS2669: Augmentations for the global scope can only be directly nested in external modules or ambient module declarations.
src/_dnt.test_polyfills.ts:13:13 - error TS2339: Property 'withResolvers' does not exist on type 'PromiseConstructor'.
src/_dnt.test_polyfills.ts:14:11 - error TS2339: Property 'withResolvers' does not exist on type 'PromiseConstructor'.
src/src/taskBouncer.test.ts:38:8 - error TS2339: Property 'withResolvers' does not exist on type 'PromiseConstructor'.
```

This went unnoticed because `tests/polyfill_project` also uses `Object.hasOwn`, and that script's `export {};` gets concatenated in, making the combined file a module.

## Changes

- Added `export {};` to `es2021.promise-withResolvers.ts`.
- Added `tests/polyfill_promise_with_resolvers_project` — a project that triggers *only* this polyfill, so the generated file is type checked in isolation. Verified it fails with the exact 4 diagnostics above without the fix.
- Added a unit test asserting every polyfill script is a module, so a future polyfill can't reintroduce this.