### PR TITLE
feat: support bare specifiers in `mappings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,36 @@ Note that dnt will error if you specify a mapping and it is not found in the
 code. This is done to prevent the scenario where a remote specifier's version is
 bumped and the mapping isn't updated.
 
+#### Mapping a bare specifier
+
+A bare specifier may be used, in which case it's resolved via the config file's
+import map. For example, given a deno.json with:
+
+```jsonc
+{
+  "imports": {
+    "code-block-writer": "https://deno.land/x/code_block_writer@11.0.0/mod.ts"
+  }
+}
+```
+
+...the specifier can be mapped by the name used in the code:
+
+```ts
+await build({
+  // ...etc...
+  mappings: {
+    "code-block-writer": {
+      name: "code-block-writer",
+      version: "^11.0.0",
+    },
+  },
+});
+```
+
+A key that has a scheme or that looks like a relative or absolute path is not
+treated as a bare specifier.
+
 #### Mapping a JSR package to an npm package
 
 A `jsr:` specifier may be mapped the same way:

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -43,6 +43,7 @@
     "wasm/target/",
     "lib/pkg/",
     "rs-lib/src/polyfills/scripts/",
+    "tests/bare_mapping_project/npm",
     "tests/declaration_import_project/npm",
     "tests/frozen_lockfile_project/npm",
     "tests/import_map_project/npm",

--- a/mod.ts
+++ b/mod.ts
@@ -167,6 +167,18 @@ export interface BuildOptions {
    *   version: "^11.0.0",
    * }
    * ```
+   *
+   * A bare specifier may be used, which is resolved via the config file's
+   * import map:
+   *
+   * ```
+   * mappings: {
+   *   "code-block-writer": {
+   *     name: "code-block-writer",
+   *     version: "^11.0.0",
+   *   }
+   * }
+   * ```
    */
   mappings?: SpecifierMappings;
   /** Package.json output. You may override dependencies and dev dependencies in here. */

--- a/rs-lib/src/graph.rs
+++ b/rs-lib/src/graph.rs
@@ -43,6 +43,8 @@ pub struct ModuleGraphOptions<'a, TSys: WorkspaceFactorySys> {
   pub loader: Rc<dyn deno_graph::source::Loader>,
   pub resolver: DefaultDenoResolverRc<TSys>,
   pub specifier_mappings: &'a HashMap<ModuleSpecifier, MappedSpecifier>,
+  /// Original key of each mapping, which is what the user specified.
+  pub specifier_mapping_keys: &'a HashMap<ModuleSpecifier, String>,
   pub compiler_options_resolver: Rc<CompilerOptionsResolver>,
   pub cjs_tracker:
     Rc<deno_resolver::cjs::CjsTracker<DenoInNpmPackageChecker, TSys>>,
@@ -208,7 +210,10 @@ impl ModuleGraph {
     if !not_found_module_mappings.is_empty() {
       bail!(
         "The following specifiers were indicated to be mapped to a module, but were not found:\n{}",
-        format_specifiers_for_message(not_found_module_mappings),
+        format_specifiers_for_message(
+          not_found_module_mappings,
+          options.specifier_mapping_keys,
+        ),
       );
     }
 
@@ -240,7 +245,10 @@ impl ModuleGraph {
     if !not_found_package_specifiers.is_empty() {
       bail!(
         "The following specifiers were indicated to be mapped to a package, but were not found:\n{}",
-        format_specifiers_for_message(not_found_package_specifiers),
+        format_specifiers_for_message(
+          not_found_package_specifiers,
+          options.specifier_mapping_keys,
+        ),
       );
     }
 
@@ -485,11 +493,16 @@ fn from_graph_specifier(
 
 fn format_specifiers_for_message(
   mut specifiers: Vec<&ModuleSpecifier>,
+  keys: &HashMap<ModuleSpecifier, String>,
 ) -> String {
   specifiers.sort();
   specifiers
     .into_iter()
-    .map(|s| format!("  * {}", s))
+    .map(|s| match keys.get(s) {
+      // show what the user specified when it was a bare specifier
+      Some(key) if key != s.as_str() => format!("  * {} ({})", key, s),
+      _ => format!("  * {}", s),
+    })
     .collect::<Vec<_>>()
     .join("\n")
 }

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -31,6 +31,7 @@ use deno_resolver::file_fetcher::DenoGraphLoader;
 use deno_resolver::file_fetcher::DenoGraphLoaderOptions;
 use deno_resolver::file_fetcher::PermissionedFileFetcher;
 use deno_resolver::file_fetcher::PermissionedFileFetcherOptions;
+use deno_resolver::npm::DenoInNpmPackageChecker;
 use deno_resolver::workspace::SpecifiedImportMap;
 use deno_resolver::NodeResolverOptions;
 use deno_semver::npm::NpmPackageReqReference;
@@ -420,12 +421,17 @@ pub async fn transform(
     },
   );
   let deno_resolver = resolver_factory.deno_resolver().await?;
-  let specifier_mappings = resolve_specifier_mappings(
-    options.specifier_mappings,
-    &deno_resolver,
-    &options.entry_points[0],
-  )?;
   let cjs_tracker = resolver_factory.cjs_tracker()?.clone();
+  let (specifier_mappings, specifier_mapping_keys) =
+    resolve_specifier_mappings(
+      options.specifier_mappings,
+      &deno_resolver,
+      &cjs_tracker,
+      options
+        .entry_points
+        .iter()
+        .chain(options.test_entry_points.iter()),
+    )?;
   let maybe_lockfile = resolver_factory
     .workspace_factory()
     .maybe_lockfile(&NullNpmPackageInfoProvider)
@@ -468,6 +474,7 @@ pub async fn transform(
         )
         .collect(),
       specifier_mappings: &specifier_mappings,
+      specifier_mapping_keys: &specifier_mapping_keys,
       loader,
       resolver: deno_resolver.clone(),
       compiler_options_resolver: resolver_factory
@@ -676,6 +683,71 @@ pub async fn transform(
   })
 }
 
