### PR TITLE
feat: add `polyfills` build option to enable or disable polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,46 @@ The module is transformed and type checked like the test files are and it is not
 included in the npm package. It is loaded once for each of the emitted script
 and ESM output, before any test file.
 
+### Polyfills
+
+dnt adds polyfills for language features that may not exist in the environment
+implied by `compilerOptions.target`. If you're targeting a runtime that already
+supports a feature, use the `polyfills` build option to opt out and keep the
+extra code out of your package:
+
+```ts
+await build({
+  // ...etc...
+  polyfills: {
+    importMeta: false,
+  },
+});
+```
+
+Pass `true` or `false` instead of an object to enable or disable every polyfill
+at once. Anything you don't specify continues to be decided by the target, so
+`polyfills` overrides the target rather than replacing it.
+
+The supported names are `arrayFindLast`, `arrayFromAsync`, `errorCause`,
+`importMeta`, `objectHasOwn`, `promiseWithResolvers`, and `stringReplaceAll`.
+
+Note that the polyfills also provide the type declarations for the features they
+polyfill, so opting out of one means relying on your `compilerOptions.lib`
+declarations for it instead.
+
+The `importMeta` polyfill can only be disabled when the `scriptModule` build
+option is `false`, because `import.meta` is not valid CommonJS:
+
+```ts
+await build({
+  // ...etc...
+  scriptModule: false,
+  polyfills: {
+    importMeta: false,
+  },
+});
+```
+
 ### Shims
 
 dnt will shim the globals specified in the build options. For example, if you

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -51,6 +51,7 @@
     "tests/node_types_project/npm",
     "tests/package_mappings_project/npm",
     "tests/polyfill_array_find_last_project/npm",
+    "tests/polyfill_disabled_project/npm",
     "tests/polyfill_project/npm",
     "tests/shim_project/npm",
     "tests/test_project/npm",

--- a/lib/polyfills.test.ts
+++ b/lib/polyfills.test.ts
@@ -1,0 +1,114 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  resolvePolyfillOptions,
+  resolveUseImportMetaPolyfill,
+} from "./polyfills.ts";
+
+Deno.test("resolvePolyfillOptions - undefined leaves everything to the target", () => {
+  assertEquals(resolvePolyfillOptions(undefined), {});
+});
+
+Deno.test("resolvePolyfillOptions - boolean applies to every polyfill", () => {
+  assertEquals(resolvePolyfillOptions(false), {
+    arrayFindLast: false,
+    arrayFromAsync: false,
+    errorCause: false,
+    importMeta: false,
+    objectHasOwn: false,
+    promiseWithResolvers: false,
+    stringReplaceAll: false,
+  });
+  assertEquals(
+    Object.values(resolvePolyfillOptions(true)).every((v) => v),
+    true,
+  );
+});
+
+Deno.test("resolvePolyfillOptions - object only includes what's specified", () => {
+  assertEquals(
+    resolvePolyfillOptions({ importMeta: false, errorCause: true }),
+    { importMeta: false, errorCause: true },
+  );
+});
+
+Deno.test("resolvePolyfillOptions - undefined values fall back to the target", () => {
+  assertEquals(
+    resolvePolyfillOptions({ importMeta: undefined, errorCause: true }),
+    { errorCause: true },
+  );
+});
+
+Deno.test("resolvePolyfillOptions - throws for an unknown polyfill", () => {
+  assertThrows(
+    () =>
+      resolvePolyfillOptions(
+        { importMata: false } as Record<string, boolean>,
+      ),
+    Error,
+    "Unknown polyfill 'importMata'",
+  );
+});
+
+Deno.test("resolveUseImportMetaPolyfill - required when emitting a script module", () => {
+  assertEquals(
+    resolveUseImportMetaPolyfill({
+      polyfills: {},
+      target: "Latest",
+      emitScriptModule: true,
+    }),
+    true,
+  );
+});
+
+Deno.test("resolveUseImportMetaPolyfill - throws when disabled with a script module", () => {
+  assertThrows(
+    () =>
+      resolveUseImportMetaPolyfill({
+        polyfills: { importMeta: false },
+        target: "ES2021",
+        emitScriptModule: true,
+      }),
+    Error,
+    "cannot be disabled when emitting a script module",
+  );
+});
+
+Deno.test("resolveUseImportMetaPolyfill - esm only follows the target by default", () => {
+  assertEquals(
+    resolveUseImportMetaPolyfill({
+      polyfills: {},
+      target: "ES2021",
+      emitScriptModule: false,
+    }),
+    true,
+  );
+  assertEquals(
+    resolveUseImportMetaPolyfill({
+      polyfills: {},
+      target: "Latest",
+      emitScriptModule: false,
+    }),
+    false,
+  );
+});
+
+Deno.test("resolveUseImportMetaPolyfill - esm only respects an explicit override", () => {
+  assertEquals(
+    resolveUseImportMetaPolyfill({
+      polyfills: { importMeta: false },
+      target: "ES2021",
+      emitScriptModule: false,
+    }),
+    false,
+  );
+  assertEquals(
+    resolveUseImportMetaPolyfill({
+      polyfills: { importMeta: true },
+      target: "Latest",
+      emitScriptModule: false,
+    }),
+    true,
+  );
+});

