### PR TITLE
fix: keep the property name when shimming a shorthand property

### DIFF
--- a/rs-lib/src/visitors/globals.rs
+++ b/rs-lib/src/visitors/globals.rs
@@ -100,7 +100,7 @@ fn visit_children(node: Node, import_name: &str, context: &mut Context) {
           } else {
             context.text_changes.push(TextChange {
               range: create_range(ident.start(), ident.end(), context),
-              new_text: "globalThis".to_string(),
+              new_text: get_replacement_text(ident, "globalThis", context),
             });
           }
         }
@@ -126,7 +126,11 @@ fn visit_children(node: Node, import_name: &str, context: &mut Context) {
         {
           context.text_changes.push(TextChange {
             range: create_range(ident.start(), ident.end(), context),
-            new_text: format!("{}.{}", import_name, ident_text),
+            new_text: get_replacement_text(
+              ident,
+              &format!("{}.{}", import_name, ident_text),
+              context,
+            ),
           });
           context.import_shim = true;
           return;
@@ -171,8 +175,27 @@ fn get_global_this_text_change(
   } else {
     Some(TextChange {
       range: create_range(ident.start(), ident.end(), context),
-      new_text: format!("{}.dntGlobalThis", import_name),
+      new_text: get_replacement_text(
+        ident,
+        &format!("{}.dntGlobalThis", import_name),
+        context,
+      ),
     })
+  }
+}
+
+/// Gets the text to replace an identifier with, expanding an object literal's
+/// shorthand property so that the property name is kept
+/// (ex. `{ prompt }` -> `{ prompt: dntShim.prompt }`).
+fn get_replacement_text(
+  ident: &Ident,
+  new_text: &str,
+  context: &Context,
+) -> String {
+  if matches!(ident.parent(), Node::ObjectLit(_)) {
+    format!("{}: {}", ident.text_fast(context.program), new_text)
+  } else {
+    new_text.to_string()
   }
 }
 

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -87,6 +87,15 @@ async fn transform_shims() {
       ),
     ),
     (
+      // only a shorthand property gets the property name
+      "const obj = { Deno: Deno, [Deno]: 1, ...Deno };",
+      concat!(
+        r#"import * as dntShim from "./_dnt.shims.js";"#,
+        "
+const obj = { Deno: dntShim.Deno, [dntShim.Deno]: 1, ...dntShim.Deno };"
+      ),
+    ),
+    (
       "const obj = { globalThis };",
       concat!(
         r#"import * as dntShim from "./_dnt.shims.js";"#,

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -79,6 +79,28 @@ async fn transform_shims() {
       ),
     ),
     (
+      // the shorthand property name must be kept
+      "const obj = { Deno, setTimeout };",
+      concat!(
+        r#"import * as dntShim from "./_dnt.shims.js";"#,
+        "\nconst obj = { Deno: dntShim.Deno, setTimeout: dntShim.setTimeout };"
+      ),
+    ),
+    (
+      "const obj = { globalThis };",
+      concat!(
+        r#"import * as dntShim from "./_dnt.shims.js";"#,
+        "\nconst obj = { globalThis: dntShim.dntGlobalThis };"
+      ),
+    ),
+    (
+      "const obj = { window };",
+      concat!(
+        r#"import * as dntShim from "./_dnt.shims.js";"#,
+        "\nconst obj = { window: dntShim.dntGlobalThis };"
+      ),
+    ),
+    (
       concat!(
         "const decl01 = Deno;\n",
         "const decl02 = setTimeout;\n",


### PR DESCRIPTION
Closes #329

An object literal shorthand property whose name is a shimmed global emitted invalid code. For example, this:

```ts
export const _internals = {
  prompt,
};
```

...emitted this to `src/`:

```ts
export const _internals = {
  dntShim.prompt,
};
```

...which the compiler then silently emitted as `{ dntShim, : .prompt, }` in the output. Now the property name is kept:

```ts
export const _internals = {
  prompt: dntShim.prompt,
};
```

This applies to the `globalThis` and `window` replacements as well (`{ window }` was becoming `{ globalThis }`, which quietly renamed the property).

Only a shorthand property is affected — a computed key, spread, or explicit key that happens to use a shimmed global still resolves the way it did before.