+/// Resolves the specifier mapping keys, which may be bare specifiers that
+/// resolve via the config file's import map (ex. `my-lib`).
+///
+/// Returns the resolved mappings along with the original key of each, which
+/// is used when displaying a mapping in an error message.
+fn resolve_specifier_mappings<'a, TSys: deno_resolver::DenoResolverSys>(
+  mappings: HashMap<String, MappedSpecifier>,
+  resolver: &deno_resolver::graph::DefaultDenoResolverRc<TSys>,
+  cjs_tracker: &deno_resolver::cjs::CjsTracker<DenoInNpmPackageChecker, TSys>,
+  referrers: impl Iterator<Item = &'a ModuleSpecifier> + Clone,
+) -> Result<(
+  HashMap<ModuleSpecifier, MappedSpecifier>,
+  HashMap<ModuleSpecifier, String>,
+)> {
+  let mut resolved = HashMap::with_capacity(mappings.len());
+  let mut keys = HashMap::with_capacity(mappings.len());
+  // resolve in a deterministic order so that any error is deterministic
+  for (key, value) in mappings.into_iter().collect::<BTreeMap<_, _>>() {
+    // urls are used as-is in order to not change how they've always resolved
+    let specifier = match ModuleSpecifier::parse(&key) {
+      Ok(specifier) => specifier,
+      Err(_) => {
+        resolve_mapping_key(&key, resolver, cjs_tracker, referrers.clone())?
+      }
+    };
+    if let Some(previous_key) = keys.insert(specifier.clone(), key.clone()) {
+      bail!(
+        "The mappings \"{}\" and \"{}\" both resolved to {}",
+        previous_key,
+        key,
+        specifier,
+      );
+    }
+    resolved.insert(specifier, value);
+  }
+  Ok((resolved, keys))
+}
+
+fn resolve_mapping_key<'a, TSys: deno_resolver::DenoResolverSys>(
+  key: &str,
+  resolver: &deno_resolver::graph::DefaultDenoResolverRc<TSys>,
+  cjs_tracker: &deno_resolver::cjs::CjsTracker<DenoInNpmPackageChecker, TSys>,
+  referrers: impl Iterator<Item = &'a ModuleSpecifier>,
+) -> Result<ModuleSpecifier> {
+  let mut last_err = None;
+  for referrer in referrers {
+    match resolver.resolve(
+      key,
+      referrer,
+      deno_graph::Position::zeroed(),
+      cjs_tracker.get_referrer_kind(referrer),
+      node_resolver::NodeResolutionKind::Execution,
+    ) {
+      Ok(specifier) => return Ok(specifier),
+      Err(err) => last_err = Some(err),
+    }
+  }
+  match last_err {
+    Some(err) => {
+      Err(err).with_context(|| format!("Failed resolving mapping \"{}\"", key))
+    }
+    None => bail!("Failed resolving mapping \"{}\"", key),
+  }
+}
+
 /// Provides npm package info when reading the lockfile.
 ///
 /// dnt resolves npm specifiers via the specifier mappers rather than through
