### PR TITLE
fix: rename declarations shadowing globals used by the emit

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -53,6 +53,7 @@
     "tests/polyfill_array_find_last_project/npm",
     "tests/polyfill_disabled_project/npm",
     "tests/polyfill_project/npm",
+    "tests/shadowed_globals_project/npm",
     "tests/shim_project/npm",
     "tests/test_project/npm",
     "tests/tla_project/npm",

--- a/lib/compiler_transforms.test.ts
+++ b/lib/compiler_transforms.test.ts
@@ -1,8 +1,11 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
 import { assertEquals } from "@std/assert";
-import { ts } from "@ts-morph/bootstrap";
-import { transformImportMeta } from "./compiler_transforms.ts";
+import { createProjectSync, ts } from "@ts-morph/bootstrap";
+import {
+  createShadowedGlobalsTransformer,
+  transformImportMeta,
+} from "./compiler_transforms.ts";
 
 function testImportReplacements(
   input: string,
@@ -82,5 +85,97 @@ Deno.test("does not transform new.target in esModule", () => {
   testImportReplacementsEsm(
     "function test(...args) { return Reflect.construct(Struct, args, new.target); }",
     `function test(...args) { return Reflect.construct(Struct, args, new.target); }\n`,
+  );
+});
+
+// the emit for every commonjs module starts with this
+const cjsPrologue =
+  `"use strict";\nObject.defineProperty(exports, "__esModule", { value: true });\n`;
+
+function testShadowedGlobals(
+  input: string,
+  output: string,
+  module = ts.ModuleKind.CommonJS,
+) {
+  const project = createProjectSync({
+    useInMemoryFileSystem: true,
+    compilerOptions: {
+      module,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+    },
+  });
+  project.createSourceFile("/mod.ts", input);
+  const program = project.createProgram();
+  let text: string | undefined;
+  program.emit(
+    undefined,
+    (_filePath, data) => text = data,
+    undefined,
+    false,
+    { before: [createShadowedGlobalsTransformer(program)] },
+  );
+  const prologue = module === ts.ModuleKind.CommonJS ? cjsPrologue : "";
+  assertEquals(text, prologue + output);
+}
+
+const testShadowedGlobalsEsm = (input: string, output: string) =>
+  testShadowedGlobals(input, output, ts.ModuleKind.ES2015);
+
+Deno.test("renames declarations shadowing the globals the emit uses", () => {
+  testShadowedGlobals(
+    `const Object = "hello";\nlet [require] = ["world"];\nexport default Object + require;\n`,
+    `const Object_1 = "hello";\nlet [require_1] = ["world"];\nexports.default = Object_1 + require_1;\n`,
+  );
+});
+
+Deno.test("uses an unused name when renaming", () => {
+  testShadowedGlobals(
+    `const Object_1 = 1;\nconst Object = 2;\nexport default Object + Object_1;\n`,
+    `const Object_1 = 1;\nconst Object_2 = 2;\nexports.default = Object_2 + Object_1;\n`,
+  );
+});
+
+Deno.test("keeps the export names of renamed declarations", () => {
+  testShadowedGlobals(
+    `export class Object {}\nfunction Symbol() {}\nexport { Symbol as other, Symbol as default };\n`,
+    `exports.other = exports.Object = void 0;\nclass Object_1 {\n}\nfunction Symbol_1() { }\nexports.Object = Object_1;\nexports.other = Symbol_1;\nexports.default = Symbol_1;\n`,
+  );
+});
+
+Deno.test("renames shorthand properties and object binding patterns", () => {
+  testShadowedGlobals(
+    `const Object = { Object: 1 };\nconst { Object: value } = Object;\nexport default { Object, value };\n`,
+    `const Object_1 = { Object: 1 };\nconst { Object: value } = Object_1;\nexports.default = { Object: Object_1, value };\n`,
+  );
+});
+
+Deno.test("does not rename declarations in other scopes", () => {
+  testShadowedGlobals(
+    `export const keys = Object.keys({});\nexport function test() {\n  const Object = 1;\n  return Object;\n}\n`,
+    `exports.keys = void 0;\nexports.test = test;\nexports.keys = Object.keys({});\nfunction test() {\n    const Object = 1;\n    return Object;\n}\n`,
+  );
+});
+
+Deno.test("does not rename exported variables, which don't create a binding", () => {
+  testShadowedGlobals(
+    `export const Object = "hello";\nexport const length = Object.length;\n`,
+    `exports.length = exports.Object = void 0;\nexports.Object = "hello";\nexports.length = exports.Object.length;\n`,
+  );
+});
+
+Deno.test("renames declarations in an es module", () => {
+  // the es module emit uses these globals when downleveling
+  // (ex. `Object.defineProperty(this, "prop", ...)` for class fields)
+  testShadowedGlobalsEsm(
+    `const Object = "hello";\nexport default Object;\n`,
+    `const Object_1 = "hello";\nexport default Object_1;\n`,
+  );
+});
+
+Deno.test("keeps the export names in an es module", () => {
+  testShadowedGlobalsEsm(
+    `export const Object = 1;\nexport class Symbol {}\nexport { Object as other };\n`,
+    `const Object_1 = 1;\nclass Symbol_1 {\n}\nexport { Object_1 as other };\nexport { Object_1 as Object, Symbol_1 as Symbol };\n`,
   );
 });

--- a/lib/compiler_transforms.ts
+++ b/lib/compiler_transforms.ts
@@ -2,6 +2,314 @@
 
 import { ts } from "@ts-morph/bootstrap";
 
+// identifiers the emit references in the module scope (ex.
+// `Object.defineProperty(exports, "__esModule", { value: true });` for
+// CommonJS or `Object.defineProperty(this, "prop", ...)` when downleveling
+// class fields)
+const emitGlobalNames = new Set([
+  "Array",
+  "Object",
+  "Promise",
+  "Reflect",
+  "Symbol",
+  "SuppressedError",
+  "TypeError",
+  "exports",
+  "globalThis",
+  "module",
+  "require",
+]);
+
+/**
+ * Creates a transformer that renames module scoped declarations shadowing an
+ * identifier the emit relies on.
+ *
+ * For example, a module declaring `const Object = "hello";` would otherwise
+ * emit CommonJS code that throws at runtime because the emitted
+ * `Object.defineProperty(exports, "__esModule", { value: true });` would
+ * resolve `Object` to the module's declaration instead of the global.
+ */
+export function createShadowedGlobalsTransformer(
+  program: ts.Program,
+): ts.TransformerFactory<ts.SourceFile> {
+  return (context) => {
+    const factory = context.factory;
+    const compilerModule = context.getCompilerOptions().module;
+    const isScriptModule = compilerModule === ts.ModuleKind.CommonJS ||
+      compilerModule === ts.ModuleKind.UMD;
+
+    return (sourceFile) => {
+      if (sourceFile.isDeclarationFile) {
+        return sourceFile;
+      }
+      const declarationNames = Array.from(
+        getShadowingDeclarationNames(sourceFile, isScriptModule),
+      );
+      if (declarationNames.length === 0) {
+        return sourceFile; // fast path—only get the type checker when necessary
+      }
+      const checker = program.getTypeChecker();
+      const renames = getRenames();
+      if (renames.size === 0) {
+        return sourceFile;
+      }
+      // exports of renamed declarations are re-added at the end of the file
+      // in order to keep the original export names (ex. a renamed
+      // `export class Object {}` still needs to be exported as `Object`)
+      const appendedExports: ExportName[] = [];
+      const statements = sourceFile.statements.map((statement) => {
+        const exportNames = getExportNamesToAppend(statement);
+        const newStatement = visitNode(statement) as ts.Statement;
+        if (exportNames.length === 0) {
+          return newStatement;
+        }
+        appendedExports.push(...exportNames);
+        return removeExportModifier(newStatement);
+      });
+      return factory.updateSourceFile(sourceFile, [
+        ...statements,
+        ...createAppendedExports(),
+      ]);
+
+      function visitNode(node: ts.Node): ts.Node | undefined {
+        // `export { Object as name };` -> `export { Object_1 as name };`
+        if (ts.isExportSpecifier(node)) {
+          const localName = getRenamedName(
+            checker.getExportSpecifierLocalTargetSymbol(node),
+          );
+          if (localName != null) {
+            if (isScriptModule) {
+              // the CommonJS emit can't resolve a renamed export specifier,
+              // so export it at the end of the file instead
+              appendedExports.push({ localName, exportName: node.name });
+              return undefined;
+            }
+            return factory.updateExportSpecifier(
+              node,
+              node.isTypeOnly,
+              factory.createIdentifier(localName),
+              node.name,
+            );
+          }
+          return node;
+        }
+
+        // `{ Object }` -> `{ Object: Object_1 }`
+        if (ts.isShorthandPropertyAssignment(node)) {
+          const newName = getRenamedName(
+            checker.getShorthandAssignmentValueSymbol(node),
+          );
+          if (newName != null) {
+            const value = factory.createIdentifier(newName);
+            return factory.createPropertyAssignment(
+              node.name,
+              node.objectAssignmentInitializer == null ? value : factory
+                .createAssignment(
+                  value,
+                  visitNode(node.objectAssignmentInitializer) as ts.Expression,
+                ),
+            );
+          }
+        }
+
+        // `const { Object } = value;` -> `const { Object: Object_1 } = value;`
+        if (
+          ts.isBindingElement(node) && node.propertyName == null &&
+          node.dotDotDotToken == null && ts.isIdentifier(node.name) &&
+          ts.isObjectBindingPattern(node.parent)
+        ) {
+          const newName = getRenamedNameAtLocation(node.name);
+          if (newName != null) {
+            return factory.updateBindingElement(
+              node,
+              node.dotDotDotToken,
+              node.name,
+              factory.createIdentifier(newName),
+              node.initializer == null
+                ? undefined
+                : visitNode(node.initializer) as ts.Expression,
+            );
+          }
+        }
+
+        if (ts.isIdentifier(node)) {
+          const newName = getRenamedNameAtLocation(node);
+          if (newName != null) {
+            return factory.createIdentifier(newName);
+          }
+        }
+
+        return ts.visitEachChild(node, visitNode, context);
+      }
+
+      function getRenames() {
+        const usedNames = getIdentifierNames(sourceFile);
+        const renames = new Map<ts.Symbol, string>();
+        for (const declarationName of declarationNames) {
+          const symbol = checker.getSymbolAtLocation(declarationName);
+          if (symbol == null || renames.has(symbol)) {
+            continue;
+          }
+          let index = 1;
+          let newName = `${declarationName.text}_${index}`;
+          while (usedNames.has(newName)) {
+            newName = `${declarationName.text}_${++index}`;
+          }
+          usedNames.add(newName);
+          renames.set(symbol, newName);
+        }
+        return renames;
+      }
+
+      /** Gets the export names of a statement that need to be re-added when
+       * it declares a renamed name. */
+      function getExportNamesToAppend(statement: ts.Statement): ExportName[] {
+        if (
+          !hasModifier(statement, ts.SyntaxKind.ExportKeyword) ||
+          // `export default class Object {}` keeps its export name
+          hasModifier(statement, ts.SyntaxKind.DefaultKeyword)
+        ) {
+          return [];
+        }
+        const names = ts.isVariableStatement(statement)
+          ? statement.declarationList.declarations.flatMap((d) =>
+            Array.from(getBindingNames(d.name))
+          )
+          : isRenameableDeclaration(statement) && statement.name != null &&
+              ts.isIdentifier(statement.name)
+          ? [statement.name]
+          : [];
+        const exportNames = names.map((name) => ({
+          localName: getRenamedNameAtLocation(name) ?? name.text,
+          exportName: name,
+        }));
+        return exportNames.some((n) => n.localName !== n.exportName.text)
+          ? exportNames
+          : [];
+      }
+
+      function createAppendedExports(): ts.Statement[] {
+        if (appendedExports.length === 0) {
+          return [];
+        }
+        if (!isScriptModule) {
+          return [factory.createExportDeclaration(
+            undefined,
+            false,
+            factory.createNamedExports(
+              appendedExports.map(({ localName, exportName }) =>
+                factory.createExportSpecifier(
+                  false,
+                  factory.createIdentifier(localName),
+                  createExportName(exportName),
+                )
+              ),
+            ),
+          )];
+        }
+        return appendedExports.map(({ localName, exportName }) => {
+          const localIdentifier = factory.createIdentifier(localName);
+          if (!ts.isIdentifier(exportName)) {
+            // ex. `exports["some name"] = Object_1;`
+            return factory.createExpressionStatement(factory.createAssignment(
+              factory.createElementAccessExpression(
+                factory.createIdentifier("exports"),
+                factory.createStringLiteral(exportName.text),
+              ),
+              localIdentifier,
+            ));
+          }
+          if (exportName.text === "default") {
+            return factory.createExportDefault(localIdentifier);
+          }
+          // an exported variable declaration is used here instead of an export
+          // specifier because the CommonJS emit does not create a module scoped
+          // binding for it, which would otherwise shadow the global again
+          return factory.createVariableStatement(
+            [factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+            factory.createVariableDeclarationList([
+              factory.createVariableDeclaration(
+                exportName.text,
+                undefined,
+                undefined,
+                localIdentifier,
+              ),
+            ], ts.NodeFlags.Const),
+          );
+        });
+      }
+
+      function createExportName(name: ts.Identifier | ts.StringLiteral) {
+        return ts.isIdentifier(name)
+          ? factory.createIdentifier(name.text)
+          : factory.createStringLiteral(name.text);
+      }
+
+      function removeExportModifier(statement: ts.Statement) {
+        const modifiers = ts.canHaveModifiers(statement)
+          ? ts.getModifiers(statement)?.filter((m) =>
+            m.kind !== ts.SyntaxKind.ExportKeyword
+          )
+          : undefined;
+        if (ts.isFunctionDeclaration(statement)) {
+          return factory.updateFunctionDeclaration(
+            statement,
+            modifiers,
+            statement.asteriskToken,
+            statement.name,
+            statement.typeParameters,
+            statement.parameters,
+            statement.type,
+            statement.body,
+          );
+        } else if (ts.isClassDeclaration(statement)) {
+          return factory.updateClassDeclaration(
+            statement,
+            modifiers,
+            statement.name,
+            statement.typeParameters,
+            statement.heritageClauses,
+            statement.members,
+          );
+        } else if (ts.isEnumDeclaration(statement)) {
+          return factory.updateEnumDeclaration(
+            statement,
+            modifiers,
+            statement.name,
+            statement.members,
+          );
+        } else if (ts.isModuleDeclaration(statement)) {
+          return factory.updateModuleDeclaration(
+            statement,
+            modifiers,
+            statement.name,
+            statement.body,
+          );
+        } else if (ts.isVariableStatement(statement)) {
+          return factory.updateVariableStatement(
+            statement,
+            modifiers,
+            statement.declarationList,
+          );
+        } else {
+          return statement;
+        }
+      }
+
+      function getRenamedNameAtLocation(node: ts.Identifier) {
+        if (!emitGlobalNames.has(node.text)) {
+          return undefined;
+        }
+        return getRenamedName(checker.getSymbolAtLocation(node));
+      }
+
+      function getRenamedName(symbol: ts.Symbol | undefined) {
+        return symbol == null ? undefined : renames.get(symbol);
+      }
+    };
+  };
+}
+
 // transform `import.meta.url` to a replacement that works in script modules
 export const transformImportMeta: ts.TransformerFactory<ts.SourceFile> = (
   context,
@@ -66,3 +374,84 @@ export const transformImportMeta: ts.TransformerFactory<ts.SourceFile> = (
     ]);
   }
 };
