### PR TITLE
fix: error on specifiers that fail to resolve

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -162,7 +162,13 @@ export interface BuildOptions {
   package: PackageJson;
   /** Path or url to a deno.json. */
   configFile?: string;
-  /** Path or url to import map. */
+  /** Path or url to import map.
+   *
+   * @remarks Use `configFile` for a deno.json. Like `deno --import-map`, the
+   * file is read as a plain import map, so bare specifier mappings are not
+   * expanded to cover sub paths (ex. `@std/path` will not map
+   * `@std/path/glob-to-regexp`).
+   */
   importMap?: string;
   /** Package manager used to install dependencies and run npm scripts.
    * This also can be an absolute path to the executable file of package manager.

--- a/rs-lib/src/graph.rs
+++ b/rs-lib/src/graph.rs
@@ -27,6 +27,7 @@ use deno_graph::source::ResolveError;
 use deno_graph::source::Resolver;
 use deno_graph::JsModule;
 use deno_graph::Module;
+use deno_graph::ModuleGraphError;
 use deno_graph::Range;
 use deno_resolver::deno_json::CompilerOptionsResolver;
 use deno_resolver::deno_json::JsxImportSourceConfigResolver;
@@ -144,6 +145,34 @@ impl ModuleGraph {
       if !error_message.contains(error.specifier().as_str()) {
         error_message.push_str(&format!(" ({})", error.specifier()));
       }
+    }
+    // module errors don't include specifiers that failed to resolve, so walk
+    // the graph for those as well. Otherwise they would be silently emitted
+    // into the output as-is, which is broken for anything but an npm package.
+    for error in graph
+      .walk(
+        graph.roots.iter(),
+        deno_graph::WalkOptions {
+          check_js: deno_graph::CheckJsOption::True,
+          kind: deno_graph::GraphKind::All,
+          follow_dynamic: true,
+          prefer_fast_check_graph: false,
+        },
+      )
+      .errors()
+    {
+      let range = match &error {
+        // already reported above
+        ModuleGraphError::ModuleError(_) => continue,
+        ModuleGraphError::ResolutionError(error)
+        | ModuleGraphError::TypesResolutionError(error) => {
+          error.range().clone()
+        }
+      };
+      if !error_message.is_empty() {
+        error_message.push_str("\n\n");
+      }
+      write!(error_message, "{:#}\n    at {}", error, range).unwrap();
     }
     if !error_message.is_empty() {
       bail!("{}", error_message);

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1693,6 +1693,45 @@ async fn transform_import_map_local_sibling_and_remote() {
 }
 
 #[tokio::test]
+async fn transform_specifier_not_in_import_map() {
+  let err_message = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file(
+          "/mod.ts",
+          "import a from 'other';\nimport b from 'other/sub.ts';",
+        )
+        .add_local_file(
+          "/import_map.json",
+          r#"{
+  "imports": {
+    "other": "./other/mod.ts"
+  }
+}"#,
+        )
+        .add_local_file("/other/mod.ts", "export default 1;")
+        .add_local_file("/other/sub.ts", "export default 2;");
+    })
+    .set_import_map("file:///import_map.json")
+    .transform()
+    .await
+    .err()
+    .unwrap();
+
+  // the sub path is not mapped, so surface it rather than emitting the
+  // bare specifier into the output as-is
+  assert_eq!(
+    err_message.to_string(),
+    normalize_urls(
+      concat!(
+        "Import \"other/sub.ts\" not a dependency and not in import map from \"file:///mod.ts\"",
+        "\n    at file:///mod.ts:2:15",
+      )
+    )
+  );
+}
+
+#[tokio::test]
 async fn transform_entry_point_with_sibling_dir_in_project() {
   let result = TestBuilder::new()
     .entry_point("file:///project/src/mod.ts")


### PR DESCRIPTION
`deno_graph`'s `module_errors()` explicitly does not include resolution errors, so a specifier that failed to resolve was silently emitted into the output as-is, which is broken for anything that isn't an npm dependency:

```ts
// input
import * as path from "@std/path";
import { globToRegExp } from "@std/path/glob-to-regexp";

// output
import * as path from "./deps/jsr.io/@std/path/1.1.6/mod.js";
import { globToRegExp } from "@std/path/glob-to-regexp"; // <-- broken
```

Now the graph is also walked for resolution errors, which surfaces the same message Deno gives:

```
error: Import "@std/path/glob-to-regexp" not a dependency and not in import map from "file:///.../util.ts"
    at file:///.../util.ts:2:30
```

The walk uses `GraphKind::All` and `follow_dynamic: true` rather than the narrower semantics of `graph.valid()`, because dnt emits type-only and dynamic imports too, so an unresolved specifier in either position is broken in the output in exactly the same way.

In the case from the issue the specifier failed to resolve because the deno.json was passed as `importMap` rather than `configFile`. Like `deno --import-map`, that is read as a plain import map, so bare specifier mappings are not expanded to cover sub paths (`deno run --import-map=deno.json` fails on the same import). Documented that on the option.

Closes #475