@@ -875,42 +947,6 @@ fn check_add_shim_file_to_environment(
 
     text
   }
-}
-
-/// Resolves the specifier mapping keys, which may be bare specifiers that
-/// resolve via the config file's import map (ex. `my-lib`).
-fn resolve_specifier_mappings<
-  TInNpmPackageChecker: node_resolver::InNpmPackageChecker,
-  TIsBuiltInNodeModuleChecker: node_resolver::IsBuiltInNodeModuleChecker,
-  TNpmPackageFolderResolver: node_resolver::NpmPackageFolderResolver,
-  TSys: deno_resolver::DenoResolverSys,
->(
-  mappings: HashMap<String, MappedSpecifier>,
-  resolver: &deno_resolver::graph::DenoResolver<
-    TInNpmPackageChecker,
-    TIsBuiltInNodeModuleChecker,
-    TNpmPackageFolderResolver,
-    TSys,
-  >,
-  referrer: &ModuleSpecifier,
-) -> Result<HashMap<ModuleSpecifier, MappedSpecifier>> {
-  let mut result = HashMap::with_capacity(mappings.len());
-  for (key, value) in mappings {
-    let specifier = match ModuleSpecifier::parse(&key) {
-      Ok(specifier) => specifier,
-      Err(_) => resolver
-        .resolve(
-          &key,
-          referrer,
-          deno_graph::Position::zeroed(),
-          node_resolver::ResolutionMode::Import,
-          node_resolver::NodeResolutionKind::Execution,
-        )
-        .with_context(|| format!("Failed resolving mapping \"{}\".", key))?,
-    };
-    result.insert(specifier, value);
-  }
-  Ok(result)
 }
 
 fn get_dependencies(

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -253,7 +253,10 @@ pub struct TransformOptions {
   pub shims: Vec<Shim>,
   pub test_shims: Vec<Shim>,
   /// Maps specifiers to an npm package or module.
-  pub specifier_mappings: HashMap<ModuleSpecifier, MappedSpecifier>,
+  ///
+  /// A key may be a url or a bare specifier that resolves via the config
+  /// file's import map (ex. `my-lib`).
+  pub specifier_mappings: HashMap<String, MappedSpecifier>,
   /// Version of ECMAScript that the final code will target.
   /// This controls whether certain polyfills should occur.
   pub target: ScriptTarget,
@@ -417,6 +420,11 @@ pub async fn transform(
     },
   );
   let deno_resolver = resolver_factory.deno_resolver().await?;
+  let specifier_mappings = resolve_specifier_mappings(
+    options.specifier_mappings,
+    &deno_resolver,
+    &options.entry_points[0],
+  )?;
   let cjs_tracker = resolver_factory.cjs_tracker()?.clone();
   let maybe_lockfile = resolver_factory
     .workspace_factory()
@@ -459,7 +467,7 @@ pub async fn transform(
             .filter_map(|s| s.maybe_specifier()),
         )
         .collect(),
-      specifier_mappings: &options.specifier_mappings,
+      specifier_mappings: &specifier_mappings,
       loader,
       resolver: deno_resolver.clone(),
       compiler_options_resolver: resolver_factory
@@ -867,6 +875,42 @@ fn check_add_shim_file_to_environment(
 
     text
   }
+}
+
+/// Resolves the specifier mapping keys, which may be bare specifiers that
+/// resolve via the config file's import map (ex. `my-lib`).
+fn resolve_specifier_mappings<
+  TInNpmPackageChecker: node_resolver::InNpmPackageChecker,
+  TIsBuiltInNodeModuleChecker: node_resolver::IsBuiltInNodeModuleChecker,
+  TNpmPackageFolderResolver: node_resolver::NpmPackageFolderResolver,
+  TSys: deno_resolver::DenoResolverSys,
+>(
+  mappings: HashMap<String, MappedSpecifier>,
+  resolver: &deno_resolver::graph::DenoResolver<
+    TInNpmPackageChecker,
+    TIsBuiltInNodeModuleChecker,
+    TNpmPackageFolderResolver,
+    TSys,
+  >,
+  referrer: &ModuleSpecifier,
+) -> Result<HashMap<ModuleSpecifier, MappedSpecifier>> {
+  let mut result = HashMap::with_capacity(mappings.len());
+  for (key, value) in mappings {
+    let specifier = match ModuleSpecifier::parse(&key) {
+      Ok(specifier) => specifier,
+      Err(_) => resolver
+        .resolve(
+          &key,
+          referrer,
+          deno_graph::Position::zeroed(),
+          node_resolver::ResolutionMode::Import,
+          node_resolver::NodeResolutionKind::Execution,
+        )
+        .with_context(|| format!("Failed resolving mapping \"{}\".", key))?,
+    };
+    result.insert(specifier, value);
+  }
+  Ok(result)
 }
 
 fn get_dependencies(

--- a/rs-lib/tests/integration/test_builder.rs
+++ b/rs-lib/tests/integration/test_builder.rs
@@ -23,7 +23,7 @@ pub struct TestBuilder {
   entry_point: String,
   additional_entry_points: Vec<String>,
   test_entry_points: Vec<String>,
-  specifier_mappings: HashMap<ModuleSpecifier, MappedSpecifier>,
+  specifier_mappings: HashMap<String, MappedSpecifier>,
   shims: Vec<Shim>,
   test_shims: Vec<Shim>,
   target: ScriptTarget,
@@ -153,7 +153,7 @@ impl TestBuilder {
     path: Option<&str>,
   ) -> &mut Self {
     self.specifier_mappings.insert(
-      ModuleSpecifier::parse(&normalize_urls(specifier.as_ref())).unwrap(),
+      normalize_urls(specifier.as_ref()),
       MappedSpecifier::Package(PackageMappedSpecifier {
         name: bare_specifier.as_ref().to_string(),
         version: version.map(|v| v.to_string()),
@@ -170,7 +170,7 @@ impl TestBuilder {
     to: impl AsRef<str>,
   ) -> &mut Self {
     self.specifier_mappings.insert(
-      ModuleSpecifier::parse(&normalize_urls(from.as_ref())).unwrap(),
+      normalize_urls(from.as_ref()),
       MappedSpecifier::Module(
         ModuleSpecifier::parse(&normalize_urls(to.as_ref())).unwrap(),
       ),

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1280,6 +1280,73 @@ async fn transform_jsr_specifier_mapping_via_import_map() {
 }
 
 #[tokio::test]
+async fn transform_specifier_mapping_of_bare_specifier() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file("/mod.ts", "import * as pkg from 'my-lib';")
+        .add_local_file(
+          "/deno.json",
+          r#"{
+  "imports": {
+    "my-lib": "https://localhost/my-lib/mod.ts"
+  }
+}"#,
+        )
+        .add_remote_file(
+          "https://localhost/my-lib/mod.ts",
+          "export const a = 1;",
+        );
+    })
+    // the bare specifier is resolved via the config file
+    .add_package_specifier_mapping(
+      "my-lib",
+      "npm-my-lib",
+      Some("^39.0.0"),
+      None,
+    )
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[("mod.ts", "import * as pkg from 'npm-my-lib';")]
+  );
+  assert_eq!(
+    result.main.dependencies,
+    &[Dependency {
+      name: "npm-my-lib".to_string(),
+      version: "^39.0.0".to_string(),
+      peer_dependency: false,
+    }]
+  );
+}
+
+#[tokio::test]
+async fn transform_specifier_mapping_of_unresolvable_bare_specifier() {
+  let err_message = TestBuilder::new()
+    .with_loader(|loader| {
+      loader.add_local_file("/mod.ts", "console.log(1);");
+    })
+    .add_package_specifier_mapping(
+      "my-lib",
+      "npm-my-lib",
+      Some("^39.0.0"),
+      None,
+    )
+    .transform()
+    .await
+    .err()
+    .unwrap();
+
+  assert_eq!(
+    err_message.to_string(),
+    "Failed resolving mapping \"my-lib\"."
+  );
+}
+
+#[tokio::test]
 async fn transform_jsr_specifier_mapping_not_found() {
   let error_message = TestBuilder::new()
     .with_loader(|loader| {

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1324,6 +1324,108 @@ async fn transform_specifier_mapping_of_bare_specifier() {
 }
 
 #[tokio::test]
+async fn transform_specifier_mapping_of_bare_specifier_to_jsr() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file("/mod.ts", "import * as pkg from 'my-lib';")
+        .add_local_file(
+          "/deno.json",
+          r#"{
+  "imports": {
+    "my-lib": "jsr:@scope/name@^1.0.0"
+  }
+}"#,
+        );
+    })
+    .add_package_specifier_mapping("my-lib", "scope-name", None, None)
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[("mod.ts", "import * as pkg from 'scope-name';")]
+  );
+  assert_eq!(
+    result.main.dependencies,
+    &[Dependency {
+      name: "scope-name".to_string(),
+      version: "^1.0.0".to_string(),
+      peer_dependency: false,
+    }]
+  );
+}
+
+#[tokio::test]
+async fn transform_module_specifier_mapping_of_bare_specifier() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file("/mod.ts", "import * as other from 'my-lib';")
+        .add_local_file(
+          "/deno.json",
+          r#"{
+  "imports": {
+    "my-lib": "./deno_file.ts"
+  }
+}"#,
+        )
+        .add_local_file("/deno_file.ts", "export const a = 1;")
+        .add_local_file("/node_file.ts", "export const a = 2;");
+    })
+    .add_module_specifier_mapping("my-lib", "file:///node_file.ts")
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[
+      ("mod.ts", "import * as other from './node_file.js';"),
+      ("node_file.ts", "export const a = 2;")
+    ]
+  );
+}
+
+#[tokio::test]
+async fn transform_specifier_mappings_resolving_to_same_specifier() {
+  let err_message = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file("/mod.ts", "import * as pkg from 'my-lib';")
+        .add_local_file(
+          "/deno.json",
+          r#"{
+  "imports": {
+    "my-lib": "https://localhost/my-lib/mod.ts"
+  }
+}"#,
+        )
+        .add_remote_file(
+          "https://localhost/my-lib/mod.ts",
+          "export const a = 1;",
+        );
+    })
+    .add_package_specifier_mapping("my-lib", "npm-my-lib", Some("^1.0.0"), None)
+    .add_package_specifier_mapping(
+      "https://localhost/my-lib/mod.ts",
+      "other-lib",
+      Some("^1.0.0"),
+      None,
+    )
+    .transform()
+    .await
+    .err()
+    .unwrap();
+
+  assert_eq!(
+    err_message.to_string(),
+    "The mappings \"https://localhost/my-lib/mod.ts\" and \"my-lib\" both resolved to https://localhost/my-lib/mod.ts"
+  );
+}
+
+#[tokio::test]
 async fn transform_specifier_mapping_of_unresolvable_bare_specifier() {
   let err_message = TestBuilder::new()
     .with_loader(|loader| {
@@ -1340,9 +1442,10 @@ async fn transform_specifier_mapping_of_unresolvable_bare_specifier() {
     .err()
     .unwrap();
 
+  // the message the user sees includes the cause
   assert_eq!(
-    err_message.to_string(),
-    "Failed resolving mapping \"my-lib\"."
+    format!("{:#}", err_message),
+    "Failed resolving mapping \"my-lib\": Import \"my-lib\" not a dependency"
   );
 }
 

--- a/tests/bare_mapping_project/deno.json
+++ b/tests/bare_mapping_project/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "code-block-writer": "https://deno.land/x/code_block_writer@11.0.0/mod.ts"
+  }
+}

--- a/tests/bare_mapping_project/mod.ts
+++ b/tests/bare_mapping_project/mod.ts
@@ -1,0 +1,6 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+import CodeBlockWriter from "code-block-writer";
+
+export function getResult() {
+  return new CodeBlockWriter().write("test").toString();
+}

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -779,6 +779,36 @@ Deno.test("should build with peer dependencies in mappings", async () => {
   });
 });
 
