### PR TITLE
feat: add `testPreloadModule` build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,33 @@ await build({
 });
 ```
 
+### Test Preload Module
+
+Specify a module to load before running the tests with the `testPreloadModule`
+build option:
+
+```ts
+await build({
+  // ...etc...
+  testPreloadModule: "./scripts/test_preload.ts",
+});
+```
+
+This is useful for setting up the Node.js environment the tests run in without
+affecting the distributed code. For example, when the distributed code assumes a
+global exists that Node.js doesn't have:
+
+```ts
+// scripts/test_preload.ts
+import { Headers, Response } from "npm:undici";
+
+Object.assign(globalThis, { Headers, Response });
+```
+
+The module is transformed and type checked like the test files are and it is not
+included in the npm package. It is loaded once for each of the emitted script
+and ESM output, before any test file.
+
 ### Shims
 
 dnt will shim the globals specified in the build options. For example, if you

--- a/lib/npm_ignore.ts
+++ b/lib/npm_ignore.ts
@@ -2,6 +2,7 @@
 
 import type { OutputFile } from "../transform.ts";
 import type { SourceMapOptions } from "./compiler.ts";
+import { toDtsFilePath, toJsFilePath } from "./utils.ts";
 
 export function getNpmIgnoreText(options: {
   sourceMap?: SourceMapOptions;
@@ -26,8 +27,8 @@ export function getNpmIgnoreText(options: {
 
   function* getTestFileNames() {
     for (const file of options.testFiles) {
-      const filePath = file.filePath.replace(/\.ts$/i, ".js");
-      const dtsFilePath = file.filePath.replace(/\.ts$/i, ".d.ts");
+      const filePath = toJsFilePath(file.filePath);
+      const dtsFilePath = toDtsFilePath(file.filePath);
       if (options.includeEsModule) {
         const esmFilePath = `/esm/${filePath}`;
         yield esmFilePath;

--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -3,7 +3,7 @@
 import type { EntryPoint, ShimOptions } from "../mod.ts";
 import type { TransformOutput } from "../transform.ts";
 import type { PackageJson } from "./types.ts";
-import { getDntVersion } from "./utils.ts";
+import { getDntVersion, toDtsFilePath, toJsFilePath } from "./utils.ts";
 
 export interface GetPackageJsonOptions {
   transformOutput: TransformOutput;
@@ -32,8 +32,8 @@ export function getPackageJson({
     .main.entryPoints.map((e, i) => ({
       name: entryPoints[i].name,
       kind: entryPoints[i].kind ?? "export",
-      path: e.replace(/\.tsx?$/i, ".js"),
-      types: e.replace(/\.tsx?$/i, ".d.ts"),
+      path: toJsFilePath(e),
+      types: toDtsFilePath(e),
     }));
   const exports = finalEntryPoints.filter((e) => e.kind === "export");
   const binaries = finalEntryPoints.filter((e) => e.kind === "bin");

--- a/lib/test_runner/get_test_runner_code.test.ts
+++ b/lib/test_runner/get_test_runner_code.test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { getTestRunnerCode } from "./get_test_runner_code.ts";
 import { runTestDefinitions } from "./test_runner.ts";
 
@@ -205,6 +205,73 @@ async function main() {
 main();
 `,
   );
