### PR TITLE
fix: do not transform `new.target` as `import.meta`

### DIFF
--- a/lib/compiler_transforms.test.ts
+++ b/lib/compiler_transforms.test.ts
@@ -70,3 +70,17 @@ Deno.test("transform import.meta.resolve expressions in esModule", () => {
     `function test(specifier) { globalThis[Symbol.for("import-meta-ponyfill-esmodule")](import.meta).resolve(specifier); }\n`,
   );
 });
+
+Deno.test("does not transform new.target in commonjs", () => {
+  testImportReplacementsCjs(
+    "function test(...args) { return Reflect.construct(Struct, args, new.target); }",
+    `function test(...args) { return Reflect.construct(Struct, args, new.target); }\n`,
+  );
+});
+
+Deno.test("does not transform new.target in esModule", () => {
+  testImportReplacementsEsm(
+    "function test(...args) { return Reflect.construct(Struct, args, new.target); }",
+    `function test(...args) { return Reflect.construct(Struct, args, new.target); }\n`,
+  );
+});

--- a/lib/compiler_transforms.ts
+++ b/lib/compiler_transforms.ts
@@ -14,8 +14,11 @@ export const transformImportMeta: ts.TransformerFactory<ts.SourceFile> = (
   return (sourceFile) => ts.visitEachChild(sourceFile, visitNode, context);
 
   function visitNode(node: ts.Node): ts.Node {
-    // find `import.meta`
-    if (ts.isMetaProperty(node)) {
+    // find `import.meta` (not `new.target`, which is also a meta property)
+    if (
+      ts.isMetaProperty(node) &&
+      node.keywordToken === ts.SyntaxKind.ImportKeyword
+    ) {
       if (isScriptModule) {
         return getReplacementImportMetaScript();
       } else {


### PR DESCRIPTION
`ts.isMetaProperty` matches both `import.meta` and `new.target`, so `new.target` was being rewritten to the `import-meta-ponyfill-esmodule` call.

Closes #480