+Deno.test("should build with a bare specifier in the mappings", async () => {
+  await runTest("bare_mapping_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    typeCheck: false,
+    test: false,
+    skipNpmInstall: true,
+    shims: {},
+    package: {
+      name: "bare-mappings",
+      version: "1.0.0",
+    },
+    mappings: {
+      // resolved via the deno.json's imports
+      "code-block-writer": {
+        name: "code-block-writer",
+        version: "=11.0.0",
+      },
+    },
+  }, (output) => {
+    assertEquals(output.packageJson.dependencies, {
+      "code-block-writer": "=11.0.0",
+    });
+    assertStringIncludes(
+      output.getFileText("esm/mod.js"),
+      `from "code-block-writer"`,
+    );
+  });
+});
+
 Deno.test("should build shim project with everything enabled", async () => {
   await runTest("shim_project", {
     entryPoints: ["mod.ts"],
@@ -1518,6 +1548,7 @@ export interface Output {
 
 async function runTest(
   project:
+    | "bare_mapping_project"
     | "bin_shebang_project"
     | "declaration_import_project"
     | "frozen_lockfile_project"

--- a/transform.ts
+++ b/transform.ts
@@ -12,7 +12,11 @@ import { valueToUrl } from "./lib/utils.ts";
 
 /** Specifier to specifier mappings. */
 export interface SpecifierMappings {
-  /** Map a specifier to another module or npm package. */
+  /** Map a specifier to another module or npm package.
+   *
+   * The specifier may be a path, url, or a bare specifier that's resolved
+   * via the config file's import map (ex. `my-lib`).
+   */
   [specifier: string]: PackageMappedSpecifier | string;
 }
 
@@ -129,7 +133,7 @@ export function transform(
     ...options,
     mappings: Object.fromEntries(
       Object.entries(options.mappings ?? {}).map(([key, value]) => {
-        return [valueToUrl(key), mapMappedSpecifier(value)];
+        return [mapMappingKey(key), mapMappedSpecifier(value)];
       }),
     ),
     entryPoints: options.entryPoints.map(valueToUrl),
@@ -143,6 +147,12 @@ export function transform(
       : valueToUrl(options.importMap),
   };
   return wasm.transform(newOptions);
+}
+
+function mapMappingKey(key: string) {
+  // leave bare specifiers alone so that they can be resolved
+  // via the config file's import map (ex. `my-lib`)
+  return isPathOrUrl(key) ? valueToUrl(key) : key;
 }
 
 type SerializableMappedSpecifier = {

--- a/transform.ts
+++ b/transform.ts
@@ -6,6 +6,8 @@
  * @module
  */
 
+import { existsSync } from "@std/fs";
+import * as path from "@std/path";
 import * as wasm from "./lib/pkg/dnt_wasm.js";
 import type { PolyfillName, ScriptTarget } from "./lib/types.ts";
 import { valueToUrl } from "./lib/utils.ts";
@@ -150,9 +152,22 @@ export function transform(
 }
 
 function mapMappingKey(key: string) {
-  // leave bare specifiers alone so that they can be resolved
+  key = key.trim();
+  if (/^[a-z]+:/i.test(key) || isRelativeOrAbsolutePath(key)) {
+    return valueToUrl(key);
+  }
+  // fall back to a path for a key like `mod.ts` that resolved to
+  // one before bare specifiers were supported
+  if (existsSync(key)) {
+    return valueToUrl(key);
+  }
+  // leave bare specifiers alone so that they're resolved
   // via the config file's import map (ex. `my-lib`)
-  return isPathOrUrl(key) ? valueToUrl(key) : key;
+  return key;
+}
+
+function isRelativeOrAbsolutePath(value: string) {
+  return /^\.\.?[\\/]/.test(value) || path.isAbsolute(value);
 }
 
 type SerializableMappedSpecifier = {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -200,7 +200,7 @@ pub struct TransformOptions {
   pub test_entry_points: Vec<String>,
   pub shims: Vec<Shim>,
   pub test_shims: Vec<Shim>,
-  pub mappings: HashMap<ModuleSpecifier, MappedSpecifier>,
+  pub mappings: HashMap<String, MappedSpecifier>,
   pub target: ScriptTarget,
   #[serde(default)]
   pub polyfills: HashMap<String, bool>,


### PR DESCRIPTION
Closes #357

A `mappings` key had to be a path or url, so a specifier that only exists in the deno.json's `imports` couldn't be mapped by the name that appears in the code. Now a bare specifier key is resolved via the config file's import map:

```jsonc
// deno.json
{
  "imports": {
    "my-lib": "https://deno.land/x/my-lib@39.0.0/src/index.ts"
  }
}
```

```ts
await build({
  // ...etc...
  mappings: {
    "my-lib": {
      name: "npm-target-for-my-lib",
      version: "^39.0.0",
    },
  },
});
```

Details:

- A key is treated as a path when it has a scheme, when it's relative or absolute, or when it exists on disk (so a key like `mod.ts` keeps resolving to a file). Everything else is a bare specifier, which means package names containing a dot like `chart.js` work.
- Urls are still used as-is rather than being run through the import map, which keeps existing mappings resolving the way they always have.
- Resolution uses each entry point as the referrer in turn (main entry points then test entry points) with the referrer's resolution mode, so mappings still resolve when the first entry point isn't the relevant workspace member.
- The "indicated to be mapped ... but were not found" error now shows the key that was specified along with what it resolved to.
- Two mappings that resolve to the same specifier is now an error instead of one silently winning.