+});
+
+Deno.test("gets code when a preload module is used without esm", () => {
+  const code = getTestRunnerCode({
+    testEntryPoints: ["./test.ts"],
+    denoTestShimPackageName: undefined,
+    preloadEntryPoint: "test_preload.ts",
+    includeEsModule: false,
+    includeScriptModule: true,
+  });
+  assertEquals(
+    code,
+    `const pc = require("picocolors");
+const process = require("process");
+
+const filePaths = [
+  "./test.js",
+];
+
+async function main() {
+  process.chdir(__dirname + "/script");
+  try {
+    require("./script/test_preload.js");
+  } catch(err) {
+    console.error(err);
+    process.exit(1);
+  }
+
+  for (const [i, filePath] of filePaths.entries()) {
+    if (i > 0) {
+      console.log("");
+    }
+
+    const scriptPath = "./script/" + filePath;
+    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    process.chdir(__dirname + "/script");
+    try {
+      require(scriptPath);
+    } catch(err) {
+      console.error(err);
+      process.exit(1);
+    }
+  }
+}
+
+main();
+`,
+  );
+});
+
+Deno.test("gets code for jsx and tsx entry points", () => {
+  const code = getTestRunnerCode({
+    testEntryPoints: ["./test.tsx", "./other.jsx", "./final.js"],
+    denoTestShimPackageName: undefined,
+    preloadEntryPoint: "test_preload.tsx",
+    includeEsModule: true,
+    includeScriptModule: false,
+  });
+  assertStringIncludes(
+    code,
+    `const filePaths = [
+  "./test.js",
+  "./other.js",
+  "./final.js",
+];`,
+  );
+  assertStringIncludes(code, `await import("./esm/test_preload.js");`);
 });
 
 Deno.test("gets code when cjs is not used", () => {

--- a/lib/test_runner/get_test_runner_code.test.ts
+++ b/lib/test_runner/get_test_runner_code.test.ts
@@ -114,6 +114,99 @@ main();
   );
 });
 
