### PR TITLE
fix: don't shift output when a dependency resolves to a `.ts` file

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -336,6 +336,7 @@ export async function build(options: BuildOptions): Promise<void> {
   const esmOutDir = path.join(options.outDir, "esm");
   const scriptOutDir = path.join(options.outDir, "script");
   const typesOutDir = path.join(options.outDir, "types");
+  const srcOutDir = path.join(options.outDir, "src");
   const compilerScriptTarget = getCompilerScriptTarget(scriptTarget);
   // TypeScript 6.0 no longer automatically discovers the `@types` packages
   // installed in the output's node_modules, so resolve and include them
@@ -346,6 +347,10 @@ export async function build(options: BuildOptions): Promise<void> {
   const project = createProjectSync({
     compilerOptions: {
       outDir: typesOutDir,
+      // pin the root so that a dependency resolving to a file outside the
+      // sources (ex. a package that ships a .ts file) can't shift the output
+      // down a directory and leave the package.json paths dangling
+      rootDir: srcOutDir,
       allowJs: true,
       alwaysStrict: true,
       stripInternal: options.compilerOptions?.stripInternal,
@@ -582,8 +587,18 @@ export async function build(options: BuildOptions): Promise<void> {
         d.code !== 1343 &&
         // 1470: The_import_meta_meta_property_is_not_allowed_in_files_which_will_build_into_CommonJS_output
         d.code !== 1470 &&
+        !isInNodeModules(d) &&
         (options.filterDiagnostic?.(d) ?? true)
       );
+    }
+
+    /** A dependency shipping a .ts file that resolution lands on is compiled
+     * as a source rather than a declaration file, so `skipLibCheck` doesn't
+     * cover it. Its code is no more the package author's problem than a .d.ts
+     * would be, so ignore it all the same. */
+    function isInNodeModules(diagnostic: ts.Diagnostic) {
+      const fileName = diagnostic.file?.fileName;
+      return fileName != null && fileName.includes("/node_modules/");
     }
 
     function shouldTypeCheck() {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1170,6 +1170,34 @@ Deno.test("should build undici project", async () => {
   });
 });
 
+Deno.test("should build a project with a dependency that resolves to a .ts file", async () => {
+  await runTest("node_modules_ts_project", {
+    entryPoints: ["mod.ts", "nested/other.ts"],
+    outDir: "./npm",
+    scriptModule: false,
+    declaration: "separate",
+    test: false,
+    shims: {},
+    package: {
+      name: "node-modules-ts-project",
+      version: "1.0.0",
+    },
+  }, (output) => {
+    // see issue #460 -- the dependency's own .ts file must not shift the
+    // output down a directory, which would leave the package.json paths
+    // pointing at files that don't exist
+    output.assertExists("esm/mod.js");
+    output.assertExists("esm/nested/other.js");
+    output.assertNotExists("esm/src/mod.js");
+    output.assertNotExists("esm/node_modules");
+    assertEquals(output.packageJson.module, "./esm/mod.js");
+    assertEquals(
+      output.packageJson.exports["."].import.default,
+      "./esm/mod.js",
+    );
+  });
+});
+
 Deno.test("should run the test preload module", async () => {
   await runTest("test_preload_project", {
     entryPoints: ["mod.ts"],
@@ -1443,6 +1471,7 @@ async function runTest(
     | "polyfill_promise_with_resolvers_project"
     | "polyfill_import_meta_project"
     | "module_mappings_project"
+    | "node_modules_ts_project"
     | "node_types_project"
     | "undici_project"
     | "shim_project"

--- a/tests/node_modules_ts_project/mod.ts
+++ b/tests/node_modules_ts_project/mod.ts
@@ -1,0 +1,9 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+// `type-detect` ships an `index.ts` that TypeScript's resolution lands on, so
+// it ends up in the program as a source file rather than a declaration file
+import typeDetect from "npm:type-detect@^4.1.0";
+
+export function detect(value: unknown): string {
+  return typeDetect(value);
+}

--- a/tests/node_modules_ts_project/nested/other.ts
+++ b/tests/node_modules_ts_project/nested/other.ts
@@ -1,0 +1,3 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+export const other = "other";


### PR DESCRIPTION
When a dependency's resolution lands on a `.ts` file, TypeScript pulls it into the program as a source file rather than a declaration file. That moved the inferred common source directory from `<outDir>/src` up to `<outDir>`, so every emitted file gained an extra `src` segment while the package.json paths — built from the transform's entry point paths — did not:

```
npm/esm/node_modules/type-detect/index.js   <-- a dependency got compiled
npm/esm/src/mod.js                          <-- extra "src" segment
npm/types/mod.d.ts                          <-- no "src" segment
```

```json
{ "module": "./esm/mod.js" }                 // points at nothing
```

Pinning `rootDir` to the sources keeps the output where the package.json says it is, and stops the dependency being emitted into the package.

Type checking hit the same file for the second half of the problem — `skipLibCheck` only covers a dependency's `.d.ts` files, so a dependency shipping `.ts` reported its own errors against the package author (14 of them for `type-detect`, ex. `Cannot find name 'window'`). Its code is no more the author's problem than a `.d.ts` would be, so diagnostics from node_modules are ignored the same way.

The regression test uses `type-detect@^4.1.0`, which has no `types`/`typings` entry and ships `index.js`, `index.d.ts` and `index.ts`. Nothing is specific to that package — any dependency shipping a `.ts` file that resolution lands on does it. The test fails on both counts without the fix.

Closes #460