### PR TITLE
fix: type check failure in import.meta polyfill with newer `@types/node`

### DIFF
--- a/rs-lib/src/polyfills/scripts/deno.import-meta.ts
+++ b/rs-lib/src/polyfills/scripts/deno.import-meta.ts
@@ -185,9 +185,12 @@ export let import_meta_ponyfill_esmodule = (
               url: importMeta.url,
               require: createRequire(importMeta.url),
             };
+            // note: the parameter types must be explicitly annotated because
+            // `@types/node` also declares `ImportMeta.resolve`, which makes
+            // the contextual type an overload set that provides no inference
             importMeta.resolve = function resolve(
               specifier: string,
-              parentURL = importMeta.url,
+              parentURL: string | URL = importMeta.url,
             ) {
               return pathToFileURL(
                 (importMetaUrlRequire.url === parentURL

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -16,6 +16,7 @@ const versions = {
   undici: "^6.0.0",
   picocolors: "^1.0.0",
   nodeTypes: "^20.9.0",
+  newNodeTypes: "^22.16.3",
   tsLib: "^2.6.2",
 };
 
@@ -966,12 +967,21 @@ Deno.test("should build and test the array find last polyfill project", async ()
 Deno.test("should build and test the import meta polyfill project", async () => {
   await runTest("polyfill_import_meta_project", {
     test: true,
+    typeCheck: "both",
     entryPoints: ["mod.ts"],
     outDir: "./npm",
     shims: { deno: "dev" },
+    // see issue #472 -- `@types/node` declares `ImportMeta.resolve` in terms
+    // of the dom's `URL`, so the polyfill's own declaration must not conflict
+    compilerOptions: {
+      lib: ["ES2022", "DOM"],
+    },
     package: {
       name: "polyfill-import-meta-project",
       version: "0.0.0",
+      devDependencies: {
+        "@types/node": versions.newNodeTypes,
+      },
     },
   }, (output) => {
     output.assertExists("esm/_dnt.polyfills.js");


### PR DESCRIPTION
`@types/node` (>=22.16.3) declares `ImportMeta.resolve`, which merges with the polyfill's own declaration into an overload set. That provides no contextual type for the assigned function's parameters, so `parentURL` was inferred as `unknown` and failed to type check when passed to `createRequire`:

```
src/_dnt.polyfills.ts:195:35 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string | URL'.
```

This only surfaced when the `dom` lib was included, so the regression test builds the import meta polyfill project with `lib: ["ES2022", "DOM"]` and `@types/node@^22.16.3` (it fails without the fix).

Closes #472