### PR TITLE
feat: add the types package of a mapped dependency to the dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,47 @@ export function fetch(/* etc... */) {
 
 This is useful in situations where you want to implement your own shim.
 
+### Type Declarations from a CDN
+
+When a remote module is mapped to an npm package and the cdn serving it
+specifies its type declarations with an `X-TypeScript-Types` header (esm.sh and
+skypack do this), the package providing those declarations is added to the dev
+dependencies.
+
+For example, this import:
+
+```ts
+import { parseSVG } from "https://esm.sh/svg-path-parser@1.1.0";
+```
+
+...outputs a package.json with:
+
+```jsonc
+{
+  "dependencies": {
+    "svg-path-parser": "1.1.0"
+  },
+  "devDependencies": {
+    "@types/svg-path-parser": "~1.1.6"
+  }
+}
+```
+
+If the declarations show up in your package's public api, move the types package
+to the dependencies by specifying it in the build options:
+
+```ts
+await build({
+  // ...etc...
+  package: {
+    // ...etc...
+    dependencies: {
+      "@types/svg-path-parser": "~1.1.6",
+    },
+  },
+});
+```
+
 ### Specifier to npm Package Mappings
 
 In most cases, dnt won't know about an npm package being available for one of

--- a/README.md
+++ b/README.md
@@ -425,47 +425,6 @@ export function fetch(/* etc... */) {
 
 This is useful in situations where you want to implement your own shim.
 
-### Type Declarations from a CDN
-
-When a remote module is mapped to an npm package and the cdn serving it
-specifies its type declarations with an `X-TypeScript-Types` header (esm.sh and
-skypack do this), the package providing those declarations is added to the dev
-dependencies.
-
-For example, this import:
-
-```ts
-import { parseSVG } from "https://esm.sh/svg-path-parser@1.1.0";
-```
-
-...outputs a package.json with:
-
-```jsonc
-{
-  "dependencies": {
-    "svg-path-parser": "1.1.0"
-  },
-  "devDependencies": {
-    "@types/svg-path-parser": "~1.1.6"
-  }
-}
-```
-
-If the declarations show up in your package's public api, move the types package
-to the dependencies by specifying it in the build options:
-
-```ts
-await build({
-  // ...etc...
-  package: {
-    // ...etc...
-    dependencies: {
-      "@types/svg-path-parser": "~1.1.6",
-    },
-  },
-});
-```
-
 ### Specifier to npm Package Mappings
 
 In most cases, dnt won't know about an npm package being available for one of

--- a/lib/package_json.test.ts
+++ b/lib/package_json.test.ts
@@ -32,6 +32,7 @@ Deno.test("single entrypoint", () => {
         }],
       },
       warnings: [],
+      typesDependencies: [],
     },
     entryPoints: [{
       name: ".",
@@ -252,6 +253,7 @@ Deno.test("exports have default last", () => {
         dependencies: [],
       },
       warnings: [],
+      typesDependencies: [],
     },
     entryPoints: [
       {
@@ -299,6 +301,7 @@ Deno.test("multiple entrypoints", () => {
         dependencies: [],
       },
       warnings: [],
+      typesDependencies: [],
     },
     entryPoints: [{
       name: ".",
@@ -375,6 +378,7 @@ Deno.test("binary entrypoints", () => {
         dependencies: [],
       },
       warnings: [],
+      typesDependencies: [],
     },
     entryPoints: [{
       name: ".",
@@ -457,6 +461,7 @@ Deno.test("peer dependencies", () => {
         }],
       },
       warnings: [],
+      typesDependencies: [],
     },
     entryPoints: [{
       name: ".",
@@ -519,4 +524,59 @@ Deno.test("peer dependencies", () => {
       2,
     ),
   );
+});
+
+Deno.test("types dependencies", () => {
+  const props: GetPackageJsonOptions = {
+    transformOutput: {
+      main: {
+        files: [],
+        dependencies: [{
+          name: "svg-path-parser",
+          version: "1.1.0",
+        }, {
+          name: "other",
+          version: "^1.0.0",
+        }],
+        entryPoints: ["mod.ts"],
+      },
+      test: {
+        entryPoints: [],
+        files: [],
+        dependencies: [],
+      },
+      warnings: [],
+      typesDependencies: [{
+        name: "@types/svg-path-parser",
+        version: "~1.1.6",
+      }, {
+        // a types package that's already a dependency is not duplicated
+        name: "other",
+        version: "^1.0.0",
+      }],
+    },
+    entryPoints: [{
+      name: ".",
+      path: "./mod.ts",
+    }],
+    package: {
+      name: "package",
+      version: "0.1.0",
+    },
+    testEnabled: false,
+    includeEsModule: true,
+    includeScriptModule: true,
+    includeDeclarations: true,
+    includeTsLib: false,
+    shims: {},
+  };
+
+  const packageJson = getPackageJson(props);
+  assertEquals(packageJson.dependencies, {
+    "svg-path-parser": "1.1.0",
+    "other": "^1.0.0",
+  });
+  assertEquals(packageJson.devDependencies, {
+    "@types/svg-path-parser": "~1.1.6",
+  });
 });

--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -79,18 +79,21 @@ export function getPackageJson({
     })
     : {};
   const devDependencies = {
+    // packages that provide the type declarations of a dependency
+    // (ex. an `@types/` package specified by an `X-TypeScript-Types` header)
+    ...Object.fromEntries(
+      transformOutput.typesDependencies
+        .filter((d) =>
+          !Object.keys(dependencies).includes(d.name) &&
+          !Object.keys(peerDependencies).includes(d.name)
+        )
+        .map((d) => [d.name, d.version]),
+    ),
     ...(shouldIncludeTypesNode()
       ? {
         "@types/node": "^20.9.0",
       }
       : {}),
-    // packages that provide the type declarations of a dependency
-    // (ex. an `@types/` package specified by an `X-TypeScript-Types` header)
-    ...Object.fromEntries(
-      transformOutput.typesDependencies
-        .filter((d) => !Object.keys(dependencies).includes(d.name))
-        .map((d) => [d.name, d.version]),
-    ),
     ...testDevDependencies,
     // override with specified dependencies
     ...(packageJsonObj.devDependencies ?? {}),

--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -84,6 +84,13 @@ export function getPackageJson({
         "@types/node": "^20.9.0",
       }
       : {}),
+    // packages that provide the type declarations of a dependency
+    // (ex. an `@types/` package specified by an `X-TypeScript-Types` header)
+    ...Object.fromEntries(
+      transformOutput.typesDependencies
+        .filter((d) => !Object.keys(dependencies).includes(d.name))
+        .map((d) => [d.name, d.version]),
+    ),
     ...testDevDependencies,
     // override with specified dependencies
     ...(packageJsonObj.devDependencies ?? {}),

--- a/rs-lib/src/declaration_file_resolution.rs
+++ b/rs-lib/src/declaration_file_resolution.rs
@@ -10,6 +10,8 @@ use deno_graph::Module;
 use deno_graph::Resolution;
 
 use crate::graph::ModuleGraph;
+use crate::loader::get_all_specifier_mappers;
+use crate::loader::get_types_package_for_specifier;
 use crate::PackageMappedSpecifier;
 
 #[derive(Debug)]
@@ -27,11 +29,21 @@ pub struct TypesDependency {
   pub referrer: ModuleSpecifier,
 }
 
+pub struct DeclarationFileResolutions {
+  pub mappings: BTreeMap<ModuleSpecifier, DeclarationFileResolution>,
+  /// Packages that provide the declaration files of a mapped package
+  /// (ex. an `@types/` package served by a cdn).
+  pub types_packages: BTreeMap<String, PackageMappedSpecifier>,
+  /// Declaration files that a types package provides, which don't
+  /// need to be included in the output.
+  pub types_package_files: HashSet<ModuleSpecifier>,
+}
+
 pub fn resolve_declaration_file_mappings(
   module_graph: &ModuleGraph,
   modules: &[&Module],
   mapped_specifiers: &BTreeMap<ModuleSpecifier, PackageMappedSpecifier>,
-) -> Result<BTreeMap<ModuleSpecifier, DeclarationFileResolution>> {
+) -> Result<DeclarationFileResolutions> {
   let mut type_dependencies = BTreeMap::new();
 
   for module in modules.iter().filter_map(|m| m.js()) {
@@ -39,16 +51,27 @@ pub fn resolve_declaration_file_mappings(
   }
 
   // get the resolved type dependencies
+  let mappers = get_all_specifier_mappers();
   let mut mappings = BTreeMap::new();
+  let mut types_packages = BTreeMap::new();
+  let mut types_package_files = HashSet::new();
   for (code_specifier, deps) in type_dependencies.into_iter() {
-    // if this type_dependency is mapped, then pass it.
-    if mapped_specifiers.contains_key(&code_specifier) {
-      continue;
-    }
-
     let deps = deps.into_iter().collect::<Vec<_>>();
     let selected_dep =
       select_best_types_dep(module_graph, &code_specifier, &deps);
+
+    // when the code is mapped to a package, the declaration file it
+    // specifies may be provided by a types package that needs to go in
+    // the package.json instead of being included in the output
+    if mapped_specifiers.contains_key(&code_specifier) {
+      if let Some(types_package) =
+        get_types_package_for_specifier(&mappers, &selected_dep.specifier)
+      {
+        types_packages.insert(types_package.name.clone(), types_package);
+        types_package_files.insert(selected_dep.specifier);
+      }
+      continue;
+    }
 
     // get the declaration file specifiers that weren't used
     let mut ignored = deps
@@ -66,7 +89,11 @@ pub fn resolve_declaration_file_mappings(
     );
   }
 
-  Ok(mappings)
+  Ok(DeclarationFileResolutions {
+    mappings,
+    types_packages,
+    types_package_files,
+  })
 }
 
 /// This resolution process works as follows:

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -512,7 +512,7 @@ pub async fn transform(
 
   let mut warnings = get_declaration_warnings(&specifiers);
   let types_dependencies =
-    get_types_dependencies(&specifiers, &file_fetcher).await;
+    get_types_dependencies(&specifiers, &file_fetcher, &mut warnings).await;
   let mut main_env_context = EnvironmentContext {
     environment: TransformOutputEnvironment {
       entry_points: options
@@ -907,8 +907,7 @@ fn check_add_shim_file_to_environment(
 /// dependencies, which are added to the dev dependencies.
 ///
 /// A mapped module isn't part of the module graph, so the `X-TypeScript-Types`
-/// header of each is resolved here. Failures are ignored because a mapped
-/// module isn't required to be fetchable.
+/// header of each is resolved here.
 async fn get_types_dependencies<TSys: WorkspaceFactorySys>(
   specifiers: &Specifiers,
   file_fetcher: &PermissionedFileFetcher<
@@ -916,6 +915,7 @@ async fn get_types_dependencies<TSys: WorkspaceFactorySys>(
     TSys,
     impl deno_cache_dir::file_fetcher::HttpClient,
   >,
+  warnings: &mut Vec<String>,
 ) -> Vec<Dependency> {
   let mappers = get_all_specifier_mappers();
   let mut types_packages = specifiers.types_packages.clone();
@@ -925,16 +925,37 @@ async fn get_types_dependencies<TSys: WorkspaceFactorySys>(
       .mapped
       .keys()
       .chain(specifiers.test.mapped.keys())
-      .filter(|s| matches!(s.scheme(), "http" | "https"))
-      .map(|specifier| async {
-        let types_specifier =
-          get_types_header_specifier(file_fetcher, specifier).await?;
-        get_types_package_for_specifier(&mappers, &types_specifier)
+      // only a module mapped by one of the cdn mappers may have a types
+      // header, so don't fetch the modules the user mapped themselves
+      .filter(|s| mappers.iter().any(|m| m.map(s).is_some()))
+      .map(|specifier| {
+        let mappers = &mappers;
+        async move {
+          match get_types_header_specifier(file_fetcher, specifier).await {
+            Ok(types_specifier) => Ok(
+              types_specifier
+                .and_then(|s| get_types_package_for_specifier(mappers, &s)),
+            ),
+            Err(err) => Err(format!(
+              "Failed getting the type declarations of {}. {:#}",
+              specifier, err
+            )),
+          }
+        }
       }),
   )
   .await;
-  for package in header_packages.into_iter().flatten() {
-    types_packages.insert(package.name.clone(), package);
+  for result in header_packages {
+    match result {
+      Ok(Some(package)) => {
+        // a declaration file specified in the code takes precedence
+        types_packages
+          .entry(package.name.clone())
+          .or_insert(package);
+      }
+      Ok(None) => {}
+      Err(warning) => warnings.push(warning),
+    }
   }
 
   types_packages
@@ -958,13 +979,17 @@ async fn get_types_header_specifier<TSys: WorkspaceFactorySys>(
     impl deno_cache_dir::file_fetcher::HttpClient,
   >,
   specifier: &ModuleSpecifier,
-) -> Option<ModuleSpecifier> {
-  let file = file_fetcher
-    .fetch_bypass_permissions(specifier)
-    .await
-    .ok()?;
-  let types_header = file.maybe_headers?.remove("x-typescript-types")?;
-  deno_path_util::resolve_url_or_path(&types_header, Path::new("")).ok()
+) -> Result<Option<ModuleSpecifier>> {
+  let mut file = file_fetcher.fetch_bypass_permissions(specifier).await?;
+  let Some(types_header) = file
+    .maybe_headers
+    .as_mut()
+    .and_then(|h| h.remove("x-typescript-types"))
+  else {
+    return Ok(None);
+  };
+  // resolve relative to the final url so that redirects are handled
+  Ok(file.url.join(&types_header).ok())
 }
 
 fn get_dependencies(

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -15,6 +15,8 @@ use analyze::get_top_level_decls;
 use anyhow::Context;
 use anyhow::Result;
 
+use crate::loader::get_all_specifier_mappers;
+use crate::loader::get_types_package_for_specifier;
 use analyze::get_ignore_line_indexes;
 use anyhow::bail;
 use deno_ast::apply_text_changes;
@@ -106,6 +108,9 @@ pub struct TransformOutput {
   /// This is `None` when no config file was found, when one was explicitly
   /// provided, or when auto-discovery is disabled.
   pub discovered_config_file: Option<PathBuf>,
+  /// Packages that provide the type declarations of a mapped dependency
+  /// (ex. an `@types/` package specified by an `X-TypeScript-Types` header).
+  pub types_dependencies: Vec<Dependency>,
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
@@ -448,8 +453,9 @@ pub async fn transform(
     .await?
     .cloned();
 
+  let file_fetcher = Rc::new(file_fetcher);
   let loader = Rc::new(DenoGraphLoader::new(
-    Rc::new(file_fetcher),
+    file_fetcher.clone(),
     resolver_factory
       .workspace_factory()
       .global_http_cache()?
@@ -505,6 +511,8 @@ pub async fn transform(
       .collect();
 
   let mut warnings = get_declaration_warnings(&specifiers);
+  let types_dependencies =
+    get_types_dependencies(&specifiers, &file_fetcher).await;
   let mut main_env_context = EnvironmentContext {
     environment: TransformOutputEnvironment {
       entry_points: options
@@ -690,6 +698,7 @@ pub async fn transform(
     test: test_env_context.environment,
     warnings,
     discovered_config_file,
+    types_dependencies,
   })
 }
 
@@ -892,6 +901,70 @@ fn check_add_shim_file_to_environment(
 
     text
   }
+}
+
+/// Gets the packages that provide the type declarations of the mapped
+/// dependencies, which are added to the dev dependencies.
+///
+/// A mapped module isn't part of the module graph, so the `X-TypeScript-Types`
+/// header of each is resolved here. Failures are ignored because a mapped
+/// module isn't required to be fetchable.
+async fn get_types_dependencies<TSys: WorkspaceFactorySys>(
+  specifiers: &Specifiers,
+  file_fetcher: &PermissionedFileFetcher<
+    NullBlobStore,
+    TSys,
+    impl deno_cache_dir::file_fetcher::HttpClient,
+  >,
+) -> Vec<Dependency> {
+  let mappers = get_all_specifier_mappers();
+  let mut types_packages = specifiers.types_packages.clone();
+  let header_packages = futures::future::join_all(
+    specifiers
+      .main
+      .mapped
+      .keys()
+      .chain(specifiers.test.mapped.keys())
+      .filter(|s| matches!(s.scheme(), "http" | "https"))
+      .map(|specifier| async {
+        let types_specifier =
+          get_types_header_specifier(file_fetcher, specifier).await?;
+        get_types_package_for_specifier(&mappers, &types_specifier)
+      }),
+  )
+  .await;
+  for package in header_packages.into_iter().flatten() {
+    types_packages.insert(package.name.clone(), package);
+  }
+
+  types_packages
+    .into_values()
+    .filter_map(|p| {
+      Some(Dependency {
+        name: p.name,
+        version: p.version?,
+        peer_dependency: false,
+      })
+    })
+    .collect()
+}
+
+/// Gets the specifier of the declaration file in a module's
+/// `X-TypeScript-Types` header.
+async fn get_types_header_specifier<TSys: WorkspaceFactorySys>(
+  file_fetcher: &PermissionedFileFetcher<
+    NullBlobStore,
+    TSys,
+    impl deno_cache_dir::file_fetcher::HttpClient,
+  >,
+  specifier: &ModuleSpecifier,
+) -> Option<ModuleSpecifier> {
+  let file = file_fetcher
+    .fetch_bypass_permissions(specifier)
+    .await
+    .ok()?;
+  let types_header = file.maybe_headers?.remove("x-typescript-types")?;
+  deno_path_util::resolve_url_or_path(&types_header, Path::new("")).ok()
 }
 
 fn get_dependencies(

--- a/rs-lib/src/loader/specifier_mappers.rs
+++ b/rs-lib/src/loader/specifier_mappers.rs
@@ -344,66 +344,70 @@ mod test {
       None,
     );
   }
-}
-#[test]
-fn map_types_esm_sh() {
-  assert_types_package(
-    "https://esm.sh/@types/svg-path-parser@~1.1.6/index.d.ts",
-    Some(("@types/svg-path-parser", "~1.1.6")),
-  );
-  // versioned cdn path
-  assert_types_package(
-    "https://esm.sh/v135/@types/react@18.2.0/index.d.ts",
-    Some(("@types/react", "18.2.0")),
-  );
-  // nested sub paths and other declaration file extensions
-  assert_types_package(
-    "https://esm.sh/@types/node@22.0.0/ts5.6/index.d.mts",
-    Some(("@types/node", "22.0.0")),
-  );
-  assert_types_package(
-    "https://esm.sh/@types/node@22.0.0/index.d.cts",
-    Some(("@types/node", "22.0.0")),
-  );
-  // no sub path
-  assert_types_package(
-    "https://esm.sh/@types/node@22.0.0",
-    Some(("@types/node", "22.0.0")),
-  );
-  // query strings
-  assert_types_package(
-    "https://esm.sh/@types/node@22.0.0/index.d.ts?target=denonext",
-    Some(("@types/node", "22.0.0")),
-  );
-  // github and jsr packages aren't on npm
-  assert_types_package("https://esm.sh/gh/user/repo@1.0.0/index.d.ts", None);
-  assert_types_package("https://esm.sh/jsr/@scope/name@1.0.0/index.d.ts", None);
-}
 
-#[test]
-fn map_types_skypack() {
-  assert_types_package(
-    "https://cdn.skypack.dev/@types/lodash@4.14.191/index.d.ts",
-    Some(("@types/lodash", "4.14.191")),
-  );
-  // internal urls have a build hash for a version
-  assert_types_package(
-      "https://cdn.skypack.dev/-/@types/lodash@v4.14.191-abcXYZ/dist=es2019/index.d.ts",
+  #[test]
+  fn map_types_esm_sh() {
+    assert_types_package(
+      "https://esm.sh/@types/svg-path-parser@~1.1.6/index.d.ts",
+      Some(("@types/svg-path-parser", "~1.1.6")),
+    );
+    // versioned cdn path
+    assert_types_package(
+      "https://esm.sh/v135/@types/react@18.2.0/index.d.ts",
+      Some(("@types/react", "18.2.0")),
+    );
+    // nested sub paths and other declaration file extensions
+    assert_types_package(
+      "https://esm.sh/@types/node@22.0.0/ts5.6/index.d.mts",
+      Some(("@types/node", "22.0.0")),
+    );
+    assert_types_package(
+      "https://esm.sh/@types/node@22.0.0/index.d.cts",
+      Some(("@types/node", "22.0.0")),
+    );
+    // no sub path
+    assert_types_package(
+      "https://esm.sh/@types/node@22.0.0",
+      Some(("@types/node", "22.0.0")),
+    );
+    // query strings
+    assert_types_package(
+      "https://esm.sh/@types/node@22.0.0/index.d.ts?target=denonext",
+      Some(("@types/node", "22.0.0")),
+    );
+    // github and jsr packages aren't on npm
+    assert_types_package("https://esm.sh/gh/user/repo@1.0.0/index.d.ts", None);
+    assert_types_package(
+      "https://esm.sh/jsr/@scope/name@1.0.0/index.d.ts",
       None,
     );
-}
+  }
 
-#[test]
-fn map_types_unknown_cdn() {
-  assert_types_package("https://deno.land/x/mod@1.0.0/mod.d.ts", None);
-}
+  #[test]
+  fn map_types_skypack() {
+    assert_types_package(
+      "https://cdn.skypack.dev/@types/lodash@4.14.191/index.d.ts",
+      Some(("@types/lodash", "4.14.191")),
+    );
+    // internal urls have a build hash for a version
+    assert_types_package(
+        "https://cdn.skypack.dev/-/@types/lodash@v4.14.191-abcXYZ/dist=es2019/index.d.ts",
+        None,
+      );
+  }
 
-fn assert_types_package(specifier: &str, expected: Option<(&str, &str)>) {
-  let mappers = get_all_specifier_mappers();
-  let specifier = ModuleSpecifier::parse(specifier).unwrap();
-  let result = get_types_package_for_specifier(&mappers, &specifier);
-  assert_eq!(
-    result.map(|p| (p.name, p.version.unwrap())),
-    expected.map(|(n, v)| (n.to_string(), v.to_string()))
-  );
+  #[test]
+  fn map_types_unknown_cdn() {
+    assert_types_package("https://deno.land/x/mod@1.0.0/mod.d.ts", None);
+  }
+
+  fn assert_types_package(specifier: &str, expected: Option<(&str, &str)>) {
+    let mappers = get_all_specifier_mappers();
+    let specifier = ModuleSpecifier::parse(specifier).unwrap();
+    let result = get_types_package_for_specifier(&mappers, &specifier);
+    assert_eq!(
+      result.map(|p| (p.name, p.version.unwrap())),
+      expected.map(|(n, v)| (n.to_string(), v.to_string()))
+    );
+  }
 }

--- a/rs-lib/src/loader/specifier_mappers.rs
+++ b/rs-lib/src/loader/specifier_mappers.rs
@@ -119,7 +119,13 @@ impl SpecifierMapper for SkypackMapper {
     &self,
     specifier: &ModuleSpecifier,
   ) -> Option<PackageMappedSpecifier> {
-    let captures = SKYPACK_MAPPING_RE.captures(specifier.as_str())?;
+    if specifier.path().starts_with("/-/") {
+      // ignore, it's an internal url whose version is a build hash
+      return None;
+    }
+
+    let text = without_query(specifier);
+    let captures = SKYPACK_MAPPING_RE.captures(&text)?;
     to_types_package(&captures)
   }
 }
@@ -171,7 +177,9 @@ impl SpecifierMapper for EsmShMapper {
     {
       return None;
     }
-    let captures = ESMSH_MAPPING_RE.captures(specifier.as_str())?;
+
+    let text = without_query(specifier);
+    let captures = ESMSH_MAPPING_RE.captures(&text)?;
     to_types_package(&captures)
   }
 }
@@ -181,23 +189,28 @@ impl SpecifierMapper for EsmShMapper {
 fn to_types_package(
   captures: &regex::Captures,
 ) -> Option<PackageMappedSpecifier> {
-  let sub_path = captures.get(4)?.as_str().to_lowercase();
-  if !sub_path.ends_with(".d.ts") && !sub_path.ends_with(".d.mts") {
-    return None;
-  }
   Some(PackageMappedSpecifier {
-    name: captures.get(2).unwrap().as_str().to_string(),
+    name: captures.get(2)?.as_str().to_string(),
     version: Some(
       captures
-        .get(3)
-        .unwrap()
+        .get(3)?
         .as_str()
         .trim_start_matches('v')
         .to_string(),
     ),
+    // the sub path is dropped because the package is only used as a
+    // dependency in the package.json and never in a module specifier
     sub_path: None,
     peer_dependency: false,
   })
+}
+
+fn without_query(specifier: &ModuleSpecifier) -> String {
+  let text = specifier.as_str();
+  match text.find(['?', '#']) {
+    Some(index) => text[..index].to_string(),
+    None => text.to_string(),
+  }
 }
 
 struct DenoStdNodeSpecifierMapper {
@@ -331,4 +344,66 @@ mod test {
       None,
     );
   }
+}
+#[test]
+fn map_types_esm_sh() {
+  assert_types_package(
+    "https://esm.sh/@types/svg-path-parser@~1.1.6/index.d.ts",
+    Some(("@types/svg-path-parser", "~1.1.6")),
+  );
+  // versioned cdn path
+  assert_types_package(
+    "https://esm.sh/v135/@types/react@18.2.0/index.d.ts",
+    Some(("@types/react", "18.2.0")),
+  );
+  // nested sub paths and other declaration file extensions
+  assert_types_package(
+    "https://esm.sh/@types/node@22.0.0/ts5.6/index.d.mts",
+    Some(("@types/node", "22.0.0")),
+  );
+  assert_types_package(
+    "https://esm.sh/@types/node@22.0.0/index.d.cts",
+    Some(("@types/node", "22.0.0")),
+  );
+  // no sub path
+  assert_types_package(
+    "https://esm.sh/@types/node@22.0.0",
+    Some(("@types/node", "22.0.0")),
+  );
+  // query strings
+  assert_types_package(
+    "https://esm.sh/@types/node@22.0.0/index.d.ts?target=denonext",
+    Some(("@types/node", "22.0.0")),
+  );
+  // github and jsr packages aren't on npm
+  assert_types_package("https://esm.sh/gh/user/repo@1.0.0/index.d.ts", None);
+  assert_types_package("https://esm.sh/jsr/@scope/name@1.0.0/index.d.ts", None);
+}
+
+#[test]
+fn map_types_skypack() {
+  assert_types_package(
+    "https://cdn.skypack.dev/@types/lodash@4.14.191/index.d.ts",
+    Some(("@types/lodash", "4.14.191")),
+  );
+  // internal urls have a build hash for a version
+  assert_types_package(
+      "https://cdn.skypack.dev/-/@types/lodash@v4.14.191-abcXYZ/dist=es2019/index.d.ts",
+      None,
+    );
+}
+
+#[test]
+fn map_types_unknown_cdn() {
+  assert_types_package("https://deno.land/x/mod@1.0.0/mod.d.ts", None);
+}
+
+fn assert_types_package(specifier: &str, expected: Option<(&str, &str)>) {
+  let mappers = get_all_specifier_mappers();
+  let specifier = ModuleSpecifier::parse(specifier).unwrap();
+  let result = get_types_package_for_specifier(&mappers, &specifier);
+  assert_eq!(
+    result.map(|p| (p.name, p.version.unwrap())),
+    expected.map(|(n, v)| (n.to_string(), v.to_string()))
+  );
 }

--- a/rs-lib/src/loader/specifier_mappers.rs
+++ b/rs-lib/src/loader/specifier_mappers.rs
@@ -8,6 +8,25 @@ use crate::PackageMappedSpecifier;
 
 pub trait SpecifierMapper {
   fn map(&self, specifier: &ModuleSpecifier) -> Option<PackageMappedSpecifier>;
+
+  /// Maps a declaration file specifier to the npm package that provides it
+  /// (ex. an `@types/` package served by a cdn).
+  fn map_types(
+    &self,
+    _specifier: &ModuleSpecifier,
+  ) -> Option<PackageMappedSpecifier> {
+    None
+  }
+}
+
+/// Gets the npm package that provides the declaration file at the specifier.
+pub fn get_types_package_for_specifier(
+  mappers: &[Box<dyn SpecifierMapper>],
+  specifier: &ModuleSpecifier,
+) -> Option<PackageMappedSpecifier> {
+  mappers
+    .iter()
+    .find_map(|mapper| mapper.map_types(specifier))
 }
 
 pub fn get_all_specifier_mappers() -> Vec<Box<dyn SpecifierMapper>> {
@@ -95,6 +114,14 @@ impl SpecifierMapper for SkypackMapper {
       peer_dependency: false,
     })
   }
+
+  fn map_types(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<PackageMappedSpecifier> {
+    let captures = SKYPACK_MAPPING_RE.captures(specifier.as_str())?;
+    to_types_package(&captures)
+  }
 }
 
 struct EsmShMapper;
@@ -134,6 +161,43 @@ impl SpecifierMapper for EsmShMapper {
       peer_dependency: false,
     })
   }
+
+  fn map_types(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<PackageMappedSpecifier> {
+    if specifier.path().starts_with("/gh/")
+      || specifier.path().starts_with("/jsr/")
+    {
+      return None;
+    }
+    let captures = ESMSH_MAPPING_RE.captures(specifier.as_str())?;
+    to_types_package(&captures)
+  }
+}
+
+/// Creates a package for a declaration file url captured by one of the
+/// cdn regexes (ex. `https://esm.sh/@types/node@22.0.0/index.d.ts`).
+fn to_types_package(
+  captures: &regex::Captures,
+) -> Option<PackageMappedSpecifier> {
+  let sub_path = captures.get(4)?.as_str().to_lowercase();
+  if !sub_path.ends_with(".d.ts") && !sub_path.ends_with(".d.mts") {
+    return None;
+  }
+  Some(PackageMappedSpecifier {
+    name: captures.get(2).unwrap().as_str().to_string(),
+    version: Some(
+      captures
+        .get(3)
+        .unwrap()
+        .as_str()
+        .trim_start_matches('v')
+        .to_string(),
+    ),
+    sub_path: None,
+    peer_dependency: false,
+  })
 }
 
 struct DenoStdNodeSpecifierMapper {

--- a/rs-lib/src/specifiers.rs
+++ b/rs-lib/src/specifiers.rs
@@ -21,6 +21,9 @@ pub struct Specifiers {
   pub local: Vec<ModuleSpecifier>,
   pub remote: Vec<ModuleSpecifier>,
   pub types: BTreeMap<ModuleSpecifier, DeclarationFileResolution>,
+  /// Packages that provide the declaration files of a mapped package,
+  /// keyed by package name (ex. an `@types/` package served by a cdn).
+  pub types_packages: BTreeMap<String, PackageMappedSpecifier>,
   pub test_modules: HashSet<ModuleSpecifier>,
   pub main: EnvironmentSpecifiers,
   pub test: EnvironmentSpecifiers,
@@ -153,16 +156,17 @@ pub fn get_specifiers<'a>(
     }
   }
 
-  let types = resolve_declaration_file_mappings(
+  let declaration_files = resolve_declaration_file_mappings(
     module_graph,
     &all_modules,
     &found_mapped_specifiers,
   )?;
-  let mut declaration_specifiers = HashSet::new();
+  let types = declaration_files.mappings;
+  let mut declaration_specifiers = declaration_files.types_package_files;
   for value in types.values() {
-    declaration_specifiers.insert(&value.selected.specifier);
+    declaration_specifiers.insert(value.selected.specifier.clone());
     for dep in value.ignored.iter() {
-      declaration_specifiers.insert(&dep.specifier);
+      declaration_specifiers.insert(dep.specifier.clone());
     }
   }
 
@@ -181,6 +185,7 @@ pub fn get_specifiers<'a>(
       .filter(|l| !declaration_specifiers.contains(&l))
       .collect(),
     types,
+    types_packages: declaration_files.types_packages,
     test_modules: test_modules
       .values()
       .map(|k| k.specifier().clone())

--- a/rs-lib/src/specifiers.rs
+++ b/rs-lib/src/specifiers.rs
@@ -163,6 +163,11 @@ pub fn get_specifiers<'a>(
   )?;
   let types = declaration_files.mappings;
   let mut declaration_specifiers = declaration_files.types_package_files;
+  // a declaration file that a module imports directly still needs to be
+  // in the output even when a types package provides it
+  for specifier in get_imported_specifiers(module_graph, &all_modules) {
+    declaration_specifiers.remove(&specifier);
+  }
   for value in types.values() {
     declaration_specifiers.insert(value.selected.specifier.clone());
     for dep in value.ignored.iter() {
@@ -197,6 +202,23 @@ pub fn get_specifiers<'a>(
       mapped: specifiers.mapped_packages,
     },
   })
+}
+
+/// Gets the specifiers that the modules import in their code, which
+/// excludes the declaration files they only specify types with.
+fn get_imported_specifiers(
+  module_graph: &ModuleGraph,
+  modules: &[&Module],
+) -> HashSet<ModuleSpecifier> {
+  let mut specifiers = HashSet::new();
+  for module in modules.iter().filter_map(|m| m.js()) {
+    for dep in module.dependencies.values() {
+      if let Some(specifier) = dep.get_code() {
+        specifiers.insert(module_graph.resolve(specifier).clone());
+      }
+    }
+  }
+  specifiers
 }
 
 fn ensure_package_mapped_specifiers_valid(

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -879,6 +879,116 @@ async fn transform_typescript_types_in_headers() {
 }
 
 #[tokio::test]
+async fn transform_types_package_from_types_header_of_mapped_module() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file(
+          "/mod.ts",
+          "export * from 'https://esm.sh/svg-path-parser@1.1.0';",
+        )
+        .add_remote_file_with_headers(
+          "https://esm.sh/svg-path-parser@1.1.0",
+          "export function parseSVG() {}",
+          &[(
+            "x-typescript-types",
+            "https://esm.sh/@types/svg-path-parser@~1.1.6/index.d.ts",
+          )],
+        );
+    })
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[("mod.ts", "export * from 'svg-path-parser';")]
+  );
+  assert_eq!(
+    result.main.dependencies,
+    &[Dependency {
+      name: "svg-path-parser".to_string(),
+      version: "1.1.0".to_string(),
+      peer_dependency: false,
+    }]
+  );
+  // the declaration files are provided by an npm package, so it's
+  // added to the dev dependencies instead of being downloaded
+  assert_eq!(
+    result.types_dependencies,
+    &[Dependency {
+      name: "@types/svg-path-parser".to_string(),
+      version: "~1.1.6".to_string(),
+      peer_dependency: false,
+    }]
+  );
+}
+
+#[tokio::test]
+async fn transform_types_package_from_deno_types_of_mapped_module() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file(
+          "/mod.ts",
+          "// @deno-types='https://esm.sh/@types/svg-path-parser@1.1.3/index.d.ts'
+export * from 'https://esm.sh/svg-path-parser@1.1.0';",
+        )
+        .add_remote_file(
+          "https://esm.sh/svg-path-parser@1.1.0",
+          "export function parseSVG() {}",
+        )
+        .add_remote_file(
+          "https://esm.sh/@types/svg-path-parser@1.1.3/index.d.ts",
+          "export declare function parseSVG(): void;",
+        );
+    })
+    .transform()
+    .await
+    .unwrap();
+
+  // the declaration file is provided by the types package, so it's
+  // not included in the output
+  assert_files!(
+    result.main.files,
+    &[(
+      "mod.ts",
+      "
+export * from 'svg-path-parser';"
+    )]
+  );
+  assert_eq!(
+    result.types_dependencies,
+    &[Dependency {
+      name: "@types/svg-path-parser".to_string(),
+      version: "1.1.3".to_string(),
+      peer_dependency: false,
+    }]
+  );
+}
+
+#[tokio::test]
+async fn transform_no_types_package_for_mapped_module_without_types() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file(
+          "/mod.ts",
+          "export * from 'https://esm.sh/svg-path-parser@1.1.0';",
+        )
+        .add_remote_file(
+          "https://esm.sh/svg-path-parser@1.1.0",
+          "export function parseSVG() {}",
+        );
+    })
+    .transform()
+    .await
+    .unwrap();
+
+  assert_eq!(result.types_dependencies, &[]);
+}
+
+#[tokio::test]
 async fn transform_typescript_types_in_deno_types() {
   let result = TestBuilder::new()
     .with_loader(|loader| {

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -968,6 +968,63 @@ export * from 'svg-path-parser';"
 }
 
 #[tokio::test]
+async fn transform_types_package_declaration_file_that_is_imported() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file(
+          "/mod.ts",
+          concat!(
+            "import type { PathCommand } from 'https://esm.sh/@types/svg-path-parser@1.1.3/index.d.ts';
+",
+            "export * from 'https://esm.sh/svg-path-parser@1.1.0';
+",
+            "export type { PathCommand };
+",
+          ),
+        )
+        .add_remote_file_with_headers(
+          "https://esm.sh/svg-path-parser@1.1.0",
+          "export function parseSVG() {}",
+          &[(
+            "x-typescript-types",
+            "https://esm.sh/@types/svg-path-parser@1.1.3/index.d.ts",
+          )],
+        )
+        .add_remote_file(
+          "https://esm.sh/@types/svg-path-parser@1.1.3/index.d.ts",
+          "export declare interface PathCommand {}",
+        );
+    })
+    .transform()
+    .await
+    .unwrap();
+
+  // the declaration file is imported directly, so it still needs
+  // to be in the output
+  assert_files!(
+    result.main.files,
+    &[
+      (
+        "mod.ts",
+        concat!(
+          "import type { PathCommand } from './deps/esm.sh/@types/svg-path-parser@1.1.3/index';
+",
+          "export * from 'svg-path-parser';
+",
+          "export type { PathCommand };
+",
+        )
+      ),
+      (
+        "deps/esm.sh/@types/svg-path-parser@1.1.3/index.d.ts",
+        "export declare interface PathCommand {}"
+      ),
+    ]
+  );
+}
+
+#[tokio::test]
 async fn transform_no_types_package_for_mapped_module_without_types() {
   let result = TestBuilder::new()
     .with_loader(|loader| {

--- a/transform.ts
+++ b/transform.ts
@@ -118,6 +118,10 @@ export interface TransformOutput {
    * explicitly provided, or when auto-discovery is disabled.
    */
   discoveredConfigFile?: string;
+  /** Packages that provide the type declarations of a mapped dependency
+   * (ex. an `@types/` package specified by an `X-TypeScript-Types` header).
+   */
+  typesDependencies: Dependency[];
 }
 
 export interface TransformOutputEnvironment {


### PR DESCRIPTION
Closes #297
Closes #343

When a remote module is mapped to an npm package, the declaration files that the cdn specifies for it were dropped, so the output failed to type check:

```ts
import { parseSVG } from "https://esm.sh/svg-path-parser@1.1.0";
```

```
error TS7016: Could not find a declaration file for module 'svg-path-parser'.
  Try `npm i --save-dev @types/svg-path-parser` if it exists...
```

esm.sh points at the declarations with an `X-TypeScript-Types` header (`https://esm.sh/@types/svg-path-parser@~1.1.6/index.d.ts`), so now the package providing them is added to the dev dependencies:

```jsonc
{
  "dependencies": {
    "svg-path-parser": "1.1.0"
  },
  "devDependencies": {
    "@types/svg-path-parser": "~1.1.6"
  }
}
```

The same applies to a declaration file specified with `@deno-types`, and the file is no longer emitted into the output when a package provides it.

Details:

- A mapped module isn't in the module graph (a dummy is substituted so it isn't downloaded), so its types header is resolved by fetching it separately. Only modules that the esm.sh and skypack mappers mapped are fetched, so a module the user mapped themselves is still never downloaded. A fetch failure warns and continues rather than failing the build.
- A declaration file that a module imports directly stays in the output.
- The readme documents moving the types package to the dependencies when it shows up in your package's public api.

Verified against the reproductions in both issues: `https://esm.sh/svg-path-parser@1.1.0` now type checks, and the react example in #343 emits `setIsEnabled: React.Dispatch<React.SetStateAction<boolean>>` instead of `any`.