### PR TITLE
feat: log auto-discovered config file and support `configFile: false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,13 +696,28 @@ await build({
 
 ### deno.json Support
 
-Starting in dnt 0.42, the deno.json is auto-discovered. A config file can be
-explicitly specified by the `configFile` key:
+Starting in dnt 0.42, the deno.json is auto-discovered by searching upwards from
+the entry points. dnt logs the config file it discovered:
+
+```
+[dnt] Auto-discovered config file: /home/david/dev/my_project/deno.json
+```
+
+A config file can be explicitly specified by the `configFile` key:
 
 ```ts
 await build({
   // ...etc...
   configFile: import.meta.resolve("../deno.json"),
+});
+```
+
+Or set it to `false` to not use a config file at all:
+
+```ts
+await build({
+  // ...etc...
+  configFile: false,
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -712,7 +712,8 @@ await build({
 });
 ```
 
-Or set it to `false` to not use a config file at all:
+Or set it to `false` to not use a config file at all, which also disables
+discovering a package.json and deno.lock:
 
 ```ts
 await build({

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -43,6 +43,7 @@
     "wasm/target/",
     "lib/pkg/",
     "rs-lib/src/polyfills/scripts/",
+    "tests/config_discovery_project/npm",
     "tests/declaration_import_project/npm",
     "tests/frozen_lockfile_project/npm",
     "tests/import_map_project/npm",

--- a/mod.ts
+++ b/mod.ts
@@ -174,7 +174,10 @@ export interface BuildOptions {
   /** Path or url to a deno.json.
    *
    * When not specified, a deno.json is auto-discovered by searching upwards
-   * from the entry points. Specify `false` to disable auto-discovery.
+   * from the entry points.
+   *
+   * Specify `false` to disable the auto-discovery, which also disables
+   * discovering a package.json and deno.lock.
    */
   configFile?: string | false;
   /** Path or url to import map.

--- a/mod.ts
+++ b/mod.ts
@@ -171,8 +171,12 @@ export interface BuildOptions {
   mappings?: SpecifierMappings;
   /** Package.json output. You may override dependencies and dev dependencies in here. */
   package: PackageJson;
-  /** Path or url to a deno.json. */
-  configFile?: string;
+  /** Path or url to a deno.json.
+   *
+   * When not specified, a deno.json is auto-discovered by searching upwards
+   * from the entry points. Specify `false` to disable auto-discovery.
+   */
+  configFile?: string | false;
   /** Path or url to import map.
    *
    * @remarks Use `configFile` for a deno.json. Like `deno --import-map`, the
@@ -340,6 +344,13 @@ export async function build(options: BuildOptions): Promise<void> {
 
   log("Transforming...");
   const transformOutput = await transformEntryPoints();
+  if (transformOutput.discoveredConfigFile != null) {
+    log(
+      `Auto-discovered config file: ${
+        standardizePath(transformOutput.discoveredConfigFile)
+      }`,
+    );
+  }
   for (const warning of transformOutput.warnings) {
     warn(warning);
   }

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -100,6 +100,11 @@ pub struct TransformOutput {
   pub main: TransformOutputEnvironment,
   pub test: TransformOutputEnvironment,
   pub warnings: Vec<String>,
+  /// Config file that was auto-discovered based on the entry points.
+  ///
+  /// This is `None` when a config file was explicitly provided or when
+  /// auto-discovery is disabled.
+  pub discovered_config_file: Option<PathBuf>,
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
@@ -261,6 +266,9 @@ pub struct TransformOptions {
   /// over what `target` implies.
   pub polyfills: PolyfillOverrides,
   pub config_file: Option<ModuleSpecifier>,
+  /// Disables auto-discovering a config file based on the entry points
+  /// when no config file or import map is provided.
+  pub no_config: bool,
   pub import_map: Option<ModuleSpecifier>,
   /// Errors when the deno lockfile would need to be updated in order to
   /// transform (ex. a dependency is not in it).
@@ -329,6 +337,7 @@ pub async fn transform(
   };
   let config_discovery = match maybe_config_path.as_ref() {
     Some(config_path) => ConfigDiscoveryOption::Path(config_path.clone()),
+    None if options.no_config => ConfigDiscoveryOption::Disabled,
     None => {
       if paths.is_empty() {
         ConfigDiscoveryOption::DiscoverCwd
@@ -337,6 +346,10 @@ pub async fn transform(
       }
     }
   };
+  let is_auto_discovering = matches!(
+    config_discovery,
+    ConfigDiscoveryOption::Discover { .. } | ConfigDiscoveryOption::DiscoverCwd
+  );
 
   let factory = deno_resolver::factory::WorkspaceFactory::new(
     sys,
@@ -360,6 +373,14 @@ pub async fn transform(
       no_lock: false,
     },
   );
+  let discovered_config_file = if is_auto_discovering {
+    factory
+      .workspace_directory()?
+      .member_or_root_deno_json()
+      .and_then(|c| deno_path_util::url_to_file_path(&c.specifier).ok())
+  } else {
+    None
+  };
   let file_fetcher = PermissionedFileFetcher::new(
     NullBlobStore,
     Rc::new(factory.http_cache()?.clone()),
@@ -665,6 +686,7 @@ pub async fn transform(
     main: main_env_context.environment,
     test: test_env_context.environment,
     warnings,
+    discovered_config_file,
   })
 }
 

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -100,10 +100,11 @@ pub struct TransformOutput {
   pub main: TransformOutputEnvironment,
   pub test: TransformOutputEnvironment,
   pub warnings: Vec<String>,
-  /// Config file that was auto-discovered based on the entry points.
+  /// Config file that was auto-discovered by searching upwards from the
+  /// entry points (or the cwd when there are no local entry points).
   ///
-  /// This is `None` when a config file was explicitly provided or when
-  /// auto-discovery is disabled.
+  /// This is `None` when no config file was found, when one was explicitly
+  /// provided, or when auto-discovery is disabled.
   pub discovered_config_file: Option<PathBuf>,
 }
 
@@ -268,6 +269,8 @@ pub struct TransformOptions {
   pub config_file: Option<ModuleSpecifier>,
   /// Disables auto-discovering a config file based on the entry points
   /// when no config file or import map is provided.
+  ///
+  /// Note this also disables discovering a package.json and deno.lock.
   pub no_config: bool,
   pub import_map: Option<ModuleSpecifier>,
   /// Errors when the deno lockfile would need to be updated in order to

--- a/rs-lib/tests/integration/test_builder.rs
+++ b/rs-lib/tests/integration/test_builder.rs
@@ -29,6 +29,7 @@ pub struct TestBuilder {
   target: ScriptTarget,
   polyfills: PolyfillOverrides,
   config_file: Option<ModuleSpecifier>,
+  no_config: bool,
   import_map: Option<ModuleSpecifier>,
   frozen_lockfile: Option<bool>,
 }
@@ -50,6 +51,7 @@ impl TestBuilder {
       target: ScriptTarget::ES5,
       polyfills: Default::default(),
       config_file: None,
+      no_config: false,
       import_map: None,
       frozen_lockfile: None,
     }
@@ -81,8 +83,13 @@ impl TestBuilder {
   }
 
   pub fn set_config_file(&mut self, url: impl AsRef<str>) -> &mut Self {
-    self.import_map =
+    self.config_file =
       Some(ModuleSpecifier::parse(&normalize_urls(url.as_ref())).unwrap());
+    self
+  }
+
+  pub fn set_no_config(&mut self, value: bool) -> &mut Self {
+    self.no_config = value;
     self
   }
 
@@ -218,6 +225,7 @@ impl TestBuilder {
         target: self.target,
         polyfills: self.polyfills.clone(),
         config_file: self.config_file.clone(),
+        no_config: self.no_config,
         import_map: self.import_map.clone(),
         frozen_lockfile: self.frozen_lockfile,
         cwd: self.loader.sys.env_current_dir().unwrap(),

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -15,6 +15,7 @@ use pretty_assertions::assert_eq;
 #[macro_use]
 mod integration;
 
+use integration::InMemoryLoader;
 use integration::TestBuilder;
 
 use crate::integration::assert_identity_transforms;
@@ -1244,7 +1245,7 @@ async fn transform_jsr_specifier_mappings() {
 }
 
 #[tokio::test]
-async fn transform_jsr_specifier_mapping_via_import_map() {
+async fn transform_jsr_specifier_mapping_via_config_file() {
   let result = TestBuilder::new()
     .with_loader(|loader| {
       loader
@@ -1259,6 +1260,42 @@ async fn transform_jsr_specifier_mapping_via_import_map() {
         );
     })
     .set_config_file("file:///deno.json")
+    // the version requirement comes from the config file
+    .add_package_specifier_mapping("jsr:@scope/name", "scope-name", None, None)
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[("mod.ts", "import * as pkg from 'scope-name';")]
+  );
+  assert_eq!(
+    result.main.dependencies,
+    &[Dependency {
+      name: "scope-name".to_string(),
+      version: "^1.0.0".to_string(),
+      peer_dependency: false,
+    }]
+  );
+}
+
+#[tokio::test]
+async fn transform_jsr_specifier_mapping_via_import_map() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file("/mod.ts", "import * as pkg from '@scope/name';")
+        .add_local_file(
+          "/import_map.json",
+          r#"{
+  "imports": {
+    "@scope/name": "jsr:@scope/name@^1.0.0"
+  }
+}"#,
+        );
+    })
+    .set_import_map("file:///import_map.json")
     // the version requirement comes from the import map
     .add_package_specifier_mapping("jsr:@scope/name", "scope-name", None, None)
     .transform()
@@ -1576,6 +1613,8 @@ async fn transform_import_map() {
     .await
     .unwrap();
 
+  // the import map is used as the config file, so nothing was auto-discovered
+  assert_eq!(result.discovered_config_file, None);
   assert_files!(
     result.main.files,
     &[
@@ -1842,7 +1881,7 @@ async fn transform_config_file() {
 async fn transform_auto_discovered_config_file() {
   let result = TestBuilder::new()
     .with_loader(|loader| {
-      add_auto_discovered_config_files(loader);
+      add_config_discovery_files(loader);
     })
     .entry_point("file:///sub_dir/mod.ts")
     .transform()
@@ -1870,7 +1909,7 @@ async fn transform_auto_discovered_config_file() {
 async fn transform_no_config() {
   let err_message = TestBuilder::new()
     .with_loader(|loader| {
-      add_auto_discovered_config_files(loader);
+      add_config_discovery_files(loader);
     })
     .entry_point("file:///sub_dir/mod.ts")
     .set_no_config(true)
@@ -1888,25 +1927,6 @@ async fn transform_no_config() {
     at file:///sub_dir/mod.ts:1:25"
     )
   );
-}
-
-/// Adds a config file in a parent directory of the `/sub_dir/mod.ts`
-/// entry point so that it's only found by searching upwards from it.
-fn add_auto_discovered_config_files(loader: &mut integration::InMemoryLoader) {
-  loader
-    .add_local_file(
-      "/sub_dir/mod.ts",
-      "import * as remote from 'localhost/mod.ts';",
-    )
-    .add_local_file(
-      "/deno.json",
-      r#"{
-  "imports": {
-    "localhost/mod.ts": "./other.ts"
-  }
-}"#,
-    )
-    .add_local_file("/other.ts", "export function test() {}");
 }
 
 #[tokio::test]
@@ -2923,4 +2943,23 @@ fn get_shim_file_text(mut text: String) -> String {
       .replace("export function", "function"),
   );
   text
+}
+
+/// Adds a config file in a parent directory of the `/sub_dir/mod.ts`
+/// entry point so that it's only found by searching upwards from it.
+fn add_config_discovery_files(loader: &mut InMemoryLoader) {
+  loader
+    .add_local_file(
+      "/sub_dir/mod.ts",
+      "import * as remote from 'localhost/mod.ts';",
+    )
+    .add_local_file(
+      "/deno.json",
+      r#"{
+  "imports": {
+    "localhost/mod.ts": "./other.ts"
+  }
+}"#,
+    )
+    .add_local_file("/other.ts", "export function test() {}");
 }

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1826,6 +1826,8 @@ async fn transform_config_file() {
     .await
     .unwrap();
 
+  // it was provided, so it wasn't auto-discovered
+  assert_eq!(result.discovered_config_file, None);
   assert_files!(
     result.main.files,
     &[
@@ -1834,6 +1836,77 @@ async fn transform_config_file() {
       ("subdir/other.ts", "export function test() {}",)
     ]
   );
+}
+
+#[tokio::test]
+async fn transform_auto_discovered_config_file() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      add_auto_discovered_config_files(loader);
+    })
+    .entry_point("file:///sub_dir/mod.ts")
+    .transform()
+    .await
+    .unwrap();
+
+  assert_eq!(
+    result.discovered_config_file,
+    Some(PathBuf::from(if cfg!(windows) {
+      "C:\\deno.json"
+    } else {
+      "/deno.json"
+    }))
+  );
+  assert_files!(
+    result.main.files,
+    &[
+      ("sub_dir/mod.ts", "import * as remote from '../other.js';",),
+      ("other.ts", "export function test() {}",)
+    ]
+  );
+}
+
+#[tokio::test]
+async fn transform_no_config() {
+  let err_message = TestBuilder::new()
+    .with_loader(|loader| {
+      add_auto_discovered_config_files(loader);
+    })
+    .entry_point("file:///sub_dir/mod.ts")
+    .set_no_config(true)
+    .transform()
+    .await
+    .err()
+    .unwrap();
+
+  // the config file should not have been discovered, so its
+  // import mapping should not have been applied
+  assert_eq!(
+    err_message.to_string(),
+    normalize_urls(
+      "Import \"localhost/mod.ts\" not a dependency
+    at file:///sub_dir/mod.ts:1:25"
+    )
+  );
+}
+
+/// Adds a config file in a parent directory of the `/sub_dir/mod.ts`
+/// entry point so that it's only found by searching upwards from it.
+fn add_auto_discovered_config_files(loader: &mut integration::InMemoryLoader) {
+  loader
+    .add_local_file(
+      "/sub_dir/mod.ts",
+      "import * as remote from 'localhost/mod.ts';",
+    )
+    .add_local_file(
+      "/deno.json",
+      r#"{
+  "imports": {
+    "localhost/mod.ts": "./other.ts"
+  }
+}"#,
+    )
+    .add_local_file("/other.ts", "export function test() {}");
 }
 
 #[tokio::test]

--- a/tests/config_discovery_project/deno.json
+++ b/tests/config_discovery_project/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@dnt/marker": "./marker.ts"
+  }
+}

--- a/tests/config_discovery_project/marker.ts
+++ b/tests/config_discovery_project/marker.ts
@@ -1,0 +1,3 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+export const marker = "marker";

--- a/tests/config_discovery_project/mod.ts
+++ b/tests/config_discovery_project/mod.ts
@@ -1,0 +1,7 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { marker } from "@dnt/marker";
+
+export function getMarker() {
+  return marker;
+}

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1412,6 +1412,62 @@ pnpm-lock.yaml
   });
 });
 
+Deno.test("should auto-discover the deno.json", async () => {
+  const logs = await captureLogs(() =>
+    runTest("config_discovery_project", {
+      entryPoints: ["mod.ts"],
+      outDir: "./npm",
+      shims: {},
+      test: false,
+      typeCheck: false,
+      skipNpmInstall: true,
+      package: {
+        name: "config_discovery",
+        version: "0.0.0",
+      },
+    }, (output) => {
+      assertStringIncludes(
+        output.getFileText("esm/mod.js"),
+        `from "./marker.js"`,
+      );
+    })
+  );
+
+  assertStringIncludes(
+    logs.join("\n"),
+    `[dnt] Auto-discovered config file: ${
+      path.join(Deno.cwd(), "tests", "config_discovery_project", "deno.json")
+    }`,
+  );
+});
+
+Deno.test("should not auto-discover the deno.json when configFile is false", async () => {
+  const logs = await captureLogs(async () => {
+    const err = await assertRejects(() =>
+      runTest("config_discovery_project", {
+        entryPoints: ["mod.ts"],
+        outDir: "./npm",
+        shims: {},
+        test: false,
+        typeCheck: false,
+        skipNpmInstall: true,
+        configFile: false,
+        package: {
+          name: "config_discovery",
+          version: "0.0.0",
+        },
+      })
+    );
+    // the mapping in the deno.json was not applied
+    assertStringIncludes(String(err), `Import "@dnt/marker" not a dependency`);
+  });
+
+  assertEquals(
+    logs.some((l) => l.includes("Auto-discovered config file")),
+    false,
+  );
+});
+
 Deno.test("should build workspace project", async () => {
   for (
     const configFile of [
@@ -1519,6 +1575,7 @@ export interface Output {
 async function runTest(
   project:
     | "bin_shebang_project"
+    | "config_discovery_project"
     | "declaration_import_project"
     | "frozen_lockfile_project"
     | "import_map_project"
@@ -1616,6 +1673,21 @@ function assertPreloadModuleOutput(output: Output) {
   const filePaths = /const filePaths = \[([^\]]*)\]/.exec(testRunnerText)![1];
   assertStringIncludes(filePaths, "mod.test.js");
   assertEquals(filePaths.includes("test_preload"), false);
+}
+
+async function captureLogs(action: () => Promise<void>) {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => {
+    logs.push(args.join(" "));
+    originalLog(...args);
+  };
+  try {
+    await action();
+  } finally {
+    console.log = originalLog;
+  }
+  return logs;
 }
 
 function getAllShimOptions(value: ShimValue): ShimOptions {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1442,30 +1442,24 @@ Deno.test("should auto-discover the deno.json", async () => {
 });
 
 Deno.test("should not auto-discover the deno.json when configFile is false", async () => {
-  const logs = await captureLogs(async () => {
-    const err = await assertRejects(() =>
-      runTest("config_discovery_project", {
-        entryPoints: ["mod.ts"],
-        outDir: "./npm",
-        shims: {},
-        test: false,
-        typeCheck: false,
-        skipNpmInstall: true,
-        configFile: false,
-        package: {
-          name: "config_discovery",
-          version: "0.0.0",
-        },
-      })
-    );
-    // the mapping in the deno.json was not applied
-    assertStringIncludes(String(err), `Import "@dnt/marker" not a dependency`);
-  });
-
-  assertEquals(
-    logs.some((l) => l.includes("Auto-discovered config file")),
-    false,
+  const err = await assertRejects(() =>
+    runTest("config_discovery_project", {
+      entryPoints: ["mod.ts"],
+      outDir: "./npm",
+      shims: {},
+      test: false,
+      typeCheck: false,
+      skipNpmInstall: true,
+      configFile: false,
+      package: {
+        name: "config_discovery",
+        version: "0.0.0",
+      },
+    })
   );
+
+  // the mapping in the deno.json was not applied
+  assertStringIncludes(String(err), `Import "@dnt/marker" not a dependency`);
 });
 
 Deno.test("should build workspace project", async () => {

--- a/transform.ts
+++ b/transform.ts
@@ -81,7 +81,10 @@ export interface TransformOptions {
   /** Path or url to a deno.json.
    *
    * When not specified, a deno.json is auto-discovered by searching upwards
-   * from the entry points. Specify `false` to disable auto-discovery.
+   * from the entry points.
+   *
+   * Specify `false` to disable the auto-discovery, which also disables
+   * discovering a package.json and deno.lock.
    */
   configFile?: string | false;
   /**
@@ -108,11 +111,11 @@ export interface TransformOutput {
   main: TransformOutputEnvironment;
   test: TransformOutputEnvironment;
   warnings: string[];
-  /** Path of the config file that was auto-discovered based on the entry
-   * points.
+  /** Path of the config file that was auto-discovered by searching upwards
+   * from the entry points (or the cwd when there are no local entry points).
    *
-   * This is `undefined` when a config file was explicitly provided or when
-   * auto-discovery is disabled.
+   * This is `undefined` when no config file was found, when one was
+   * explicitly provided, or when auto-discovery is disabled.
    */
   discoveredConfigFile?: string;
 }

--- a/transform.ts
+++ b/transform.ts
@@ -78,7 +78,12 @@ export interface TransformOptions {
   polyfills?: Partial<Record<PolyfillName, boolean>>;
   /// Path or url to the import map.
   importMap?: string;
-  configFile?: string;
+  /** Path or url to a deno.json.
+   *
+   * When not specified, a deno.json is auto-discovered by searching upwards
+   * from the entry points. Specify `false` to disable auto-discovery.
+   */
+  configFile?: string | false;
   /**
    * Errors when the deno lock file would need to be updated in order to
    * transform (ex. a dependency is not in it).
@@ -103,6 +108,13 @@ export interface TransformOutput {
   main: TransformOutputEnvironment;
   test: TransformOutputEnvironment;
   warnings: string[];
+  /** Path of the config file that was auto-discovered based on the entry
+   * points.
+   *
+   * This is `undefined` when a config file was explicitly provided or when
+   * auto-discovery is disabled.
+   */
+  discoveredConfigFile?: string;
 }
 
 export interface TransformOutputEnvironment {
@@ -141,6 +153,10 @@ export function transform(
     importMap: options.importMap == null
       ? undefined
       : valueToUrl(options.importMap),
+    configFile: typeof options.configFile === "string"
+      ? valueToUrl(options.configFile)
+      : undefined,
+    noConfig: options.configFile === false,
   };
   return wasm.transform(newOptions);
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -206,6 +206,8 @@ pub struct TransformOptions {
   pub polyfills: HashMap<String, bool>,
   pub import_map: Option<ModuleSpecifier>,
   pub config_file: Option<ModuleSpecifier>,
+  #[serde(default)]
+  pub no_config: bool,
   pub frozen_lockfile: Option<bool>,
   pub cwd: ModuleSpecifier,
 }
@@ -241,6 +243,7 @@ async fn transform_inner(options: JsValue) -> Result<JsValue, anyhow::Error> {
       polyfills: options.polyfills,
       import_map: options.import_map,
       config_file: options.config_file,
+      no_config: options.no_config,
       frozen_lockfile: options.frozen_lockfile,
       cwd: deno_path_util::url_to_file_path(&options.cwd)?,
     },


### PR DESCRIPTION
Closes #399

The deno.json has been auto-discovered since 0.42 (#462), but there was no indication of which config file a build ended up using. Now it's logged:

```
[dnt] Transforming...
[dnt] Auto-discovered config file: /home/david/dev/my_project/deno.json
[dnt] Building project...
```

Additionally, `configFile` accepts `false` to opt out of the discovery entirely:

```ts
await build({
  // ...etc...
  configFile: false,
});
```

Details:

- The discovery already searches upwards from the entry points rather than the cwd, so the reported path is the config file that was actually used.
- Nothing is logged when a config file is explicitly provided, when an import map is provided (it's used as the config file), or when nothing was found.
- `configFile: false` maps to `ConfigDiscoveryOption::Disabled`, which also stops a package.json and deno.lock from being discovered. That's documented on the option and in the readme.
- `configFile` is now run through `valueToUrl` like `importMap` already was, so a plain path works instead of erroring while deserializing the specifier.
- Also fixes `set_config_file` in the rust test builder, which was setting the import map instead of the config file. The one test relying on it is renamed to match what it covers and a sibling test was added for the import map path.