### PR TITLE
fix: only publish `src` directory when something references it

### DIFF
--- a/lib/npm_ignore.test.ts
+++ b/lib/npm_ignore.test.ts
@@ -101,7 +101,7 @@ Deno.test("should include declaration maps of test files", () => {
   runTest({
     sourceMaps: undefined,
     inlineSources: undefined,
-    expectHasSrcFolder: true,
+    expectHasSrcFolder: false,
     includeScriptModule: true,
     includeEsModule: true,
     declaration: "inline",
@@ -119,7 +119,7 @@ Deno.test("should include declaration maps of test files", () => {
   runTest({
     sourceMaps: undefined,
     inlineSources: undefined,
-    expectHasSrcFolder: true,
+    expectHasSrcFolder: false,
     includeScriptModule: true,
     includeEsModule: true,
     declaration: "separate",
@@ -134,6 +134,39 @@ Deno.test("should include declaration maps of test files", () => {
     includeEsModule: true,
     declaration: false,
     declarationMap: true,
+  });
+});
+
+Deno.test("should keep the src directory when the declaration maps need it", () => {
+  // declaration maps never inline their sources, so `inlineSources` does not
+  // remove the need for the src directory like it does for source maps
+  runTest({
+    sourceMaps: true,
+    inlineSources: true,
+    expectHasSrcFolder: false,
+    includeScriptModule: true,
+    includeEsModule: true,
+    declaration: "inline",
+    declarationMap: true,
+  });
+  runTest({
+    sourceMaps: "inline",
+    inlineSources: true,
+    expectHasSrcFolder: false,
+    includeScriptModule: true,
+    includeEsModule: true,
+    declaration: "separate",
+    declarationMap: true,
+  });
+  // nothing references the src directory, so it's excluded
+  runTest({
+    sourceMaps: true,
+    inlineSources: true,
+    expectHasSrcFolder: true,
+    includeScriptModule: true,
+    includeEsModule: true,
+    declaration: "inline",
+    declarationMap: false,
   });
 });
 
@@ -163,6 +196,9 @@ function runTest(options: {
 
   function getExpectedText() {
     let startText = options.expectHasSrcFolder ? "/src/\n" : "";
+    if (!options.expectHasSrcFolder) {
+      startText += "/src/mod.test.ts\n";
+    }
     if (options.includeEsModule !== false) {
       startText += "/esm/mod.test.js\n";
       if (options.sourceMaps === true) {

--- a/lib/npm_ignore.ts
+++ b/lib/npm_ignore.ts
@@ -16,7 +16,7 @@ export function getNpmIgnoreText(options: {
   // Try to make as little of this conditional in case a user edits settings
   // to exclude something, but then the output directory still has that file
   const lines = [];
-  if (!isUsingSourceMaps() || options.inlineSources) {
+  if (!isReferencingSrcDir()) {
     lines.push("/src/");
   }
   for (const fileName of getTestFileNames()) {
@@ -29,6 +29,10 @@ export function getNpmIgnoreText(options: {
     for (const file of options.testFiles) {
       const filePath = toJsFilePath(file.filePath);
       const dtsFilePath = toDtsFilePath(file.filePath);
+      // the whole directory is excluded above when it's not published
+      if (isReferencingSrcDir()) {
+        yield `/src/${file.filePath}`;
+      }
       if (options.includeEsModule) {
         const esmFilePath = `/esm/${filePath}`;
         yield esmFilePath;
@@ -63,6 +67,20 @@ export function getNpmIgnoreText(options: {
       }
     }
     yield "/test_runner.cjs";
+  }
+
+  /** Whether any emitted map points back at the files in `/src/`, in which
+   * case the directory needs to be published for the map to resolve. */
+  function isReferencingSrcDir() {
+    // `inlineSources` embeds the sources in the source map, so `/src/` is only
+    // needed without it. It has no effect on declaration maps though, so those
+    // always need the directory.
+    return (isUsingSourceMaps() && !options.inlineSources) ||
+      isEmittingDeclarationMaps();
+  }
+
+  function isEmittingDeclarationMaps() {
+    return options.declaration !== false && !!options.declarationMap;
   }
 
   function isUsingSourceMaps() {

--- a/mod.ts
+++ b/mod.ts
@@ -89,7 +89,14 @@ export interface BuildOptions {
    * @default "inline"
    */
   declaration?: "inline" | "separate" | false;
-  /** Create declaration map files. Defaults to `true` if `declaration` is enabled and `skipSourceOutput` is `false`.
+  /** Create declaration map files so that "go to definition" in an editor
+   * lands on the original TypeScript rather than the emitted declaration file.
+   *
+   * @remarks Enabling this causes the `src` directory to be published, because
+   * that's what the declaration maps point at. Requires `declaration` to be
+   * enabled and `skipSourceOutput` to be `false`.
+   *
+   * @default false
    */
   declarationMap?: boolean;
   /** Include a CommonJS or UMD module.
@@ -278,8 +285,16 @@ export async function build(options: BuildOptions): Promise<void> {
       : options.declaration ?? "inline",
   };
   const cwd = Deno.cwd();
-  const declarationMap = options.declarationMap ??
-    (!!options.declaration && !options.skipSourceOutput);
+  // the declaration maps point at the `src` directory, so they're only useful
+  // when it's written out and published alongside them
+  const declarationMap = (options.declarationMap ?? false) &&
+    !!options.declaration && !options.skipSourceOutput;
+  if (options.declarationMap && !declarationMap) {
+    warn(
+      `Ignoring the 'declarationMap' build option because it requires ` +
+        `'declaration' to be enabled and 'skipSourceOutput' to be 'false'.`,
+    );
+  }
   const packageManager = options.packageManager ?? "npm";
   const scriptTarget = options.compilerOptions?.target ?? "ES2021";
   const polyfills = resolvePolyfillOptions(options.polyfills);

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -90,46 +90,32 @@ Deno.test("should build test project - basic", async () => {
       `/src/
 /esm/mod.test.js
 /esm/mod.test.d.ts
-/esm/mod.test.d.ts.map
 /script/mod.test.js
 /script/mod.test.d.ts
-/script/mod.test.d.ts.map
 /esm/deps/deno.land/std@0.181.0/fmt/colors.js
 /esm/deps/deno.land/std@0.181.0/fmt/colors.d.ts
-/esm/deps/deno.land/std@0.181.0/fmt/colors.d.ts.map
 /script/deps/deno.land/std@0.181.0/fmt/colors.js
 /script/deps/deno.land/std@0.181.0/fmt/colors.d.ts
-/script/deps/deno.land/std@0.181.0/fmt/colors.d.ts.map
 /esm/deps/deno.land/std@0.181.0/testing/_diff.js
 /esm/deps/deno.land/std@0.181.0/testing/_diff.d.ts
-/esm/deps/deno.land/std@0.181.0/testing/_diff.d.ts.map
 /script/deps/deno.land/std@0.181.0/testing/_diff.js
 /script/deps/deno.land/std@0.181.0/testing/_diff.d.ts
-/script/deps/deno.land/std@0.181.0/testing/_diff.d.ts.map
 /esm/deps/deno.land/std@0.181.0/testing/_format.js
 /esm/deps/deno.land/std@0.181.0/testing/_format.d.ts
-/esm/deps/deno.land/std@0.181.0/testing/_format.d.ts.map
 /script/deps/deno.land/std@0.181.0/testing/_format.js
 /script/deps/deno.land/std@0.181.0/testing/_format.d.ts
-/script/deps/deno.land/std@0.181.0/testing/_format.d.ts.map
 /esm/deps/deno.land/std@0.181.0/testing/asserts.js
 /esm/deps/deno.land/std@0.181.0/testing/asserts.d.ts
-/esm/deps/deno.land/std@0.181.0/testing/asserts.d.ts.map
 /script/deps/deno.land/std@0.181.0/testing/asserts.js
 /script/deps/deno.land/std@0.181.0/testing/asserts.d.ts
-/script/deps/deno.land/std@0.181.0/testing/asserts.d.ts.map
 /esm/_dnt.test_polyfills.js
 /esm/_dnt.test_polyfills.d.ts
-/esm/_dnt.test_polyfills.d.ts.map
 /script/_dnt.test_polyfills.js
 /script/_dnt.test_polyfills.d.ts
-/script/_dnt.test_polyfills.d.ts.map
 /esm/_dnt.test_shims.js
 /esm/_dnt.test_shims.d.ts
-/esm/_dnt.test_shims.d.ts.map
 /script/_dnt.test_shims.js
 /script/_dnt.test_shims.d.ts
-/script/_dnt.test_shims.d.ts.map
 /test_runner.cjs
 yarn.lock
 pnpm-lock.yaml
@@ -183,25 +169,18 @@ Deno.test("should build test project without esm", async () => {
       `/src/
 /script/mod.test.js
 /types/mod.test.d.ts
-/types/mod.test.d.ts.map
 /script/deps/deno.land/std@0.181.0/fmt/colors.js
 /types/deps/deno.land/std@0.181.0/fmt/colors.d.ts
-/types/deps/deno.land/std@0.181.0/fmt/colors.d.ts.map
 /script/deps/deno.land/std@0.181.0/testing/_diff.js
 /types/deps/deno.land/std@0.181.0/testing/_diff.d.ts
-/types/deps/deno.land/std@0.181.0/testing/_diff.d.ts.map
 /script/deps/deno.land/std@0.181.0/testing/_format.js
 /types/deps/deno.land/std@0.181.0/testing/_format.d.ts
-/types/deps/deno.land/std@0.181.0/testing/_format.d.ts.map
 /script/deps/deno.land/std@0.181.0/testing/asserts.js
 /types/deps/deno.land/std@0.181.0/testing/asserts.d.ts
-/types/deps/deno.land/std@0.181.0/testing/asserts.d.ts.map
 /script/_dnt.test_polyfills.js
 /types/_dnt.test_polyfills.d.ts
-/types/_dnt.test_polyfills.d.ts.map
 /script/_dnt.test_shims.js
 /types/_dnt.test_shims.d.ts
-/types/_dnt.test_shims.d.ts.map
 /test_runner.cjs
 yarn.lock
 pnpm-lock.yaml
@@ -334,7 +313,7 @@ Deno.test("should build test project with declarations inline by default", async
   }
 });
 
-Deno.test("should build test project with declaration maps by default", async () => {
+Deno.test("should build test project without declaration maps by default", async () => {
   await runTest("test_project", {
     entryPoints: ["mod.ts"],
     outDir: "./npm",
@@ -347,15 +326,40 @@ Deno.test("should build test project with declaration maps by default", async ()
       version: "1.0.0",
     },
   }, (output) => {
+    output.assertNotExists("script/mod.d.ts.map");
+    output.assertNotExists("esm/mod.d.ts.map");
+    // nothing points at the sources, so they're not published
+    assertStringIncludes(output.npmIgnore, "/src/\n");
+  });
+});
+
+Deno.test("should build test project with declaration maps when enabled", async () => {
+  await runTest("test_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    declaration: "inline",
+    declarationMap: true,
+    shims: {
+      deno: "dev",
+    },
+    package: {
+      name: "add",
+      version: "1.0.0",
+    },
+  }, (output) => {
     output.assertNotExists("types/mod.d.ts");
     output.assertExists("script/mod.d.ts.map");
     output.assertExists("esm/mod.d.ts.map");
+    // the declaration maps point at the sources, so they must be published
+    output.assertExists("src/mod.ts");
+    assertEquals(output.npmIgnore.includes("/src/\n"), false);
   });
 
   await runTest("test_project", {
     entryPoints: ["mod.ts"],
     outDir: "./npm",
     declaration: "separate",
+    declarationMap: true,
     shims: {
       deno: "dev",
     },
@@ -365,6 +369,29 @@ Deno.test("should build test project with declaration maps by default", async ()
     },
   }, (output) => {
     output.assertExists("types/mod.d.ts.map");
+    output.assertNotExists("script/mod.d.ts.map");
+    output.assertNotExists("esm/mod.d.ts.map");
+    output.assertExists("src/mod.ts");
+    assertEquals(output.npmIgnore.includes("/src/\n"), false);
+  });
+});
+
+Deno.test("should not create declaration maps when the sources are skipped", async () => {
+  await runTest("test_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    declaration: "inline",
+    declarationMap: true,
+    skipSourceOutput: true,
+    shims: {
+      deno: "dev",
+    },
+    package: {
+      name: "add",
+      version: "1.0.0",
+    },
+  }, (output) => {
+    output.assertNotExists("src/mod.ts");
     output.assertNotExists("script/mod.d.ts.map");
     output.assertNotExists("esm/mod.d.ts.map");
   });
@@ -569,62 +596,55 @@ Deno.test("should build with source maps", async () => {
     output.assertExists("esm/mod.js.map");
     assertEquals(
       output.npmIgnore,
-      `/esm/mod.test.js
+      `/src/mod.test.ts
+/esm/mod.test.js
 /esm/mod.test.js.map
 /esm/mod.test.d.ts
-/esm/mod.test.d.ts.map
 /script/mod.test.js
 /script/mod.test.js.map
 /script/mod.test.d.ts
-/script/mod.test.d.ts.map
+/src/deps/deno.land/std@0.181.0/fmt/colors.ts
 /esm/deps/deno.land/std@0.181.0/fmt/colors.js
 /esm/deps/deno.land/std@0.181.0/fmt/colors.js.map
 /esm/deps/deno.land/std@0.181.0/fmt/colors.d.ts
-/esm/deps/deno.land/std@0.181.0/fmt/colors.d.ts.map
 /script/deps/deno.land/std@0.181.0/fmt/colors.js
 /script/deps/deno.land/std@0.181.0/fmt/colors.js.map
 /script/deps/deno.land/std@0.181.0/fmt/colors.d.ts
-/script/deps/deno.land/std@0.181.0/fmt/colors.d.ts.map
+/src/deps/deno.land/std@0.181.0/testing/_diff.ts
 /esm/deps/deno.land/std@0.181.0/testing/_diff.js
 /esm/deps/deno.land/std@0.181.0/testing/_diff.js.map
 /esm/deps/deno.land/std@0.181.0/testing/_diff.d.ts
-/esm/deps/deno.land/std@0.181.0/testing/_diff.d.ts.map
 /script/deps/deno.land/std@0.181.0/testing/_diff.js
 /script/deps/deno.land/std@0.181.0/testing/_diff.js.map
 /script/deps/deno.land/std@0.181.0/testing/_diff.d.ts
-/script/deps/deno.land/std@0.181.0/testing/_diff.d.ts.map
+/src/deps/deno.land/std@0.181.0/testing/_format.ts
 /esm/deps/deno.land/std@0.181.0/testing/_format.js
 /esm/deps/deno.land/std@0.181.0/testing/_format.js.map
 /esm/deps/deno.land/std@0.181.0/testing/_format.d.ts
-/esm/deps/deno.land/std@0.181.0/testing/_format.d.ts.map
 /script/deps/deno.land/std@0.181.0/testing/_format.js
 /script/deps/deno.land/std@0.181.0/testing/_format.js.map
 /script/deps/deno.land/std@0.181.0/testing/_format.d.ts
-/script/deps/deno.land/std@0.181.0/testing/_format.d.ts.map
+/src/deps/deno.land/std@0.181.0/testing/asserts.ts
 /esm/deps/deno.land/std@0.181.0/testing/asserts.js
 /esm/deps/deno.land/std@0.181.0/testing/asserts.js.map
 /esm/deps/deno.land/std@0.181.0/testing/asserts.d.ts
-/esm/deps/deno.land/std@0.181.0/testing/asserts.d.ts.map
 /script/deps/deno.land/std@0.181.0/testing/asserts.js
 /script/deps/deno.land/std@0.181.0/testing/asserts.js.map
 /script/deps/deno.land/std@0.181.0/testing/asserts.d.ts
-/script/deps/deno.land/std@0.181.0/testing/asserts.d.ts.map
+/src/_dnt.test_polyfills.ts
 /esm/_dnt.test_polyfills.js
 /esm/_dnt.test_polyfills.js.map
 /esm/_dnt.test_polyfills.d.ts
-/esm/_dnt.test_polyfills.d.ts.map
 /script/_dnt.test_polyfills.js
 /script/_dnt.test_polyfills.js.map
 /script/_dnt.test_polyfills.d.ts
-/script/_dnt.test_polyfills.d.ts.map
+/src/_dnt.test_shims.ts
 /esm/_dnt.test_shims.js
 /esm/_dnt.test_shims.js.map
 /esm/_dnt.test_shims.d.ts
-/esm/_dnt.test_shims.d.ts.map
 /script/_dnt.test_shims.js
 /script/_dnt.test_shims.js.map
 /script/_dnt.test_shims.d.ts
-/script/_dnt.test_shims.d.ts.map
 /test_runner.cjs
 yarn.lock
 pnpm-lock.yaml
@@ -691,11 +711,9 @@ Deno.test("should build with package mappings", async () => {
 /esm/mod.test.js
 /script/mod.test.js
 /types/mod.test.d.ts
-/types/mod.test.d.ts.map
 /esm/_dnt.test_shims.js
 /script/_dnt.test_shims.js
 /types/_dnt.test_shims.d.ts
-/types/_dnt.test_shims.d.ts.map
 /test_runner.cjs
 yarn.lock
 pnpm-lock.yaml
@@ -1380,16 +1398,12 @@ Deno.test("should build jsr project", async () => {
       `/src/
 /esm/mod.test.js
 /esm/mod.test.d.ts
-/esm/mod.test.d.ts.map
 /script/mod.test.js
 /script/mod.test.d.ts
-/script/mod.test.d.ts.map
 /esm/_dnt.test_shims.js
 /esm/_dnt.test_shims.d.ts
-/esm/_dnt.test_shims.d.ts.map
 /script/_dnt.test_shims.js
 /script/_dnt.test_shims.d.ts
-/script/_dnt.test_shims.d.ts.map
 /test_runner.cjs
 yarn.lock
 pnpm-lock.yaml


### PR DESCRIPTION
Closes #400
Closes #413

## Problem

`.npmignore` decided whether to exclude `/src/` based on **JS source maps only** — declaration maps were never considered. Since `declarationMap` defaulted to `true` whenever `declaration` was enabled and `skipSourceOutput` was `false`, the default build published `.d.ts.map` files pointing at `../src/foo.ts` while `.npmignore` contained `/src/`:

```
$ npm i ./npm && cat node_modules/pkg/types/index.d.ts.map
sources: ["../src/index.ts"]

$ ls node_modules/pkg/src
(missing)
```

Editors follow those maps, find nothing, and "go to definition" lands nowhere — the report in #400. `inlineSources` does not help: it embeds `sourcesContent` in the JS source map only, never in a `.d.ts.map`.

This started when `declarationMap` became default-on in b5f0a23 (0.41.0); #400 was filed six weeks later.

The `.js` module specifiers both issues point at are not the problem — `./dom.js` in a `.d.ts` resolves to `dom.d.ts`, and `npm/src` type checks clean under `node16`, `nodenext`, and `bundler`.

## Fix

- `declarationMap` now defaults to `false`, and is ignored (with a warning) when `declaration` is disabled or `skipSourceOutput` is on, since the maps have nothing to point at.
- When declaration maps *are* emitted, `/src/` is published so they resolve.
- Test files under `/src/` are now excluded individually. They were never listed, so anyone using `sourceMap: true` (which already published `/src/`) was shipping their test sources and test shims.

## Verification

Building a package with `declarationMap: true` and installing it:

```
index.d.ts.map -> ../src/index.ts: EXISTS
dom.d.ts.map   -> ../src/dom.ts:   EXISTS
```

and with the default config, no `.d.ts.map` files are emitted and `/src/` stays ignored.

`deno test -A` passes. Integration coverage added for both the new default and the `declarationMap: true` path.