+
+interface ExportName {
+  localName: string;
+  exportName: ts.Identifier | ts.StringLiteral;
+}
+
+/** Gets the module scoped declaration names that shadow an identifier the
+ * emit relies on. */
+function* getShadowingDeclarationNames(
+  sourceFile: ts.SourceFile,
+  isScriptModule: boolean,
+): Generator<ts.Identifier> {
+  for (const statement of sourceFile.statements) {
+    if (hasModifier(statement, ts.SyntaxKind.DeclareKeyword)) {
+      continue; // ambient declarations don't emit
+    }
+    if (ts.isVariableStatement(statement)) {
+      // exported variables become properties on `exports` in the CommonJS
+      // emit, so they never create a module scoped binding there
+      if (
+        isScriptModule && hasModifier(statement, ts.SyntaxKind.ExportKeyword)
+      ) {
+        continue;
+      }
+      for (const declaration of statement.declarationList.declarations) {
+        for (const name of getBindingNames(declaration.name)) {
+          if (emitGlobalNames.has(name.text)) {
+            yield name;
+          }
+        }
+      }
+    } else if (
+      isRenameableDeclaration(statement) && statement.name != null &&
+      ts.isIdentifier(statement.name) &&
+      emitGlobalNames.has(statement.name.text)
+    ) {
+      yield statement.name;
+    }
+  }
+}
+
+function* getBindingNames(name: ts.BindingName): Generator<ts.Identifier> {
+  if (ts.isIdentifier(name)) {
+    yield name;
+  } else {
+    for (const element of name.elements) {
+      if (ts.isBindingElement(element)) {
+        yield* getBindingNames(element.name);
+      }
+    }
+  }
+}
+
+function isRenameableDeclaration(
+  node: ts.Node,
+): node is
+  | ts.FunctionDeclaration
+  | ts.ClassDeclaration
+  | ts.EnumDeclaration
+  | ts.ModuleDeclaration {
+  return ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node) ||
+    ts.isEnumDeclaration(node) || ts.isModuleDeclaration(node);
+}
+
+function getIdentifierNames(sourceFile: ts.SourceFile) {
+  const names = new Set<string>();
+  visitNode(sourceFile);
+  return names;
+
+  function visitNode(node: ts.Node) {
+    if (ts.isIdentifier(node)) {
+      names.add(node.text);
+    }
+    ts.forEachChild(node, visitNode);
+  }
+}
+
+function hasModifier(node: ts.Node, kind: ts.ModifierSyntaxKind) {
+  return ts.canHaveModifiers(node) &&
+    (ts.getModifiers(node)?.some((m) => m.kind === kind) ?? false);
+}