+Deno.test("gets code when a preload module is used", () => {
+  const code = getTestRunnerCode({
+    testEntryPoints: ["./test.ts"],
+    denoTestShimPackageName: undefined,
+    preloadEntryPoint: "scripts/test_preload.ts",
+    includeEsModule: true,
+    includeScriptModule: true,
+  });
+  assertEquals(
+    code,
+    `const pc = require("picocolors");
+const process = require("process");
+
+const filePaths = [
+  "./test.js",
+];
+
+async function main() {
+  process.chdir(__dirname + "/script");
+  try {
+    require("./script/scripts/test_preload.js");
+  } catch(err) {
+    console.error(err);
+    process.exit(1);
+  }
+  process.chdir(__dirname + "/esm");
+  await import("./esm/scripts/test_preload.js");
+
+  for (const [i, filePath] of filePaths.entries()) {
+    if (i > 0) {
+      console.log("");
+    }
+
+    const scriptPath = "./script/" + filePath;
+    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    process.chdir(__dirname + "/script");
+    try {
+      require(scriptPath);
+    } catch(err) {
+      console.error(err);
+      process.exit(1);
+    }
+
+    const esmPath = "./esm/" + filePath;
+    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    process.chdir(__dirname + "/esm");
+    await import(esmPath);
+  }
+}
+
+main();
+`,
+  );
+});
+
+Deno.test("gets code when a preload module is used without cjs", () => {
+  const code = getTestRunnerCode({
+    testEntryPoints: ["./test.ts"],
+    denoTestShimPackageName: undefined,
+    preloadEntryPoint: "test_preload.ts",
+    includeEsModule: true,
+    includeScriptModule: false,
+  });
+  assertEquals(
+    code,
+    `const pc = require("picocolors");
+const process = require("process");
+
+const filePaths = [
+  "./test.js",
+];
+
+async function main() {
+  process.chdir(__dirname + "/esm");
+  await import("./esm/test_preload.js");
+
+  for (const [i, filePath] of filePaths.entries()) {
+    if (i > 0) {
+      console.log("");
+    }
+
+    const esmPath = "./esm/" + filePath;
+    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    process.chdir(__dirname + "/esm");
+    await import(esmPath);
+  }
+}
+
+main();
+`,
+  );
+});
+
 Deno.test("gets code when cjs is not used", () => {
   const code = getTestRunnerCode({
     testEntryPoints: ["./test.ts"],

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -8,8 +8,10 @@ export function getTestRunnerCode(options: {
   denoTestShimPackageName: string | undefined;
   includeEsModule: boolean | undefined;
   includeScriptModule: boolean | undefined;
+  preloadEntryPoint?: string;
 }) {
   const usesDenoTest = options.denoTestShimPackageName != null;
+  const preloadPath = options.preloadEntryPoint?.replace(/\.ts$/, ".js");
   const writer = createWriter();
   writer.writeLine(`const pc = require("picocolors");`)
     .writeLine(`const process = require("process");`);
@@ -30,6 +32,22 @@ export function getTestRunnerCode(options: {
   writer.writeLine("];").newLine();
 
   writer.write("async function main()").block(() => {
+    if (preloadPath != null) {
+      if (options.includeScriptModule) {
+        writer.writeLine(`process.chdir(__dirname + "/script");`);
+        writer.write("try ").inlineBlock(() => {
+          writer.writeLine(`require("./script/${preloadPath}");`);
+        }).write(" catch(err)").block(() => {
+          writer.writeLine("console.error(err);");
+          writer.writeLine("process.exit(1);");
+        });
+      }
+      if (options.includeEsModule) {
+        writer.writeLine(`process.chdir(__dirname + "/esm");`);
+        writer.writeLine(`await import("./esm/${preloadPath}");`);
+      }
+      writer.blankLine();
+    }
     if (usesDenoTest) {
       writer.write("const testContext = ").inlineBlock(() => {
         writer.writeLine("process,");

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
 import CodeBlockWriter from "code-block-writer";
+import { toJsFilePath } from "../utils.ts";
 import { runTestDefinitions } from "./test_runner.ts";
 
 export function getTestRunnerCode(options: {
@@ -11,7 +12,9 @@ export function getTestRunnerCode(options: {
   preloadEntryPoint?: string;
 }) {
   const usesDenoTest = options.denoTestShimPackageName != null;
-  const preloadPath = options.preloadEntryPoint?.replace(/\.ts$/, ".js");
+  const preloadPath = options.preloadEntryPoint == null
+    ? undefined
+    : toJsFilePath(options.preloadEntryPoint);
   const writer = createWriter();
   writer.writeLine(`const pc = require("picocolors");`)
     .writeLine(`const process = require("process");`);
@@ -26,7 +29,7 @@ export function getTestRunnerCode(options: {
   writer.writeLine("const filePaths = [");
   writer.indent(() => {
     for (const entryPoint of options.testEntryPoints) {
-      writer.quote(entryPoint.replace(/\.ts$/, ".js")).write(",").newLine();
+      writer.quote(toJsFilePath(entryPoint)).write(",").newLine();
     }
   });
   writer.writeLine("];").newLine();
@@ -36,7 +39,8 @@ export function getTestRunnerCode(options: {
       if (options.includeScriptModule) {
         writer.writeLine(`process.chdir(__dirname + "/script");`);
         writer.write("try ").inlineBlock(() => {
-          writer.writeLine(`require("./script/${preloadPath}");`);
+          writer.write("require(").quote(`./script/${preloadPath}`).write(");")
+            .newLine();
         }).write(" catch(err)").block(() => {
           writer.writeLine("console.error(err);");
           writer.writeLine("process.exit(1);");
@@ -44,7 +48,8 @@ export function getTestRunnerCode(options: {
       }
       if (options.includeEsModule) {
         writer.writeLine(`process.chdir(__dirname + "/esm");`);
-        writer.writeLine(`await import("./esm/${preloadPath}");`);
+        writer.write("await import(").quote(`./esm/${preloadPath}`).write(");")
+          .newLine();
       }
       writer.blankLine();
     }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -3,6 +3,22 @@
 import { expandGlob } from "@std/fs/expand-glob";
 import * as path from "@std/path";
 
+/** Gets the path of the JavaScript file the TypeScript compiler emits
+ * for the provided output file path. */
+export function toJsFilePath(filePath: string): string {
+  return filePath.replace(COMPILED_EXT_RE, ".js");
+}
+
+/** Gets the path of the declaration file the TypeScript compiler emits
+ * for the provided output file path. */
+export function toDtsFilePath(filePath: string): string {
+  return filePath.replace(COMPILED_EXT_RE, ".d.ts");
+}
+
+// extensions of the transform's output files that the TypeScript compiler
+// emits as `.js` files (the transform already outputs `.mts` and `.mjs` as `.js`)
+const COMPILED_EXT_RE = /\.(?:ts|tsx|jsx)$/i;
+
 /** Gets the files found in the provided root dir path based on the glob. */
 export async function glob(options: {
   pattern: string;

--- a/mod.ts
+++ b/mod.ts
@@ -100,6 +100,16 @@ export interface BuildOptions {
   rootTestDir?: string;
   /** Glob pattern to use to find tests files. Defaults to `deno test`'s pattern. */
   testPattern?: string;
+  /** Path to a module to load before running the tests. Ex. `./scripts/test_preload.ts`
+   *
+   * This is useful for setting up the Node.js environment the tests run in
+   * without affecting the distributed code. For example, setting globals that
+   * the distributed code assumes exist.
+   *
+   * @remarks The module is not included in the npm package. It is loaded once
+   * for each of the emitted script and ESM output.
+   */
+  testPreloadModule?: string;
   /**
    * Specifiers to map from and to.
    *
@@ -253,6 +263,9 @@ export async function build(options: BuildOptions): Promise<void> {
       };
     }
   });
+  const testPreloadModule = options.testPreloadModule == null
+    ? undefined
+    : standardizePath(options.testPreloadModule);
 
   await Deno.permissions.request({ name: "write", path: options.outDir });
 
@@ -616,13 +629,7 @@ export async function build(options: BuildOptions): Promise<void> {
     const { shims, testShims } = shimOptionsToTransformShims(options.shims);
     return transform({
       entryPoints: entryPoints.map((e) => e.path),
-      testEntryPoints: options.test
-        ? await glob({
-          pattern: getTestPattern(),
-          rootDir: options.rootTestDir ?? Deno.cwd(),
-          excludeDirs: [options.outDir],
-        })
-        : [],
+      testEntryPoints: options.test ? await getTestEntryPoints() : [],
       shims,
       testShims,
       mappings: options.mappings,
@@ -631,6 +638,23 @@ export async function build(options: BuildOptions): Promise<void> {
       configFile: options.configFile,
       cwd: path.toFileUrl(cwd).toString(),
     });
+  }
+
+  async function getTestEntryPoints() {
+    const filePaths = await glob({
+      pattern: getTestPattern(),
+      rootDir: options.rootTestDir ?? Deno.cwd(),
+      excludeDirs: [options.outDir],
+    });
+    if (testPreloadModule == null) {
+      return filePaths;
+    }
+    // keep the preload module first so that its output path is
+    // known when creating the test launcher script
+    return [
+      testPreloadModule,
+      ...filePaths.filter((filePath) => filePath !== testPreloadModule),
+    ];
   }
 
   function log(message: string) {
@@ -644,6 +668,7 @@ export async function build(options: BuildOptions): Promise<void> {
   function createTestLauncherScript() {
     const denoTestShimPackage = getDependencyByName("@deno/shim-deno-test") ??
       getDependencyByName("@deno/shim-deno");
+    const testEntryPoints = transformOutput.test.entryPoints;
     writeFile(
       path.join(options.outDir, "test_runner.cjs"),
       transformCodeToTarget(
@@ -653,7 +678,12 @@ export async function build(options: BuildOptions): Promise<void> {
             : denoTestShimPackage.name === "@deno/shim-deno"
             ? "@deno/shim-deno/test-internals"
             : denoTestShimPackage.name,
-          testEntryPoints: transformOutput.test.entryPoints,
+          preloadEntryPoint: testPreloadModule == null
+            ? undefined
+            : testEntryPoints[0],
+          testEntryPoints: testPreloadModule == null
+            ? testEntryPoints
+            : testEntryPoints.slice(1),
           includeEsModule: options.esModule !== false,
           includeScriptModule: options.scriptModule !== false,
         }),

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1088,6 +1088,45 @@ Deno.test("should build undici project", async () => {
   });
 });
 
+Deno.test("should run the test preload module", async () => {
+  await runTest("test_preload_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    typeCheck: "both",
+    shims: {
+      ...getAllShimOptions(false),
+      deno: { test: "dev" },
+    },
+    testPreloadModule: "./scripts/test_preload.ts",
+    package: {
+      name: "test-preload-project",
+      version: "1.0.0",
+    },
+  }, (output) => {
+    // the preload module should be emitted, but not distributed
+    output.assertExists("esm/scripts/test_preload.js");
+    output.assertExists("script/scripts/test_preload.js");
+    assertStringIncludes(output.npmIgnore, "/esm/scripts/test_preload.js\n");
+    assertStringIncludes(output.npmIgnore, "/script/scripts/test_preload.js\n");
+
+    // it should be loaded once for each output, before any test file
+    const testRunnerText = output.getFileText("test_runner.cjs");
+    assertStringIncludes(
+      testRunnerText,
+      `require("./script/scripts/test_preload.js");`,
+    );
+    assertStringIncludes(
+      testRunnerText,
+      `await import("./esm/scripts/test_preload.js");`,
+    );
+    // it should not be run as a test file
+    assertEquals(
+      testRunnerText.includes(`"./scripts/test_preload.js",`),
+      false,
+    );
+  });
+});
+
 Deno.test("should build and type check node types project", async () => {
   await runTest("node_types_project", {
     scriptModule: false,
@@ -1321,6 +1360,7 @@ async function runTest(
     | "node_types_project"
     | "undici_project"
     | "shim_project"
+    | "test_preload_project"
     | "test_project"
     | "tla_project"
     | "web_socket_project"

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1103,27 +1103,29 @@ Deno.test("should run the test preload module", async () => {
       version: "1.0.0",
     },
   }, (output) => {
-    // the preload module should be emitted, but not distributed
-    output.assertExists("esm/scripts/test_preload.js");
-    output.assertExists("script/scripts/test_preload.js");
-    assertStringIncludes(output.npmIgnore, "/esm/scripts/test_preload.js\n");
-    assertStringIncludes(output.npmIgnore, "/script/scripts/test_preload.js\n");
+    assertPreloadModuleOutput(output);
+  });
+});
 
-    // it should be loaded once for each output, before any test file
-    const testRunnerText = output.getFileText("test_runner.cjs");
-    assertStringIncludes(
-      testRunnerText,
-      `require("./script/scripts/test_preload.js");`,
-    );
-    assertStringIncludes(
-      testRunnerText,
-      `await import("./esm/scripts/test_preload.js");`,
-    );
-    // it should not be run as a test file
-    assertEquals(
-      testRunnerText.includes(`"./scripts/test_preload.js",`),
-      false,
-    );
+Deno.test("should run the test preload module when it matches the test pattern", async () => {
+  await runTest("test_preload_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    typeCheck: false,
+    shims: {
+      ...getAllShimOptions(false),
+      deno: { test: "dev" },
+    },
+    // this matches the preload module as well, so it should not be
+    // collected as a test file twice
+    testPattern: "**/{*.test.ts,test_preload.ts}",
+    testPreloadModule: "./scripts/test_preload.ts",
+    package: {
+      name: "test-preload-project",
+      version: "1.0.0",
+    },
+  }, (output) => {
+    assertPreloadModuleOutput(output);
   });
 });
 
@@ -1416,6 +1418,30 @@ async function runTest(
       }
     }
   }
+}
+
+function assertPreloadModuleOutput(output: Output) {
+  // the preload module should be emitted, but not distributed
+  output.assertExists("esm/scripts/test_preload.js");
+  output.assertExists("script/scripts/test_preload.js");
+  assertStringIncludes(output.npmIgnore, "/esm/scripts/test_preload.js\n");
+  assertStringIncludes(output.npmIgnore, "/script/scripts/test_preload.js\n");
+
+  // it should be loaded once for each output, before any test file
+  const testRunnerText = output.getFileText("test_runner.cjs");
+  assertStringIncludes(
+    testRunnerText,
+    `require("./script/scripts/test_preload.js");`,
+  );
+  assertStringIncludes(
+    testRunnerText,
+    `await import("./esm/scripts/test_preload.js");`,
+  );
+
+  // it should not be run as a test file
+  const filePaths = /const filePaths = \[([^\]]*)\]/.exec(testRunnerText)![1];
+  assertStringIncludes(filePaths, "mod.test.js");
+  assertEquals(filePaths.includes("test_preload"), false);
 }
 
 function getAllShimOptions(value: ShimValue): ShimOptions {

--- a/tests/test_preload_project/mod.test.ts
+++ b/tests/test_preload_project/mod.test.ts
@@ -1,0 +1,11 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { getExistingGlobalNames } from "./mod.ts";
+import { assertEquals } from "https://deno.land/std@0.181.0/testing/asserts.ts";
+
+Deno.test("should have the globals set by the preload module", () => {
+  assertEquals(
+    getExistingGlobalNames(["Blob", "alert"]),
+    ["Blob", "alert"],
+  );
+});

--- a/tests/test_preload_project/mod.ts
+++ b/tests/test_preload_project/mod.ts
@@ -1,0 +1,13 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+/** Gets which of the provided names exist on `globalThis`.
+ *
+ * @remarks This module is distributed to npm as-is. The globals it uses are
+ * expected to exist, which the test preload module ensures when testing.
+ */
+export function getExistingGlobalNames(names: string[]) {
+  return names.filter((name) =>
+    // dnt-shim-ignore
+    name in globalThis
+  );
+}

--- a/tests/test_preload_project/scripts/test_preload.ts
+++ b/tests/test_preload_project/scripts/test_preload.ts
@@ -1,0 +1,10 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { Blob } from "node:buffer";
+
+// node does not have an `alert` global, so this shows the preload
+// module ran before the code being tested
+Object.assign(globalThis, {
+  Blob,
+  alert() {},
+});


### PR DESCRIPTION
Closes #181

Adds the ability to specify a module to load before running the tests:

```ts
await build({
  // ...etc...
  testPreloadModule: "./scripts/test_preload.ts",
});
```

This allows setting up the Node.js environment the tests run in without affecting the distributed code. For #181, where the distributed code should assume a global exists but it needs to be present when testing on Node.js:

```ts
// scripts/test_preload.ts
import { Headers, Response } from "npm:undici";

Object.assign(globalThis, { Headers, Response });
```

Previously this needed two separate builds, since dev shims only transform the test code — the code being tested is emitted untouched, so a global it uses doesn't exist when running on Node.js.

The module is added to the test entry points, so it's transformed, type checked and `.npmignore`d exactly like the test files are, and its dependencies land in `devDependencies`. It's the counterpart to `postBuild`, which runs in the Deno process rather than the Node.js one.

The test runner loads it once for each of the emitted script and ESM output, before any test file:

```js
async function main() {
  process.chdir(__dirname + "/script");
  try {
    require("./script/scripts/test_preload.js");
  } catch(err) {
    console.error(err);
    process.exit(1);
  }
  process.chdir(__dirname + "/esm");
  await import("./esm/scripts/test_preload.js");

  for (const [i, filePath] of filePaths.entries()) {
    // ...etc...
  }
}
```

So a preload with side effects beyond setting up the environment will see them happen twice — once per module system. This seemed better than picking one of the two builds arbitrarily, since each pass then preloads the same output it's testing.

### Testing

New `tests/test_preload_project` has a preload module that sets globals Node.js doesn't otherwise have, and a test asserting the code being tested — which is untransformed — sees them. It also checks the preload is emitted to both outputs, is in the `.npmignore`, and isn't run as a test file. Plus unit tests for the generated runner code with and without the script output.
