### PR TITLE
fix: do not search `node_modules` directories for test files

### DIFF
--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,6 +1,37 @@
 import * as path from "@std/path";
 import { assertEquals, assertRejects } from "@std/assert";
-import { getDntVersion, runCommand, valueToUrl } from "./utils.ts";
+import { getDntVersion, glob, runCommand, valueToUrl } from "./utils.ts";
+
+Deno.test("glob should not search node_modules or excluded dirs", async () => {
+  const rootDir = await Deno.makeTempDir();
+  try {
+    const testFilePaths = [
+      ["mod.test.ts"],
+      ["sub", "mod.test.ts"],
+      ["node_modules", "pkg", "mod.test.ts"],
+      ["sub", "node_modules", "pkg", "mod.test.ts"],
+      ["npm", "mod.test.ts"],
+    ];
+    for (const filePath of testFilePaths) {
+      const absPath = path.join(rootDir, ...filePath);
+      await Deno.mkdir(path.dirname(absPath), { recursive: true });
+      await Deno.writeTextFile(absPath, "");
+    }
+
+    const paths = await glob({
+      pattern: "**/*.test.ts",
+      rootDir,
+      excludeDirs: [path.join(rootDir, "npm")],
+    });
+
+    assertEquals(
+      paths.map((p) => path.relative(rootDir, p)).sort(),
+      ["mod.test.ts", path.join("sub", "mod.test.ts")],
+    );
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});
 
 Deno.test({
   name: "should error when command doesn't exist",

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -3,7 +3,11 @@
 import { expandGlob } from "@std/fs/expand-glob";
 import * as path from "@std/path";
 
-/** Gets the files found in the provided root dir path based on the glob. */
+/**
+ * Gets the files found in the provided root dir path based on the glob.
+ *
+ * Any `node_modules` directory is never searched.
+ */
 export async function glob(options: {
   pattern: string;
   rootDir: string;
@@ -14,7 +18,7 @@ export async function glob(options: {
     root: options.rootDir,
     extended: true,
     globstar: true,
-    exclude: options.excludeDirs,
+    exclude: [...options.excludeDirs, "**/node_modules"],
   });
   for await (const entry of entries) {
     if (entry.isFile) {

--- a/mod.ts
+++ b/mod.ts
@@ -98,7 +98,11 @@ export interface BuildOptions {
   skipSourceOutput?: boolean;
   /** Root directory to find test files in. Defaults to the cwd. */
   rootTestDir?: string;
-  /** Glob pattern to use to find tests files. Defaults to `deno test`'s pattern. */
+  /**
+   * Glob pattern to use to find tests files. Defaults to `deno test`'s pattern.
+   *
+   * Note that `node_modules` directories are never searched.
+   */
   testPattern?: string;
   /**
    * Specifiers to map from and to.


### PR DESCRIPTION
Closes #412

When globbing for test entry points, `node_modules` directories are now skipped (the walk no longer descends into them), so tests bundled inside dependencies are not picked up by the generated test runner.