--- a/lib/polyfills.ts
+++ b/lib/polyfills.ts
@@ -1,0 +1,71 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import type { PolyfillName, PolyfillOptions, ScriptTarget } from "./types.ts";
+
+/** Every polyfill dnt knows how to apply. */
+export const polyfillNames: readonly PolyfillName[] = [
+  "arrayFindLast",
+  "arrayFromAsync",
+  "errorCause",
+  "importMeta",
+  "objectHasOwn",
+  "promiseWithResolvers",
+  "stringReplaceAll",
+];
+
+/** Resolves the user provided polyfill options into an explicit
+ * enabled/disabled value per polyfill.
+ *
+ * Polyfills that the user didn't specify are left out of the result so that
+ * the script target continues to decide whether they're used.
+ */
+export function resolvePolyfillOptions(
+  options: PolyfillOptions | undefined,
+): Record<string, boolean> {
+  if (options == null) {
+    return {};
+  }
+  if (typeof options === "boolean") {
+    return Object.fromEntries(polyfillNames.map((name) => [name, options]));
+  }
+
+  const resolved: Record<string, boolean> = {};
+  for (const [name, enabled] of Object.entries(options)) {
+    if (enabled == null) {
+      continue;
+    }
+    if (!polyfillNames.includes(name as PolyfillName)) {
+      throw new Error(
+        `Unknown polyfill '${name}' specified in the 'polyfills' option. ` +
+          `Supported polyfills: ${polyfillNames.join(", ")}`,
+      );
+    }
+    resolved[name] = enabled;
+  }
+  return resolved;
+}
+
+/** Whether the `import.meta` polyfill applies, given the resolved polyfill
+ * overrides and the rest of the build options.
+ *
+ * `import.meta` is a syntax error in CommonJS, so the polyfill is required
+ * whenever a script module is emitted regardless of the target.
+ */
+export function resolveUseImportMetaPolyfill(options: {
+  polyfills: Record<string, boolean>;
+  target: ScriptTarget;
+  emitScriptModule: boolean;
+}): boolean {
+  const explicit = options.polyfills["importMeta"];
+  if (options.emitScriptModule) {
+    if (explicit === false) {
+      throw new Error(
+        "The 'importMeta' polyfill cannot be disabled when emitting a script " +
+          "module because `import.meta` is not valid CommonJS. Set the " +
+          "'scriptModule' build option to false to distribute an ES module only.",
+      );
+    }
+    return true;
+  }
+  return explicit ?? options.target !== "Latest";
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,6 +52,30 @@ export interface PackageJson {
   [propertyName: string]: any;
 }
 
+// NOTICE: make sure to update the `name` of each polyfill in the rust code
+// when changing the names on this
+// todo(dsherret): code generate this from the Rust code to prevent out of sync issues
+
+/** Name of a polyfill that dnt may add to the output. */
+export type PolyfillName =
+  | "arrayFindLast"
+  | "arrayFromAsync"
+  | "errorCause"
+  | "importMeta"
+  | "objectHasOwn"
+  | "promiseWithResolvers"
+  | "stringReplaceAll";
+
+/** Explicitly enables or disables polyfills by name.
+ *
+ * Provide `true` or `false` to enable or disable all polyfills, or an object
+ * to control them individually. Polyfills that aren't specified fall back to
+ * what the script target implies.
+ */
+export type PolyfillOptions =
+  | boolean
+  | Partial<Record<PolyfillName, boolean>>;
+
 // NOTICE: make sure to update `ScriptTarget` in the rust code when changing the names on this
 // todo(dsherret): code generate this from the Rust code to prevent out of sync issues
 

--- a/mod.ts
+++ b/mod.ts
@@ -18,7 +18,15 @@ import {
 } from "./lib/compiler.ts";
 import { type ShimOptions, shimOptionsToTransformShims } from "./lib/shims.ts";
 import { getNpmIgnoreText } from "./lib/npm_ignore.ts";
-import type { PackageJson, ScriptTarget } from "./lib/types.ts";
+import {
+  resolvePolyfillOptions,
+  resolveUseImportMetaPolyfill,
+} from "./lib/polyfills.ts";
+import type {
+  PackageJson,
+  PolyfillOptions,
+  ScriptTarget,
+} from "./lib/types.ts";
 import { glob, runNpmCommand, standardizePath } from "./lib/utils.ts";
 import {
   type SpecifierMappings,
@@ -30,7 +38,11 @@ import { getPackageJson } from "./lib/package_json.ts";
 import { getTestRunnerCode } from "./lib/test_runner/get_test_runner_code.ts";
 
 export { emptyDir } from "@std/fs/empty-dir";
-export type { PackageJson } from "./lib/types.ts";
+export type {
+  PackageJson,
+  PolyfillName,
+  PolyfillOptions,
+} from "./lib/types.ts";
 export type { JsxEmit, LibName, SourceMapOptions } from "./lib/compiler.ts";
 export type { ShimOptions } from "./lib/shims.ts";
 
@@ -88,6 +100,20 @@ export interface BuildOptions {
    * @default true
    */
   esModule?: boolean;
+  /** Explicitly enables or disables polyfills, overriding what
+   * `compilerOptions.target` implies.
+   *
+   * Provide `true` or `false` to enable or disable all polyfills, or an object
+   * to control them individually:
+   *
+   * ```ts
+   * polyfills: { importMeta: false }
+   * ```
+   *
+   * @remarks The `importMeta` polyfill cannot be disabled unless `scriptModule`
+   * is `false`, because `import.meta` is not valid CommonJS.
+   */
+  polyfills?: PolyfillOptions;
   /** Skip running `npm install`.
    * @default false
    */
@@ -250,6 +276,14 @@ export async function build(options: BuildOptions): Promise<void> {
     (!!options.declaration && !options.skipSourceOutput);
   const packageManager = options.packageManager ?? "npm";
   const scriptTarget = options.compilerOptions?.target ?? "ES2021";
+  const polyfills = resolvePolyfillOptions(options.polyfills);
+  // `import.meta` call sites are rewritten by the TypeScript compiler rather
+  // than the transform, so resolve this up front and keep both sides in sync
+  polyfills["importMeta"] = resolveUseImportMetaPolyfill({
+    polyfills,
+    target: scriptTarget,
+    emitScriptModule: options.scriptModule !== false,
+  });
   const entryPoints: EntryPoint[] = options.entryPoints.map((e, i) => {
     if (typeof e === "string") {
       return {
@@ -433,7 +467,9 @@ export async function build(options: BuildOptions): Promise<void> {
     program = project.createProgram();
     emit({
       transformers: {
-        before: [compilerTransforms.transformImportMeta],
+        before: polyfills["importMeta"]
+          ? [compilerTransforms.transformImportMeta]
+          : [],
       },
     });
     writeFile(
@@ -458,7 +494,9 @@ export async function build(options: BuildOptions): Promise<void> {
     program = getProgramAndMaybeTypeCheck("script");
     emit({
       transformers: {
-        before: [compilerTransforms.transformImportMeta],
+        before: polyfills["importMeta"]
+          ? [compilerTransforms.transformImportMeta]
+          : [],
       },
     });
     writeFile(
@@ -634,6 +672,7 @@ export async function build(options: BuildOptions): Promise<void> {
       testShims,
       mappings: options.mappings,
       target: scriptTarget,
+      polyfills,
       importMap: options.importMap,
       configFile: options.configFile,
       cwd: path.toFileUrl(cwd).toString(),

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -43,6 +43,7 @@ use node_resolver::NodeConditionOptions;
 use polyfills::build_polyfill_file;
 use polyfills::polyfills_for_target;
 use polyfills::Polyfill;
+pub use polyfills::PolyfillOverrides;
 use specifiers::Specifiers;
 use utils::get_relative_specifier;
 use utils::prepend_statement_to_text;
@@ -256,6 +257,9 @@ pub struct TransformOptions {
   /// Version of ECMAScript that the final code will target.
   /// This controls whether certain polyfills should occur.
   pub target: ScriptTarget,
+  /// Explicitly enables or disables polyfills by name, taking precedence
+  /// over what `target` implies.
+  pub polyfills: PolyfillOverrides,
   pub config_file: Option<ModuleSpecifier>,
   pub import_map: Option<ModuleSpecifier>,
   pub cwd: PathBuf,
@@ -482,7 +486,10 @@ pub async fn transform(
       dependencies: get_dependencies(specifiers.main.mapped),
       ..Default::default()
     },
-    searching_polyfills: polyfills_for_target(options.target),
+    searching_polyfills: polyfills_for_target(
+      options.target,
+      &options.polyfills,
+    ),
     found_polyfills: Default::default(),
     shim_file_specifier: &SYNTHETIC_SPECIFIERS.shims,
     shim_global_names: options
@@ -503,7 +510,10 @@ pub async fn transform(
       dependencies: get_dependencies(specifiers.test.mapped),
       ..Default::default()
     },
-    searching_polyfills: polyfills_for_target(options.target),
+    searching_polyfills: polyfills_for_target(
+      options.target,
+      &options.polyfills,
+    ),
     found_polyfills: Default::default(),
     shim_file_specifier: &SYNTHETIC_TEST_SPECIFIERS.shims,
     shim_global_names: options

--- a/rs-lib/src/polyfills/array_find_last.rs
+++ b/rs-lib/src/polyfills/array_find_last.rs
@@ -12,6 +12,10 @@ use crate::ScriptTarget;
 pub struct ArrayFindLastPolyfill;
 
 impl Polyfill for ArrayFindLastPolyfill {
+  fn name(&self) -> &'static str {
+    "arrayFindLast"
+  }
+
   fn use_for_target(&self, _target: ScriptTarget) -> bool {
     true
   }

--- a/rs-lib/src/polyfills/array_from_async.rs
+++ b/rs-lib/src/polyfills/array_from_async.rs
@@ -9,6 +9,10 @@ use crate::ScriptTarget;
 pub struct ArrayFromAsyncPolyfill;
 
 impl Polyfill for ArrayFromAsyncPolyfill {
+  fn name(&self) -> &'static str {
+    "arrayFromAsync"
+  }
+
   fn use_for_target(&self, _target: ScriptTarget) -> bool {
     true
   }

--- a/rs-lib/src/polyfills/error_cause.rs
+++ b/rs-lib/src/polyfills/error_cause.rs
@@ -10,6 +10,10 @@ use crate::ScriptTarget;
 pub struct ErrorCausePolyfill;
 
 impl Polyfill for ErrorCausePolyfill {
+  fn name(&self) -> &'static str {
+    "errorCause"
+  }
+
   fn use_for_target(&self, _target: ScriptTarget) -> bool {
     true
   }

--- a/rs-lib/src/polyfills/import_meta.rs
+++ b/rs-lib/src/polyfills/import_meta.rs
@@ -10,6 +10,10 @@ use crate::ScriptTarget;
 pub struct ImportMetaPolyfill;
 
 impl Polyfill for ImportMetaPolyfill {
+  fn name(&self) -> &'static str {
+    "importMeta"
+  }
+
   fn use_for_target(&self, _target: ScriptTarget) -> bool {
     true
   }

--- a/rs-lib/src/polyfills/mod.rs
+++ b/rs-lib/src/polyfills/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 
 use deno_ast::swc::common::SyntaxContext;
@@ -23,6 +24,11 @@ mod promise_with_resolvers;
 mod string_replace_all;
 
 pub trait Polyfill {
+  /// Stable name used to enable or disable this polyfill explicitly.
+  ///
+  /// NOTICE: make sure to update `PolyfillName` in the TS code when
+  /// changing these names.
+  fn name(&self) -> &'static str;
   fn use_for_target(&self, target: ScriptTarget) -> bool;
   fn visit_node(
     &self,
@@ -95,14 +101,22 @@ impl PolyfillVisitContext<'_, '_> {
   }
 }
 
-pub fn polyfills_for_target(target: ScriptTarget) -> Vec<Box<dyn Polyfill>> {
-  if matches!(target, ScriptTarget::Latest) {
-    return Vec::new();
-  }
+/// Explicitly enables or disables polyfills by name, overriding what the
+/// script target implies.
+pub type PolyfillOverrides = HashMap<String, bool>;
 
+pub fn polyfills_for_target(
+  target: ScriptTarget,
+  overrides: &PolyfillOverrides,
+) -> Vec<Box<dyn Polyfill>> {
   all_polyfills()
     .into_iter()
-    .filter(|p| p.use_for_target(target))
+    .filter(|p| match overrides.get(p.name()) {
+      Some(enabled) => *enabled,
+      None => {
+        !matches!(target, ScriptTarget::Latest) && p.use_for_target(target)
+      }
+    })
     .collect()
 }
 

--- a/rs-lib/src/polyfills/object_has_own.rs
+++ b/rs-lib/src/polyfills/object_has_own.rs
@@ -9,6 +9,10 @@ use crate::ScriptTarget;
 pub struct ObjectHasOwnPolyfill;
 
 impl Polyfill for ObjectHasOwnPolyfill {
+  fn name(&self) -> &'static str {
+    "objectHasOwn"
+  }
+
   fn use_for_target(&self, _target: ScriptTarget) -> bool {
     true
   }

--- a/rs-lib/src/polyfills/promise_with_resolvers.rs
+++ b/rs-lib/src/polyfills/promise_with_resolvers.rs
@@ -9,6 +9,10 @@ use crate::ScriptTarget;
 pub struct PromiseWithResolversPolyfill;
 
 impl Polyfill for PromiseWithResolversPolyfill {
+  fn name(&self) -> &'static str {
+    "promiseWithResolvers"
+  }
+
   fn use_for_target(&self, _target: ScriptTarget) -> bool {
     // (target as u32) < (ScriptTarget::ES2021 as u32)
     true // just always use it for the time being

--- a/rs-lib/src/polyfills/string_replace_all.rs
+++ b/rs-lib/src/polyfills/string_replace_all.rs
@@ -12,6 +12,10 @@ use crate::ScriptTarget;
 pub struct StringReplaceAllPolyfill;
 
 impl Polyfill for StringReplaceAllPolyfill {
+  fn name(&self) -> &'static str {
+    "stringReplaceAll"
+  }
+
   fn use_for_target(&self, target: ScriptTarget) -> bool {
     (target as u32) < (ScriptTarget::ES2021 as u32)
   }

--- a/rs-lib/tests/integration/test_builder.rs
+++ b/rs-lib/tests/integration/test_builder.rs
@@ -9,6 +9,7 @@ use deno_node_transform::MappedSpecifier;
 use deno_node_transform::ModuleSpecifier;
 use deno_node_transform::PackageMappedSpecifier;
 use deno_node_transform::PackageShim;
+use deno_node_transform::PolyfillOverrides;
 use deno_node_transform::ScriptTarget;
 use deno_node_transform::Shim;
 use deno_node_transform::TransformOptions;
@@ -26,6 +27,7 @@ pub struct TestBuilder {
   shims: Vec<Shim>,
   test_shims: Vec<Shim>,
   target: ScriptTarget,
+  polyfills: PolyfillOverrides,
   config_file: Option<ModuleSpecifier>,
   import_map: Option<ModuleSpecifier>,
 }
@@ -45,6 +47,7 @@ impl TestBuilder {
       shims: Default::default(),
       test_shims: Default::default(),
       target: ScriptTarget::ES5,
+      polyfills: Default::default(),
       config_file: None,
       import_map: None,
     }
@@ -178,6 +181,11 @@ impl TestBuilder {
     self
   }
 
+  pub fn set_polyfill(&mut self, name: &str, enabled: bool) -> &mut Self {
+    self.polyfills.insert(name.to_string(), enabled);
+    self
+  }
+
   pub async fn transform(&self) -> Result<TransformOutput> {
     let mut entry_points =
       vec![ModuleSpecifier::parse(&self.entry_point).unwrap()];
@@ -201,6 +209,7 @@ impl TestBuilder {
         test_shims: self.test_shims.clone(),
         specifier_mappings: self.specifier_mappings.clone(),
         target: self.target,
+        polyfills: self.polyfills.clone(),
         config_file: self.config_file.clone(),
         import_map: self.import_map.clone(),
         cwd: self.loader.sys.env_current_dir().unwrap(),

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -9,6 +9,7 @@ use deno_node_transform::PackageMappedSpecifier;
 use deno_node_transform::PackageShim;
 use deno_node_transform::ScriptTarget;
 use deno_node_transform::Shim;
+use deno_node_transform::TransformOutput;
 use pretty_assertions::assert_eq;
 
 #[macro_use]
@@ -1925,6 +1926,99 @@ async fn test_string_replace_all_polyfill(
     );
   }
   assert_eq!(result.main.entry_points, &[PathBuf::from("mod.ts")]);
+}
+
+#[tokio::test]
+async fn polyfills_override_disables_for_target() {
+  // ES2020 would normally get the polyfill, but the override wins
+  let result = build_string_replace_all_polyfill_test(
+    ScriptTarget::ES2020,
+    Some(("stringReplaceAll", false)),
+  )
+  .await;
+
+  assert_files!(
+    result.main.files,
+    &[("mod.ts", "''.replaceAll('test', 'other');\n")]
+  );
+}
+
+#[tokio::test]
+async fn polyfills_override_enables_for_latest_target() {
+  // `Latest` normally excludes every polyfill, but the override wins
+  let result = build_string_replace_all_polyfill_test(
+    ScriptTarget::Latest,
+    Some(("stringReplaceAll", true)),
+  )
+  .await;
+
+  assert_files!(
+    result.main.files,
+    &[
+      (
+        "mod.ts",
+        concat!(
+          "import \"./_dnt.polyfills.js\";\n",
+          "''.replaceAll('test', 'other');\n",
+        ),
+      ),
+      (
+        "_dnt.polyfills.ts",
+        include_str!("../src/polyfills/scripts/es2021.string-replaceAll.ts")
+      ),
+    ]
+  );
+}
+
+#[tokio::test]
+async fn polyfills_override_only_affects_named_polyfill() {
+  // disabling one polyfill leaves the others resolving by target
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader.add_local_file(
+        "/mod.ts",
+        "''.replaceAll('test', 'other');\nObject.hasOwn({}, 'test');\n",
+      );
+    })
+    .set_target(ScriptTarget::ES2020)
+    .set_polyfill("stringReplaceAll", false)
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[
+      (
+        "mod.ts",
+        concat!(
+          "import \"./_dnt.polyfills.js\";\n",
+          "''.replaceAll('test', 'other');\n",
+          "Object.hasOwn({}, 'test');\n",
+        ),
+      ),
+      (
+        "_dnt.polyfills.ts",
+        include_str!("../src/polyfills/scripts/esnext.object-has-own.ts")
+      ),
+    ]
+  );
+}
+
+async fn build_string_replace_all_polyfill_test(
+  target: ScriptTarget,
+  polyfill_override: Option<(&str, bool)>,
+) -> TransformOutput {
+  let mut builder = TestBuilder::new();
+  builder
+    .with_loader(|loader| {
+      loader.add_local_file("/mod.ts", "''.replaceAll('test', 'other');\n");
+    })
+    .set_target(target);
+  if let Some((name, enabled)) = polyfill_override {
+    builder.set_polyfill(name, enabled);
+  }
+  builder.transform().await.unwrap()
 }
 
 #[tokio::test]

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -978,6 +978,69 @@ Deno.test("should build and test the import meta polyfill project", async () => 
   });
 });
 
+Deno.test("should not polyfill import.meta when disabled for an esm only build", async () => {
+  await runTest("polyfill_disabled_project", {
+    test: false,
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    scriptModule: false,
+    shims: { deno: "dev" },
+    polyfills: { importMeta: false },
+    package: {
+      name: "polyfill-disabled-project",
+      version: "0.0.0",
+    },
+  }, (output) => {
+    output.assertNotExists("esm/_dnt.polyfills.js");
+    // the call sites should be left alone rather than rewritten to a
+    // ponyfill that's no longer emitted
+    assertStringIncludes(output.getFileText("esm/mod.js"), "import.meta.url");
+  });
+});
+
+Deno.test("should error disabling the import.meta polyfill with a script module", async () => {
+  await assertRejects(
+    () =>
+      runTest("polyfill_import_meta_project", {
+        entryPoints: ["mod.ts"],
+        outDir: "./npm",
+        shims: { deno: "dev" },
+        polyfills: { importMeta: false },
+        package: {
+          name: "polyfill-import-meta-project",
+          version: "0.0.0",
+        },
+      }),
+    Error,
+    "cannot be disabled when emitting a script module",
+  );
+});
+
+Deno.test("should build the polyfill project with all polyfills disabled", async () => {
+  await runTest("polyfill_project", {
+    test: false,
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    scriptModule: false,
+    shims: {
+      ...getAllShimOptions(false),
+      deno: "dev",
+    },
+    polyfills: false,
+    compilerOptions: {
+      // the polyfills provide ambient declarations, so opting out of them
+      // means relying on the lib declarations instead
+      lib: ["ESNext"],
+    },
+    package: {
+      name: "polyfill-package",
+      version: "1.0.0",
+    },
+  }, (output) => {
+    output.assertNotExists("esm/_dnt.polyfills.js");
+  });
+});
+
 Deno.test("should build and test the array.fromAsync polyfill project", async () => {
   await runTest("polyfill_array_from_async_project", {
     entryPoints: ["mod.ts"],
@@ -1376,6 +1439,7 @@ async function runTest(
     | "polyfill_project"
     | "polyfill_array_from_async_project"
     | "polyfill_array_find_last_project"
+    | "polyfill_disabled_project"
     | "polyfill_promise_with_resolvers_project"
     | "polyfill_import_meta_project"
     | "module_mappings_project"

--- a/tests/polyfill_disabled_project/mod.ts
+++ b/tests/polyfill_disabled_project/mod.ts
@@ -1,0 +1,5 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+// `import.meta.url` is standard, so this builds without the import.meta
+// ponyfill as long as only an ES module is emitted
+export const url = import.meta.url;

--- a/transform.ts
+++ b/transform.ts
@@ -7,7 +7,7 @@
  */
 
 import * as wasm from "./lib/pkg/dnt_wasm.js";
-import type { ScriptTarget } from "./lib/types.ts";
+import type { PolyfillName, ScriptTarget } from "./lib/types.ts";
 import { valueToUrl } from "./lib/utils.ts";
 
 /** Specifier to specifier mappings. */
@@ -72,6 +72,10 @@ export interface TransformOptions {
   testShims?: Shim[];
   mappings?: SpecifierMappings;
   target: ScriptTarget;
+  /** Explicitly enables or disables polyfills by name, taking precedence
+   * over what `target` implies.
+   */
+  polyfills?: Partial<Record<PolyfillName, boolean>>;
   /// Path or url to the import map.
   importMap?: string;
   configFile?: string;
@@ -126,6 +130,7 @@ export function transform(
     shims: (options.shims ?? []).map(mapShim),
     testShims: (options.testShims ?? []).map(mapShim),
     target: options.target,
+    polyfills: options.polyfills ?? {},
     importMap: options.importMap == null
       ? undefined
       : valueToUrl(options.importMap),

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -202,6 +202,8 @@ pub struct TransformOptions {
   pub test_shims: Vec<Shim>,
   pub mappings: HashMap<ModuleSpecifier, MappedSpecifier>,
   pub target: ScriptTarget,
+  #[serde(default)]
+  pub polyfills: HashMap<String, bool>,
   pub import_map: Option<ModuleSpecifier>,
   pub config_file: Option<ModuleSpecifier>,
   pub cwd: ModuleSpecifier,
@@ -235,6 +237,7 @@ async fn transform_inner(options: JsValue) -> Result<JsValue, anyhow::Error> {
       test_shims: options.test_shims,
       specifier_mappings: options.mappings,
       target: options.target,
+      polyfills: options.polyfills,
       import_map: options.import_map,
       config_file: options.config_file,
       cwd: deno_path_util::url_to_file_path(&options.cwd)?,


### PR DESCRIPTION
Closes #471

Polyfills were previously selected entirely by `compilerOptions.target`: `Latest` disabled all of them and every other target enabled whichever ones matched. There was no way to keep a target and opt out of an individual polyfill.

This adds a `polyfills` build option that overrides the target per polyfill:

```ts
await build({
  // ...etc...
  polyfills: {
    importMeta: false,
  },
});
```

A bare `true`/`false` enables or disables all of them. Anything left unspecified still resolves from the target, so `polyfills` overrides the target rather than replacing it.

Supported names: `arrayFindLast`, `arrayFromAsync`, `errorCause`, `importMeta`, `objectHasOwn`, `promiseWithResolvers`, `stringReplaceAll`.

## The `import.meta` bug

This also fixes the runtime error reported in #471, which turned out to be a separate pre-existing bug.

The `import.meta` call sites are rewritten by a TypeScript compiler transform in `lib/compiler_transforms.ts`, not by the Rust transform, and that rewrite was never gated on the target. Setting `target: "Latest"` dropped the polyfill file (via the `Latest` early-return in `polyfills_for_target`) while still emitting `globalThis[Symbol.for("import-meta-ponyfill-esmodule")](import.meta)` calls into it — so the output threw at runtime. The rewrite is now gated on the same resolved decision as the polyfill file.

Disabling the `importMeta` polyfill requires `scriptModule: false`, since `import.meta` is a syntax error in CommonJS. It errors with an explanation rather than emitting invalid output.

## Implementation

- `Polyfill` gains `fn name(&self) -> &'static str`, and `polyfills_for_target` takes an overrides map. The `Latest` early-return moves into the filter so an explicit override can turn a polyfill back on at `Latest`; defaults are unchanged.
- `polyfills` is threaded through `TransformOptions` in `rs-lib`, `wasm`, and `transform.ts`.
- `lib/polyfills.ts` holds the option resolution and the `import.meta` decision, and errors on unknown polyfill names for JS callers (TS callers get it from the `PolyfillName` union).

## Note on types

The polyfill scripts carry the ambient `declare global` declarations for the features they polyfill, so opting out of one means relying on `compilerOptions.lib` for those declarations instead. This is documented in the README. It's worth being aware of because users will hit a type error before a runtime one — e.g. `polyfills: false` on a project using `Object.hasOwn` needs `lib: ["ESNext"]`, and `import.meta.main` is a Deno-ism that exists in no TS lib, so it stops type checking entirely with `importMeta: false`.

## Tests

- 3 Rust integration tests: override disables for a target, override enables at `Latest`, and an override affecting only the named polyfill.
- `lib/polyfills.test.ts` unit tests for option resolution and the `import.meta` decision.
- 3 integration tests: `import.meta` left intact for an ESM-only build with the polyfill off, the script-module error, and `polyfills: false` emitting no polyfill file.

`deno test -A` (111 passed), `cargo test --workspace` (83 passed), `deno fmt`/`deno lint`/`cargo fmt` all clean.
