### PR TITLE
feat: set the globals of dev shims when running the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,29 @@ await build({
 });
 ```
 
+Only the test code is transformed to use these shims. The code being tested is
+left as-is, so the test runner additionally sets the globals of these shims on
+`globalThis` before running the tests.
+
+This is useful when the distributed code should assume a global exists, but it
+needs to be present when testing on Node.js:
+
+```ts
+await build({
+  // ...etc...
+  shims: {
+    // `Headers`, `Response`, etc. are used without being shimmed in the
+    // distributed code, but exist when running the tests
+    undici: "dev",
+  },
+});
+```
+
+Note that the `Deno` namespace is never set on `globalThis` because code
+commonly checks for its existence in order to detect the runtime it's running
+in. Similarly, the globals of [local and remote shims](#local-and-remote-shims)
+are not set because the test runner has no way of resolving those modules.
+
 #### Preventing Shimming
 
 To prevent shimming in specific instances, add a `// dnt-shim-ignore` comment:

--- a/lib/shims.ts
+++ b/lib/shims.ts
@@ -40,7 +40,7 @@ export interface ShimOptions {
    */
   weakRef?: ShimValue;
   /** Shim `WebSocket` with the `ws` package (https://www.npmjs.com/package/ws). */
-  webSocket?: boolean | "dev";
+  webSocket?: ShimValue;
   /** Custom shims to use. */
   custom?: Shim[];
   /** Custom shims to use only for the test code. */
@@ -51,7 +51,7 @@ export interface DenoShimOptions {
   /** Only import the `Deno` namespace for `Deno.test`.
    * This may be useful for environments
    */
-  test: boolean | "dev";
+  test: ShimValue;
 }
 
 export function shimOptionsToTransformShims(options: ShimOptions) {
@@ -84,7 +84,7 @@ export function shimOptionsToTransformShims(options: ShimOptions) {
     testShims,
   };
 
-  function add(option: boolean | "dev" | undefined, getShim: () => Shim) {
+  function add(option: ShimValue | undefined, getShim: () => Shim) {
     if (option === true) {
       shims.push(getShim());
       testShims.push(getShim());

--- a/lib/test_runner/get_test_runner_code.test.ts
+++ b/lib/test_runner/get_test_runner_code.test.ts
@@ -114,6 +114,114 @@ main();
   );
 });
 
+Deno.test("gets code that sets the globals of the test shims", () => {
+  const code = getTestRunnerCode({
+    testEntryPoints: ["./test.ts"],
+    denoTestShimPackageName: undefined,
+    includeEsModule: true,
+    includeScriptModule: false,
+    testShims: [{
+      // the `Deno` namespace is never set as a global, so this
+      // shim should be ignored
+      package: {
+        name: "@deno/shim-deno",
+        version: "~0.18.0",
+      },
+      globalNames: ["Deno"],
+    }, {
+      package: {
+        name: "test-shim-package",
+        version: "^1.0.0",
+        subPath: "sub-path",
+      },
+      globalNames: ["Headers", {
+        name: "DOMException",
+        exportName: "default",
+      }, {
+        name: "RequestInit",
+        typeOnly: true,
+      }],
+    }, {
+      module: "node:buffer",
+      globalNames: ["Blob"],
+    }, {
+      // only has type only globals, so it should be ignored
+      module: "node:util",
+      globalNames: [{
+        name: "SomeType",
+        typeOnly: true,
+      }],
+    }],
+  });
+  assertEquals(
+    code,
+    `const pc = require("picocolors");
+const process = require("process");
+
+const filePaths = [
+  "./test.js",
+];
+
+async function main() {
+  await setUpGlobals();
+  for (const [i, filePath] of filePaths.entries()) {
+    if (i > 0) {
+      console.log("");
+    }
+
+    const esmPath = "./esm/" + filePath;
+    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    process.chdir(__dirname + "/esm");
+    await import(esmPath);
+  }
+}
+
+async function setUpGlobals() {
+  const shim0 = await import("test-shim-package/sub-path");
+  defineGlobal("Headers", shim0.Headers);
+  defineGlobal("DOMException", shim0.default);
+  const shim1 = await import("node:buffer");
+  defineGlobal("Blob", shim1.Blob);
+
+  function defineGlobal(name, value) {
+    // some globals are defined as getters on globalThis (ex. \`crypto\`),
+    // so a plain assignment would not work here
+    Object.defineProperty(globalThis, name, {
+      value,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+}
+
+main();
+`,
+  );
+});
+
+Deno.test("does not set the globals of local and remote shims", () => {
+  // these modules are in the graph, so the test runner has no way of
+  // resolving them to an output file
+  const code = getTestRunnerCode({
+    testEntryPoints: ["./test.ts"],
+    denoTestShimPackageName: undefined,
+    includeEsModule: true,
+    includeScriptModule: true,
+    testShims: [{
+      module: "./my_shim.ts",
+      globalNames: ["fetch"],
+    }, {
+      module: "my_shim.ts",
+      globalNames: ["Response"],
+    }, {
+      module: "https://deno.land/x/some_shim/mod.ts",
+      globalNames: ["setTimeout"],
+    }],
+  });
+  assertEquals(code.includes("setUpGlobals"), false);
+});
+
 Deno.test("gets code when cjs is not used", () => {
   const code = getTestRunnerCode({
     testEntryPoints: ["./test.ts"],

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -1,15 +1,33 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
 import CodeBlockWriter from "code-block-writer";
+import type { GlobalName, Shim } from "../../transform.ts";
+import { isPathOrUrl } from "../utils.ts";
 import { runTestDefinitions } from "./test_runner.ts";
+
+/** The `Deno` namespace is never set as a global because code commonly checks
+ * for its existence in order to detect the runtime it's running in.
+ */
+const nonGlobalShimNames = new Set(["Deno"]);
 
 export function getTestRunnerCode(options: {
   testEntryPoints: string[];
   denoTestShimPackageName: string | undefined;
   includeEsModule: boolean | undefined;
   includeScriptModule: boolean | undefined;
+  testShims?: Shim[];
 }) {
   const usesDenoTest = options.denoTestShimPackageName != null;
+  // the test code is transformed to use the shims, but the code being tested
+  // is not, so set the globals in order for it to use them as well
+  const globalShims = (options.testShims ?? [])
+    .map((shim) => ({
+      specifier: getShimSpecifier(shim),
+      globalNames: shim.globalNames
+        .map(toGlobalName)
+        .filter((n) => !n.typeOnly && !nonGlobalShimNames.has(n.name)),
+    }))
+    .filter((shim) => shim.specifier != null && shim.globalNames.length > 0);
   const writer = createWriter();
   writer.writeLine(`const pc = require("picocolors");`)
     .writeLine(`const process = require("process");`);
@@ -30,6 +48,9 @@ export function getTestRunnerCode(options: {
   writer.writeLine("];").newLine();
 
   writer.write("async function main()").block(() => {
+    if (globalShims.length > 0) {
+      writer.writeLine("await setUpGlobals();");
+    }
     if (usesDenoTest) {
       writer.write("const testContext = ").inlineBlock(() => {
         writer.writeLine("process,");
@@ -93,6 +114,42 @@ export function getTestRunnerCode(options: {
   });
   writer.blankLine();
 
+  if (globalShims.length > 0) {
+    writer.write("async function setUpGlobals()").block(() => {
+      for (const [i, shim] of globalShims.entries()) {
+        const shimName = `shim${i}`;
+        writer.writeLine(
+          `const ${shimName} = await import(${
+            JSON.stringify(shim.specifier)
+          });`,
+        );
+        for (const globalName of shim.globalNames) {
+          writer.writeLine(
+            `defineGlobal(${JSON.stringify(globalName.name)}, ${shimName}.${
+              globalName.exportName ?? globalName.name
+            });`,
+          );
+        }
+      }
+      writer.blankLine();
+      writer.write("function defineGlobal(name, value)").block(() => {
+        writer.writeLine(
+          "// some globals are defined as getters on globalThis (ex. `crypto`),",
+        );
+        writer.writeLine("// so a plain assignment would not work here");
+        writer.write("Object.defineProperty(globalThis, name, ").inlineBlock(
+          () => {
+            writer.writeLine("value,");
+            writer.writeLine("writable: true,");
+            writer.writeLine("enumerable: false,");
+            writer.writeLine("configurable: true,");
+          },
+        ).write(");").newLine();
+      });
+    });
+    writer.blankLine();
+  }
+
   if (options.denoTestShimPackageName != null) {
     writer.writeLine(`${getRunTestDefinitionsCode()}`);
     writer.blankLine();
@@ -100,6 +157,25 @@ export function getTestRunnerCode(options: {
 
   writer.writeLine("main();");
   return writer.toString();
+}
+
+/** Gets the specifier to import the shim from in the test runner or
+ * `undefined` when the shim can't be imported from there.
+ */
+function getShimSpecifier(shim: Shim) {
+  if ("package" in shim) {
+    return shim.package.subPath == null
+      ? shim.package.name
+      : `${shim.package.name}/${shim.package.subPath}`;
+  }
+
+  // local and remote modules are part of the graph, which the test runner
+  // has no way of resolving to an output file
+  return isPathOrUrl(shim.module) ? undefined : shim.module;
+}
+
+function toGlobalName(name: GlobalName | string): GlobalName {
+  return typeof name === "string" ? { name } : name;
 }
 
 function getRunTestDefinitionsCode() {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -89,6 +89,17 @@ export function standardizePath(fileOrDirPath: string) {
   return path.resolve(fileOrDirPath);
 }
 
+/** Gets if the provided value refers to a module rather than
+ * a bare specifier (ex. an npm package).
+ */
+export function isPathOrUrl(value: string) {
+  value = value.trim();
+  return /^[a-z]+:\/\//i.test(value) || // has scheme
+    value.startsWith("./") ||
+    value.startsWith("../") ||
+    /\.[a-z]+$/i.test(value); // has extension
+}
+
 export function valueToUrl(value: string) {
   const lowerCaseValue = value.toLowerCase();
   if (

--- a/mod.ts
+++ b/mod.ts
@@ -254,6 +254,8 @@ export async function build(options: BuildOptions): Promise<void> {
     }
   });
 
+  const { shims, testShims } = shimOptionsToTransformShims(options.shims);
+
   await Deno.permissions.request({ name: "write", path: options.outDir });
 
   log("Transforming...");
@@ -613,7 +615,6 @@ export async function build(options: BuildOptions): Promise<void> {
   }
 
   async function transformEntryPoints(): Promise<TransformOutput> {
-    const { shims, testShims } = shimOptionsToTransformShims(options.shims);
     return transform({
       entryPoints: entryPoints.map((e) => e.path),
       testEntryPoints: options.test
@@ -656,6 +657,7 @@ export async function build(options: BuildOptions): Promise<void> {
           testEntryPoints: transformOutput.test.entryPoints,
           includeEsModule: options.esModule !== false,
           includeScriptModule: options.scriptModule !== false,
+          testShims,
         }),
         compilerScriptTarget,
       ),

--- a/tests/dev_shim_globals_project/mod.test.ts
+++ b/tests/dev_shim_globals_project/mod.test.ts
@@ -1,0 +1,17 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { getExistingGlobalNames } from "./mod.ts";
+import { assertEquals } from "https://deno.land/std@0.181.0/testing/asserts.ts";
+
+Deno.test("should set the globals of the built-in shims", () => {
+  // node does not have these globals, so they can only exist
+  // when the test runner sets them from `@deno/shim-prompts`
+  assertEquals(
+    getExistingGlobalNames(["alert", "confirm", "prompt"]),
+    ["alert", "confirm", "prompt"],
+  );
+});
+
+Deno.test("should set the globals of the custom shims", () => {
+  assertEquals(getExistingGlobalNames(["Blob"]), ["Blob"]);
+});

--- a/tests/dev_shim_globals_project/mod.ts
+++ b/tests/dev_shim_globals_project/mod.ts
@@ -1,0 +1,13 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+/** Gets which of the provided names exist on `globalThis`.
+ *
+ * @remarks This module is not transformed by the shims. It relies on the
+ * globals being set when running the tests.
+ */
+export function getExistingGlobalNames(names: string[]) {
+  return names.filter((name) =>
+    // dnt-shim-ignore
+    name in globalThis
+  );
+}

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1088,6 +1088,54 @@ Deno.test("should build undici project", async () => {
   });
 });
 
+Deno.test("should set the globals of the dev shims when testing", async () => {
+  await runTest("dev_shim_globals_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    typeCheck: "both",
+    shims: {
+      ...getAllShimOptions(false),
+      deno: { test: "dev" },
+      prompts: "dev",
+      customDev: [{
+        module: "node:buffer",
+        globalNames: ["Blob"],
+      }],
+    },
+    package: {
+      name: "dev-shim-globals-project",
+      version: "1.0.0",
+    },
+  }, (output) => {
+    // the shims should only be dev dependencies
+    assertEquals(output.packageJson.dependencies, undefined);
+    assertEquals(output.packageJson.devDependencies, {
+      "@deno/shim-deno-test": versions.denoTestShim,
+      "@deno/shim-prompts": versions.promptsShim,
+      "@types/node": versions.nodeTypes,
+      "picocolors": versions.picocolors,
+    });
+
+    // the code being tested should not be transformed
+    output.assertNotExists("esm/_dnt.shims.js");
+    assertStringIncludes(
+      output.getFileText("esm/mod.js"),
+      "name in globalThis",
+    );
+
+    const testRunnerText = output.getFileText("test_runner.cjs");
+    assertStringIncludes(testRunnerText, `await import("@deno/shim-prompts")`);
+    assertStringIncludes(
+      testRunnerText,
+      `defineGlobal("confirm", shim0.confirm)`,
+    );
+    assertStringIncludes(testRunnerText, `await import("node:buffer")`);
+    assertStringIncludes(testRunnerText, `defineGlobal("Blob", shim1.Blob)`);
+    // the `Deno` namespace should never be set as a global
+    assertEquals(testRunnerText.includes(`"Deno"`), false);
+  });
+});
+
 Deno.test("should build and type check node types project", async () => {
   await runTest("node_types_project", {
     scriptModule: false,
@@ -1309,6 +1357,7 @@ async function runTest(
   project:
     | "bin_shebang_project"
     | "declaration_import_project"
+    | "dev_shim_globals_project"
     | "import_map_project"
     | "json_module_project"
     | "jsr_project"

--- a/transform.ts
+++ b/transform.ts
@@ -8,7 +8,7 @@
 
 import * as wasm from "./lib/pkg/dnt_wasm.js";
 import type { ScriptTarget } from "./lib/types.ts";
-import { valueToUrl } from "./lib/utils.ts";
+import { isPathOrUrl, valueToUrl } from "./lib/utils.ts";
 
 /** Specifier to specifier mappings. */
 export interface SpecifierMappings {
@@ -212,12 +212,4 @@ function resolveBareSpecifierOrPath(value: string) {
   } else {
     return value;
   }
-}
-
-function isPathOrUrl(value: string) {
-  value = value.trim();
-  return /^[a-z]+:\/\//i.test(value) || // has scheme
-    value.startsWith("./") ||
-    value.startsWith("../") ||
-    /\.[a-z]+$/i.test(value); // has extension
 }


### PR DESCRIPTION
Closes #181

Dev shims are only applied to the *test* modules — the code being tested is emitted untouched, so a global like `Headers` or `crypto` genuinely doesn't exist when the tests run on Node.js. That makes it impossible to shim a global for the tests without also shipping the shim to npm, which is what #181 asks for (the workaround today is running two separate builds).

Now `"dev"` (and `customDev`) does both: the test code is transformed as before, and the test runner additionally sets the shim's globals on `globalThis` before loading any test file. So #181 becomes `shims: { undici: "dev" }`.

`test_runner.cjs` gets a prelude that runs as the first statement of `main()`, which covers both the `script/` and `esm/` passes since it's the same process:

```js
async function setUpGlobals() {
  const shim0 = await import("undici");
  defineGlobal("Headers", shim0.Headers);

  function defineGlobal(name, value) {
    // some globals are defined as getters on globalThis (ex. `crypto`),
    // so a plain assignment would not work here
    Object.defineProperty(globalThis, name, {
      value,
      writable: true,
      enumerable: false,
      configurable: true,
    });
  }
}
```

It uses `await import()` rather than `require` so ESM-only shim packages work (`ts.transpile` leaves dynamic import intact). Type-only global names are skipped and `exportName` is honoured. No changes to the Rust side or to the generated package.json — the shim packages are already dev dependencies via the transform's test dependencies.

Two exclusions, both of which the existing test suite caught:

- **The `Deno` namespace is never set as a global.** `tests/module_mappings_project` uses `which_runtime`'s `isDeno`, and setting `globalThis.Deno` made it take the Deno branch inside the Node tests. `typeof Deno !== "undefined"` is the standard runtime check, so setting it would silently flip that for everyone using `deno: "dev"`.
- **Local and remote shims are skipped**, since the test runner has no way of resolving a graph module to an output file. `tests/shim_project` has `module: "ArrayBuffer.ts"` — a local module with no `./` prefix — so the check reuses dnt's own `isPathOrUrl`, moved from `transform.ts` to `lib/utils.ts` so both use the same rule. Those shims behave exactly as before.

Note that with `"dev"` the code being tested is still untransformed, so its bare `Headers`/`crypto` references need types from `compilerOptions.lib` or `@types/node` — the shim packages export named types rather than globals.

### Testing

New `tests/dev_shim_globals_project` builds with `prompts: "dev"` plus a `customDev` `node:buffer` shim. Its library module — which is not transformed — reports which of `alert`, `confirm` and `prompt` exist, and the tests assert all three do. Node has none of them natively, so this only passes if the globals came from the shim. Plus unit tests in `get_test_runner_code.test.ts` for the generated code, the `Deno` exclusion, and local/remote skipping.