--- a/mod.ts
+++ b/mod.ts
@@ -467,9 +467,7 @@ export async function build(options: BuildOptions): Promise<void> {
     program = project.createProgram();
     emit({
       transformers: {
-        before: polyfills["importMeta"]
-          ? [compilerTransforms.transformImportMeta]
-          : [],
+        before: getBeforeTransformers(),
       },
     });
     writeFile(
@@ -494,9 +492,7 @@ export async function build(options: BuildOptions): Promise<void> {
     program = getProgramAndMaybeTypeCheck("script");
     emit({
       transformers: {
-        before: polyfills["importMeta"]
-          ? [compilerTransforms.transformImportMeta]
-          : [],
+        before: getBeforeTransformers(),
       },
     });
     writeFile(
@@ -525,6 +521,16 @@ export async function build(options: BuildOptions): Promise<void> {
   }
 
   log("Complete!");
+
+  function getBeforeTransformers() {
+    return [
+      // must go first in order to analyze the unmodified source files
+      compilerTransforms.createShadowedGlobalsTransformer(program),
+      ...(polyfills["importMeta"]
+        ? [compilerTransforms.transformImportMeta]
+        : []),
+    ];
+  }
 
   function emit(
     opts?: { onlyDtsFiles?: boolean; transformers?: ts.CustomTransformers },

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1292,6 +1292,35 @@ Deno.test("using declaration project", async () => {
   });
 });
 
+Deno.test("shadowed globals project", async () => {
+  await runTest("shadowed_globals_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    typeCheck: "both",
+    shims: {
+      deno: {
+        test: true,
+      },
+    },
+    package: {
+      name: "shadowed_globals_project",
+      version: "0.0.0",
+    },
+  }, (output) => {
+    const scriptText = output.getFileText("script/mod.js");
+    assertStringIncludes(scriptText, `const Object_1 = "hello";`);
+    assertStringIncludes(scriptText, `exports.Symbol = Symbol_1;`);
+    const esmText = output.getFileText("esm/mod.js");
+    assertStringIncludes(esmText, `const Object_1 = "hello";`);
+    assertStringIncludes(esmText, `export { Symbol_1 as Symbol };`);
+    // the declaration files keep the original names
+    assertStringIncludes(
+      output.getFileText("esm/mod.d.ts"),
+      `export declare class Symbol {`,
+    );
+  });
+});
+
 Deno.test("should build jsr project", async () => {
   await runTest("jsr_project", {
     entryPoints: ["mod.ts"],
@@ -1445,6 +1474,7 @@ async function runTest(
     | "module_mappings_project"
     | "node_types_project"
     | "undici_project"
+    | "shadowed_globals_project"
     | "shim_project"
     | "test_preload_project"
     | "test_project"

--- a/tests/shadowed_globals_project/mod.test.ts
+++ b/tests/shadowed_globals_project/mod.test.ts
@@ -1,0 +1,15 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import text, { getText, Symbol } from "./mod.ts";
+
+Deno.test("shadowed globals", () => {
+  if (text !== "hello") {
+    throw new Error("Failed.");
+  }
+  if (getText() !== "hello world") {
+    throw new Error("Failed.");
+  }
+  if (new Symbol().text !== "hello world") {
+    throw new Error("Failed.");
+  }
+});

--- a/tests/shadowed_globals_project/mod.ts
+++ b/tests/shadowed_globals_project/mod.ts
@@ -1,0 +1,15 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+// these declarations shadow identifiers that the emit relies on
+// (ex. `Object.defineProperty(exports, "__esModule", { value: true });`)
+const Object = "hello";
+
+export class Symbol {
+  text = `${Object} world`;
+}
+
+export function getText() {
+  return new Symbol().text;
+}
+
+export default Object;


### PR DESCRIPTION
Closes #444

A module declaring a module scoped binding with the same name as an identifier the emit relies on caused the output to resolve that identifier to the declaration instead of the global:

```ts
const Object = "hello";
export default Object;
```

...emitted CommonJS that throws with "Cannot access 'Object' before initialization":

```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
const Object = "hello";
exports.default = Object;
```

The ES module output has the same problem when downleveling (ex. class fields emit `Object.defineProperty(this, ...)` when targeting below ES2022).

This adds a compiler transformer that renames these module scoped declarations (`const Object_1 = "hello";`) along with their references, keeping the original export names so the public API and declaration files are unchanged:

```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
const Object_1 = "hello";
exports.default = Object_1;
```

Notes:

- The type checker is only asked for symbols when a module actually declares one of these names, so the common case is a scan of the top level statements.
- Exported variable declarations don't create a module scoped binding in the CommonJS emit (they become properties on `exports`), so they're left alone there.
- Renamed exports are re-added at the end of the file as `export const <name> = <renamed>;` for CommonJS/UMD (the CommonJS transform can't resolve a synthesized export specifier) and as `export { <renamed> as <name> };` for ES modules.