### PR TITLE
fix: binary entrypoint output and shim type declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,14 @@ await build({
 This will add a `"bin"` entry to the package.json and add `#!/usr/bin/env node`
 to the top of the specified entry point.
 
+The `name` may be left out when there's a single binary entry point, in which
+case the package name is used as the command name.
+
+Since a binary is only ever run by Node.js, the modules that only it uses are
+not included in the CommonJS/UMD output (they're only in the ESM output). This
+means a binary may use a top level await even when the package has a
+CommonJS/UMD output.
+
 ### Node and Deno Specific Code
 
 You may find yourself in a scenario where you want to run certain code based on

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -44,6 +44,7 @@
     "lib/pkg/",
     "rs-lib/src/polyfills/scripts/",
     "tests/bare_mapping_project/npm",
+    "tests/bin_project/npm",
     "tests/config_discovery_project/npm",
     "tests/declaration_import_project/npm",
     "tests/frozen_lockfile_project/npm",

--- a/lib/package_json.test.ts
+++ b/lib/package_json.test.ts
@@ -586,3 +586,51 @@ Deno.test("types dependencies", () => {
     "@types/svg-path-parser": "~1.1.6",
   });
 });
+
+Deno.test("binary entrypoint without a name", () => {
+  const props = getBinaryProps({ includeEsModule: true, name: undefined });
+  // the package name is used as the name of the command
+  assertEquals(getPackageJson(props).bin, "./esm/mod.js");
+});
+
+Deno.test("binary entrypoint without an esm output", () => {
+  const props = getBinaryProps({ includeEsModule: false, name: "cmd" });
+  assertEquals(getPackageJson(props).bin, { cmd: "./script/mod.js" });
+});
+
+function getBinaryProps(
+  options: { includeEsModule: boolean; name: string | undefined },
+): GetPackageJsonOptions {
+  return {
+    transformOutput: {
+      main: {
+        files: [],
+        dependencies: [],
+        entryPoints: ["mod.ts"],
+      },
+      test: {
+        entryPoints: [],
+        files: [],
+        dependencies: [],
+      },
+      warnings: [],
+      typesDependencies: [],
+      binOnlyFiles: [],
+    },
+    entryPoints: [{
+      kind: "bin",
+      name: options.name,
+      path: "./mod.ts",
+    }],
+    package: {
+      name: "package",
+      version: "0.1.0",
+    },
+    testEnabled: false,
+    includeEsModule: options.includeEsModule,
+    includeScriptModule: true,
+    includeDeclarations: false,
+    includeTsLib: false,
+    shims: {},
+  };
+}

--- a/lib/package_json.test.ts
+++ b/lib/package_json.test.ts
@@ -33,6 +33,7 @@ Deno.test("single entrypoint", () => {
       },
       warnings: [],
       typesDependencies: [],
+      binOnlyFiles: [],
     },
     entryPoints: [{
       name: ".",
@@ -254,6 +255,7 @@ Deno.test("exports have default last", () => {
       },
       warnings: [],
       typesDependencies: [],
+      binOnlyFiles: [],
     },
     entryPoints: [
       {
@@ -302,6 +304,7 @@ Deno.test("multiple entrypoints", () => {
       },
       warnings: [],
       typesDependencies: [],
+      binOnlyFiles: [],
     },
     entryPoints: [{
       name: ".",
@@ -379,6 +382,7 @@ Deno.test("binary entrypoints", () => {
       },
       warnings: [],
       typesDependencies: [],
+      binOnlyFiles: [],
     },
     entryPoints: [{
       name: ".",
@@ -462,6 +466,7 @@ Deno.test("peer dependencies", () => {
       },
       warnings: [],
       typesDependencies: [],
+      binOnlyFiles: [],
     },
     entryPoints: [{
       name: ".",
@@ -554,6 +559,7 @@ Deno.test("types dependencies", () => {
         name: "other",
         version: "^1.0.0",
       }],
+      binOnlyFiles: [],
     },
     entryPoints: [{
       name: ".",

--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -35,7 +35,13 @@ export function getPackageJson({
       path: toJsFilePath(e),
       types: toDtsFilePath(e),
     }));
-  const exports = finalEntryPoints.filter((e) => e.kind === "export");
+  const exports = finalEntryPoints.filter((e) => e.kind === "export").map((
+    e,
+  ) => ({
+    ...e,
+    // only a binary entrypoint may go without a name
+    name: e.name!,
+  }));
   const binaries = finalEntryPoints.filter((e) => e.kind === "bin");
   const dependencies = {
     // typescript helpers library (https://www.npmjs.com/package/tslib)
@@ -112,11 +118,7 @@ export function getPackageJson({
       types: includeDeclarations ? `./types/${exports[0].types}` : undefined,
     }
     : {};
-  const binaryExport = binaries.length > 0
-    ? {
-      bin: Object.fromEntries(binaries.map((b) => [b.name, `./esm/${b.path}`])),
-    }
-    : {};
+  const binaryExport = binaries.length > 0 ? { bin: getBin() } : {};
 
   const final: Record<string, unknown> = {
     ...mainExport,
@@ -165,6 +167,18 @@ export function getPackageJson({
     _generatedBy: `dnt@${getDntVersion()}`,
   };
   return sortObject(final);
+
+  function getBin() {
+    // a single binary without a name uses the package name as the command
+    if (binaries.length === 1 && binaries[0].name == null) {
+      return getBinPath(binaries[0]);
+    }
+    return Object.fromEntries(binaries.map((b) => [b.name, getBinPath(b)]));
+  }
+
+  function getBinPath(binary: { path: string }) {
+    return includeEsModule ? `./esm/${binary.path}` : `./script/${binary.path}`;
+  }
 
   function shouldIncludeTypesNode() {
     if (Object.keys(dependencies).includes("@types/node")) {

--- a/mod.ts
+++ b/mod.ts
@@ -52,8 +52,12 @@ export interface EntryPoint {
    * @default "export"
    */
   kind?: "bin" | "export";
-  /** Name of the entrypoint in the "binary" or "exports". */
-  name: string;
+  /** Name of the entrypoint in the "binary" or "exports".
+   *
+   * @remarks A single binary entrypoint may leave this undefined, in which
+   * case the package name is used as the name of the command.
+   */
+  name?: string;
   /** Path to the entrypoint. */
   path: string;
 }
@@ -351,6 +355,7 @@ export async function build(options: BuildOptions): Promise<void> {
       };
     }
   });
+  validateEntryPoints(entryPoints);
   const testPreloadModule = options.testPreloadModule == null
     ? undefined
     : standardizePath(options.testPreloadModule);
@@ -810,6 +815,27 @@ export async function build(options: BuildOptions): Promise<void> {
     function getDependencyByName(name: string) {
       return transformOutput.test.dependencies.find((d) => d.name === name) ??
         transformOutput.main.dependencies.find((d) => d.name === name);
+    }
+  }
+
+  function validateEntryPoints(entryPoints: EntryPoint[]) {
+    const nameless = entryPoints.filter((e) => e.name == null);
+    if (nameless.length === 0) {
+      return;
+    }
+    const exportEntryPoint = nameless.find((e) =>
+      (e.kind ?? "export") !== "bin"
+    );
+    if (exportEntryPoint != null) {
+      throw new Error(
+        `The entrypoint '${exportEntryPoint.path}' requires a name.`,
+      );
+    }
+    if (entryPoints.filter((e) => e.kind === "bin").length > 1) {
+      throw new Error(
+        `The binary entrypoint '${nameless[0].path}' requires a name because ` +
+          `there are multiple binary entrypoints.`,
+      );
     }
   }
 

--- a/mod.ts
+++ b/mod.ts
@@ -364,6 +364,11 @@ export async function build(options: BuildOptions): Promise<void> {
 
   log("Transforming...");
   const transformOutput = await transformEntryPoints();
+  // a binary is only ever run by node, so its modules aren't part of the
+  // script output when nothing else uses them
+  const binOnlyFiles = new Set(
+    options.esModule !== false ? transformOutput.binOnlyFiles : [],
+  );
   if (transformOutput.discoveredConfigFile != null) {
     log(
       `Auto-discovered config file: ${
@@ -497,7 +502,7 @@ export async function build(options: BuildOptions): Promise<void> {
       outputFileText,
     );
 
-    if (options.scriptModule) {
+    if (options.scriptModule && !binOnlyFiles.has(outputFile.filePath)) {
       // cjs does not support TLA so error fast if we find one
       const tlaLocation = getTopLevelAwaitLocation(sourceFile);
       if (tlaLocation) {
@@ -562,12 +567,8 @@ export async function build(options: BuildOptions): Promise<void> {
         : ts.ModuleKind.CommonJS,
       moduleResolution: ts.ModuleResolutionKind.Node10,
     });
-    if (options.esModule !== false) {
-      // a binary is only ever run by node, so its modules don't need to be
-      // in the script output when nothing else uses them
-      for (const filePath of transformOutput.binOnlyFiles) {
-        project.removeSourceFile(path.join(options.outDir, "src", filePath));
-      }
+    for (const filePath of binOnlyFiles) {
+      project.removeSourceFile(path.join(options.outDir, "src", filePath));
     }
     program = getProgramAndMaybeTypeCheck("script");
     emit({
@@ -755,9 +756,7 @@ export async function build(options: BuildOptions): Promise<void> {
     const { shims, testShims } = shimOptionsToTransformShims(options.shims);
     return transform({
       entryPoints: entryPoints.map((e) => e.path),
-      binEntryPoints: entryPoints.filter((e) => e.kind === "bin").map((e) =>
-        e.path
-      ),
+      binEntryPoints: getBinOnlyEntryPointPaths(),
       testEntryPoints: options.test ? await getTestEntryPoints() : [],
       shims,
       testShims,
@@ -769,6 +768,17 @@ export async function build(options: BuildOptions): Promise<void> {
       frozenLockfile: options.frozenLockfile,
       cwd: path.toFileUrl(cwd).toString(),
     });
+  }
+
+  function getBinOnlyEntryPointPaths() {
+    const exportPaths = new Set(
+      entryPoints.filter((e) => (e.kind ?? "export") !== "bin").map((e) =>
+        e.path
+      ),
+    );
+    return entryPoints
+      .filter((e) => e.kind === "bin" && !exportPaths.has(e.path))
+      .map((e) => e.path);
   }
 
   async function getTestEntryPoints() {

--- a/mod.ts
+++ b/mod.ts
@@ -562,6 +562,13 @@ export async function build(options: BuildOptions): Promise<void> {
         : ts.ModuleKind.CommonJS,
       moduleResolution: ts.ModuleResolutionKind.Node10,
     });
+    if (options.esModule !== false) {
+      // a binary is only ever run by node, so its modules don't need to be
+      // in the script output when nothing else uses them
+      for (const filePath of transformOutput.binOnlyFiles) {
+        project.removeSourceFile(path.join(options.outDir, "src", filePath));
+      }
+    }
     program = getProgramAndMaybeTypeCheck("script");
     emit({
       transformers: {
@@ -748,6 +755,9 @@ export async function build(options: BuildOptions): Promise<void> {
     const { shims, testShims } = shimOptionsToTransformShims(options.shims);
     return transform({
       entryPoints: entryPoints.map((e) => e.path),
+      binEntryPoints: entryPoints.filter((e) => e.kind === "bin").map((e) =>
+        e.path
+      ),
       testEntryPoints: options.test ? await getTestEntryPoints() : [],
       shims,
       testShims,

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -112,6 +112,10 @@ pub struct TransformOutput {
   /// Packages that provide the type declarations of a mapped dependency
   /// (ex. an `@types/` package specified by an `X-TypeScript-Types` header).
   pub types_dependencies: Vec<Dependency>,
+  /// Output files that are only reachable from a binary entry point, which
+  /// don't need to be in the script output because a binary is only ever
+  /// run by node.
+  pub bin_only_files: Vec<PathBuf>,
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
@@ -261,6 +265,8 @@ pub enum ScriptTarget {
 
 pub struct TransformOptions {
   pub entry_points: Vec<ModuleSpecifier>,
+  /// Entry points that are npm binaries, which is a subset of the entry points.
+  pub bin_entry_points: Vec<ModuleSpecifier>,
   pub test_entry_points: Vec<ModuleSpecifier>,
   pub shims: Vec<Shim>,
   pub test_shims: Vec<Shim>,
@@ -525,9 +531,24 @@ pub async fn transform(
       .map(|m| (m.0.clone(), m.1.module_specifier_text()))
       .collect();
 
+  let bin_only_files = get_bin_only_files(GetBinOnlyFilesOptions {
+    module_graph: &module_graph,
+    mappings: &mappings,
+    specifiers: &specifiers,
+    entry_points: &options.entry_points,
+    bin_entry_points: &options.bin_entry_points,
+    test_entry_points: &options.test_entry_points,
+    shims: &options.shims,
+    test_shims: &options.test_shims,
+  });
   let mut warnings = get_declaration_warnings(&specifiers);
-  let types_dependencies =
+  let mut types_dependencies =
     get_types_dependencies(&specifiers, &file_fetcher, &mut warnings).await;
+  // the type declarations of a shim are needed to type check the output
+  // whether or not the tests are included
+  types_dependencies.extend(get_shim_types_packages(
+    options.shims.iter().chain(options.test_shims.iter()),
+  ));
   let mut main_env_context = EnvironmentContext {
     environment: TransformOutputEnvironment {
       entry_points: options
@@ -694,11 +715,6 @@ pub async fn transform(
     &mappings,
   );
 
-  add_shim_types_packages_to_test_environment(
-    &mut test_env_context.environment,
-    options.shims.iter().chain(options.test_shims.iter()),
-  );
-
   // Remove any dependencies from the test environment that
   // are found in the main environment. Only check for exact
   // matches in order to cause an npm install error if there
@@ -714,6 +730,7 @@ pub async fn transform(
     warnings,
     discovered_config_file,
     types_dependencies,
+    bin_only_files,
   })
 }
 
@@ -803,17 +820,16 @@ impl deno_lockfile::NpmPackageInfoProvider for NullNpmPackageInfoProvider {
   }
 }
 
-fn add_shim_types_packages_to_test_environment<'a>(
-  test_output_env: &mut TransformOutputEnvironment,
+/// Gets the packages that provide the type declarations of the shims.
+fn get_shim_types_packages<'a>(
   all_shims: impl Iterator<Item = &'a Shim>,
-) {
-  for shim in all_shims {
-    if let Shim::Package(shim) = shim {
-      if let Some(types_package) = &shim.types_package {
-        test_output_env.dependencies.push(types_package.clone())
-      }
-    }
-  }
+) -> Vec<Dependency> {
+  all_shims
+    .filter_map(|shim| match shim {
+      Shim::Package(shim) => shim.types_package.clone(),
+      Shim::Module(_) => None,
+    })
+    .collect()
 }
 
 fn check_add_polyfill_file_to_environment(
@@ -1070,6 +1086,53 @@ async fn get_types_header_specifier<TSys: WorkspaceFactorySys>(
   };
   // resolve relative to the final url so that redirects are handled
   Ok(file.url.join(&types_header).ok())
+}
+
+struct GetBinOnlyFilesOptions<'a> {
+  module_graph: &'a crate::graph::ModuleGraph,
+  mappings: &'a Mappings,
+  specifiers: &'a Specifiers,
+  entry_points: &'a [ModuleSpecifier],
+  bin_entry_points: &'a [ModuleSpecifier],
+  test_entry_points: &'a [ModuleSpecifier],
+  shims: &'a [Shim],
+  test_shims: &'a [Shim],
+}
+
+/// Gets the output files that are only reachable from a binary entry point.
+fn get_bin_only_files(options: GetBinOnlyFilesOptions) -> Vec<PathBuf> {
+  if options.bin_entry_points.is_empty() {
+    return Vec::new();
+  }
+  let other_roots = options
+    .entry_points
+    .iter()
+    .filter(|s| !options.bin_entry_points.contains(s))
+    .cloned()
+    .chain(options.test_entry_points.iter().cloned())
+    .chain(options.shims.iter().filter_map(|s| s.maybe_specifier()))
+    .chain(
+      options
+        .test_shims
+        .iter()
+        .filter_map(|s| s.maybe_specifier()),
+    )
+    .collect::<Vec<_>>();
+  let exclusive = crate::specifiers::get_exclusively_reachable(
+    options.module_graph,
+    options.bin_entry_points,
+    &other_roots,
+  );
+  let mut file_paths = options
+    .specifiers
+    .local
+    .iter()
+    .chain(options.specifiers.remote.iter())
+    .filter(|s| exclusive.contains(s))
+    .map(|s| options.mappings.get_file_path(s).clone())
+    .collect::<Vec<_>>();
+  file_paths.sort();
+  file_paths
 }
 
 fn get_dependencies(

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -112,9 +112,7 @@ pub struct TransformOutput {
   /// Packages that provide the type declarations of a mapped dependency
   /// (ex. an `@types/` package specified by an `X-TypeScript-Types` header).
   pub types_dependencies: Vec<Dependency>,
-  /// Output files that are only reachable from a binary entry point, which
-  /// don't need to be in the script output because a binary is only ever
-  /// run by node.
+  /// Output files that are only reachable from a binary entry point.
   pub bin_only_files: Vec<PathBuf>,
 }
 
@@ -265,7 +263,8 @@ pub enum ScriptTarget {
 
 pub struct TransformOptions {
   pub entry_points: Vec<ModuleSpecifier>,
-  /// Entry points that are npm binaries, which is a subset of the entry points.
+  /// Entry points that are only used as an npm binary, which is a subset
+  /// of the entry points.
   pub bin_entry_points: Vec<ModuleSpecifier>,
   pub test_entry_points: Vec<ModuleSpecifier>,
   pub shims: Vec<Shim>,
@@ -824,12 +823,18 @@ impl deno_lockfile::NpmPackageInfoProvider for NullNpmPackageInfoProvider {
 fn get_shim_types_packages<'a>(
   all_shims: impl Iterator<Item = &'a Shim>,
 ) -> Vec<Dependency> {
-  all_shims
-    .filter_map(|shim| match shim {
-      Shim::Package(shim) => shim.types_package.clone(),
-      Shim::Module(_) => None,
-    })
-    .collect()
+  let mut packages: Vec<Dependency> = Vec::new();
+  for shim in all_shims {
+    // the same shim may be in both the main and test shims
+    if let Shim::Package(shim) = shim {
+      if let Some(types_package) = &shim.types_package {
+        if !packages.contains(types_package) {
+          packages.push(types_package.clone());
+        }
+      }
+    }
+  }
+  packages
 }
 
 fn check_add_polyfill_file_to_environment(

--- a/rs-lib/src/specifiers.rs
+++ b/rs-lib/src/specifiers.rs
@@ -221,6 +221,55 @@ fn get_imported_specifiers(
   specifiers
 }
 
+/// Gets the local and remote modules that are only reachable from the
+/// provided roots, which is used to keep a binary entrypoint's modules out
+/// of the script output.
+pub fn get_exclusively_reachable(
+  module_graph: &ModuleGraph,
+  roots: &[ModuleSpecifier],
+  other_roots: &[ModuleSpecifier],
+) -> HashSet<ModuleSpecifier> {
+  let mut reachable = get_reachable(module_graph, roots);
+  for specifier in get_reachable(module_graph, other_roots) {
+    reachable.remove(&specifier);
+  }
+  reachable
+}
+
+fn get_reachable(
+  module_graph: &ModuleGraph,
+  roots: &[ModuleSpecifier],
+) -> HashSet<ModuleSpecifier> {
+  let mut found = HashSet::new();
+  let mut pending = roots.iter().cloned().collect::<Vec<_>>();
+  while let Some(specifier) = pending.pop() {
+    let specifier = module_graph.resolve(&specifier).clone();
+    if !found.insert(specifier.clone()) {
+      continue;
+    }
+    let Some(module) = module_graph.try_get(&specifier).and_then(|m| m.js())
+    else {
+      continue;
+    };
+    for dep in module.dependencies.values() {
+      if let Some(specifier) = dep.get_code() {
+        pending.push(specifier.clone());
+      }
+      if let Some(specifier) = dep.get_type() {
+        pending.push(specifier.clone());
+      }
+    }
+    if let Some(deno_graph::TypesDependency {
+      dependency: Resolution::Ok(resolved),
+      ..
+    }) = &module.maybe_types_dependency
+    {
+      pending.push(resolved.specifier.clone());
+    }
+  }
+  found
+}
+
 fn ensure_package_mapped_specifiers_valid(
   mapped_specifiers: &BTreeMap<ModuleSpecifier, PackageMappedSpecifier>,
   test_mapped_specifiers: &BTreeMap<ModuleSpecifier, PackageMappedSpecifier>,

--- a/rs-lib/tests/integration/test_builder.rs
+++ b/rs-lib/tests/integration/test_builder.rs
@@ -22,6 +22,7 @@ pub struct TestBuilder {
   loader: InMemoryLoader,
   entry_point: String,
   additional_entry_points: Vec<String>,
+  bin_entry_points: Vec<String>,
   test_entry_points: Vec<String>,
   specifier_mappings: HashMap<String, MappedSpecifier>,
   shims: Vec<Shim>,
@@ -44,6 +45,7 @@ impl TestBuilder {
         "file:///mod.ts".to_string()
       },
       additional_entry_points: Vec::new(),
+      bin_entry_points: Vec::new(),
       test_entry_points: Vec::new(),
       specifier_mappings: Default::default(),
       shims: Default::default(),
@@ -74,6 +76,13 @@ impl TestBuilder {
     self
       .additional_entry_points
       .push(normalize_urls(value.as_ref()));
+    self
+  }
+
+  pub fn add_bin_entry_point(&mut self, value: impl AsRef<str>) -> &mut Self {
+    let value = normalize_urls(value.as_ref());
+    self.additional_entry_points.push(value.clone());
+    self.bin_entry_points.push(value);
     self
   }
 
@@ -214,6 +223,11 @@ impl TestBuilder {
       self.loader.clone(),
       TransformOptions {
         entry_points,
+        bin_entry_points: self
+          .bin_entry_points
+          .iter()
+          .map(|p| ModuleSpecifier::parse(p).unwrap())
+          .collect(),
         test_entry_points: self
           .test_entry_points
           .iter()

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -340,8 +340,11 @@ async fn transform_shim_custom_shims() {
       }
     ]
   );
+  assert_eq!(result.test.dependencies, vec![]);
+  // the declarations of a shim are needed whether or not the tests
+  // are included in the output
   assert_eq!(
-    result.test.dependencies,
+    result.types_dependencies,
     vec![Dependency {
       name: "@types/domexception".to_string(),
       version: "^2.0.1".to_string(),
@@ -3063,6 +3066,32 @@ async fn node_specifier() {
   assert_files!(
     result.main.files,
     &[("mod.ts", "import * as fs from 'node:fs'; console.log(fs);"),]
+  );
+}
+
+#[tokio::test]
+async fn transform_bin_only_files() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file("/mod.ts", "export * from './shared.ts';")
+        .add_local_file(
+          "/cli.ts",
+          "import './shared.ts';
+import './cli_only.ts';",
+        )
+        .add_local_file("/shared.ts", "export const a = 1;")
+        .add_local_file("/cli_only.ts", "export const b = 2;");
+    })
+    .add_bin_entry_point("file:///cli.ts")
+    .transform()
+    .await
+    .unwrap();
+
+  // only the modules that nothing else uses are binary only
+  assert_eq!(
+    result.bin_only_files,
+    &[PathBuf::from("cli.ts"), PathBuf::from("cli_only.ts")]
   );
 }
 

--- a/tests/bin_project/cli.ts
+++ b/tests/bin_project/cli.ts
@@ -1,0 +1,8 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { shared } from "./shared.ts";
+
+// a top level await is fine because a binary isn't in the script output
+await Promise.resolve();
+
+console.log(shared);

--- a/tests/bin_project/mod.ts
+++ b/tests/bin_project/mod.ts
@@ -1,0 +1,3 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+export { shared } from "./shared.ts";

--- a/tests/bin_project/shared.ts
+++ b/tests/bin_project/shared.ts
@@ -1,0 +1,3 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+export const shared = 5;

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -529,6 +529,76 @@ Deno.test("should build bin project without an esm output", async () => {
   });
 });
 
+Deno.test("should build bin project", async () => {
+  await runTest("bin_project", {
+    entryPoints: [{ name: ".", path: "./mod.ts" }, {
+      kind: "bin",
+      name: "hello",
+      path: "./cli.ts",
+    }],
+    outDir: "./npm",
+    shims: {},
+    test: false,
+    compilerOptions: {
+      lib: ["ESNext", "DOM"],
+    },
+    package: {
+      name: "hello",
+      version: "1.0.0",
+    },
+  }, (output) => {
+    assertEquals(output.packageJson.bin, { hello: "./esm/cli.js" });
+    // a binary is only run by node, so it's not in the script output,
+    // but a module something else uses still is
+    output.assertNotExists("script/cli.js");
+    output.assertExists("esm/cli.js");
+    output.assertExists("script/shared.js");
+    output.assertExists("esm/shared.js");
+  });
+});
+
+Deno.test("should build bin project when it's also an export", async () => {
+  await runTest("bin_project", {
+    entryPoints: [{ name: ".", path: "./cli.ts" }, {
+      kind: "bin",
+      name: "hello",
+      path: "./cli.ts",
+    }],
+    outDir: "./npm",
+    shims: {},
+    test: false,
+    // the top level await in cli.ts is an error when it's in the script output
+    scriptModule: false,
+    compilerOptions: {
+      lib: ["ESNext", "DOM"],
+    },
+    package: {
+      name: "hello",
+      version: "1.0.0",
+    },
+  }, (output) => {
+    output.assertExists("esm/cli.js");
+  });
+});
+
+Deno.test("should error when an entrypoint has no name", async () => {
+  await assertRejects(
+    () =>
+      runTest("bin_project", {
+        entryPoints: [{ path: "./mod.ts" }],
+        outDir: "./npm",
+        shims: {},
+        test: false,
+        package: {
+          name: "hello",
+          version: "1.0.0",
+        },
+      }),
+    Error,
+    "requires a name",
+  );
+});
+
 Deno.test("should run tests when using @deno/shim-deno-test shim", async () => {
   await runTest("test_project", {
     entryPoints: ["mod.ts"],
@@ -1642,6 +1712,7 @@ export interface Output {
 async function runTest(
   project:
     | "bare_mapping_project"
+    | "bin_project"
     | "bin_shebang_project"
     | "config_discovery_project"
     | "declaration_import_project"

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -473,16 +473,59 @@ Deno.test("should build bin project with a shebang", async () => {
       },
       _generatedBy: "dnt@dev",
     });
-    const expectedText =
-      '#!/usr/bin/env node\n"use strict";\nconsole.log("Hello!");\n';
-    assertEquals(
-      output.getFileText("script/main.js"),
-      expectedText,
-    );
     assertEquals(
       output.getFileText("esm/main.js"),
-      expectedText,
+      '#!/usr/bin/env node\n"use strict";\nconsole.log("Hello!");\n',
     );
+    // a binary is only run by node, so it's not in the script output
+    output.assertNotExists("script/main.js");
+  });
+});
+
+Deno.test("should build bin project without a name", async () => {
+  await runTest("bin_shebang_project", {
+    entryPoints: [{
+      kind: "bin",
+      path: "./main.ts",
+    }],
+    shims: getAllShimOptions(false),
+    outDir: "./npm",
+    package: {
+      name: "hello",
+      version: "1.0.0",
+    },
+    compilerOptions: {
+      lib: ["ESNext", "DOM"],
+    },
+  }, (output) => {
+    // the package name is used as the name of the command
+    assertEquals(output.packageJson.bin, "./esm/main.js");
+  });
+});
+
+Deno.test("should build bin project without an esm output", async () => {
+  await runTest("bin_shebang_project", {
+    entryPoints: [{
+      kind: "bin",
+      name: "hello",
+      path: "./main.ts",
+    }],
+    shims: getAllShimOptions(false),
+    outDir: "./npm",
+    esModule: false,
+    declaration: "separate",
+    package: {
+      name: "hello",
+      version: "1.0.0",
+    },
+    compilerOptions: {
+      lib: ["ESNext", "DOM"],
+    },
+  }, (output) => {
+    assertEquals(output.packageJson.bin, {
+      hello: "./script/main.js",
+    });
+    output.assertExists("script/main.js");
   });
 });
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -525,7 +525,11 @@ Deno.test("should build bin project without an esm output", async () => {
     assertEquals(output.packageJson.bin, {
       hello: "./script/main.js",
     });
-    output.assertExists("script/main.js");
+    // the binary is in the script output because there's no esm output
+    assertEquals(
+      output.getFileText("script/main.js"),
+      '#!/usr/bin/env node\n"use strict";\nconsole.log("Hello!");\n',
+    );
   });
 });
 

--- a/transform.ts
+++ b/transform.ts
@@ -73,8 +73,8 @@ export interface ModuleShim {
 
 export interface TransformOptions {
   entryPoints: string[];
-  /** Entry points that are npm binaries, which is a subset of the
-   * entry points. */
+  /** Entry points that are only used as an npm binary, which is a subset
+   * of the entry points. */
   binEntryPoints?: string[];
   testEntryPoints?: string[];
   shims?: Shim[];
@@ -131,10 +131,7 @@ export interface TransformOutput {
    * (ex. an `@types/` package specified by an `X-TypeScript-Types` header).
    */
   typesDependencies: Dependency[];
-  /** Output files that are only reachable from a binary entrypoint, which
-   * don't need to be in the script output because a binary is only ever
-   * run by node.
-   */
+  /** Output files that are only reachable from a binary entrypoint. */
   binOnlyFiles: string[];
 }
 

--- a/transform.ts
+++ b/transform.ts
@@ -73,6 +73,9 @@ export interface ModuleShim {
 
 export interface TransformOptions {
   entryPoints: string[];
+  /** Entry points that are npm binaries, which is a subset of the
+   * entry points. */
+  binEntryPoints?: string[];
   testEntryPoints?: string[];
   shims?: Shim[];
   testShims?: Shim[];
@@ -128,6 +131,11 @@ export interface TransformOutput {
    * (ex. an `@types/` package specified by an `X-TypeScript-Types` header).
    */
   typesDependencies: Dependency[];
+  /** Output files that are only reachable from a binary entrypoint, which
+   * don't need to be in the script output because a binary is only ever
+   * run by node.
+   */
+  binOnlyFiles: string[];
 }
 
 export interface TransformOutputEnvironment {
@@ -158,6 +166,7 @@ export function transform(
       }),
     ),
     entryPoints: options.entryPoints.map(valueToUrl),
+    binEntryPoints: (options.binEntryPoints ?? []).map(valueToUrl),
     testEntryPoints: (options.testEntryPoints ?? []).map(valueToUrl),
     shims: (options.shims ?? []).map(mapShim),
     testShims: (options.testShims ?? []).map(mapShim),

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -197,6 +197,8 @@ fn response_headers_to_headermap(headers: JsValue) -> HeaderMap {
 #[serde(rename_all = "camelCase")]
 pub struct TransformOptions {
   pub entry_points: Vec<String>,
+  #[serde(default)]
+  pub bin_entry_points: Vec<String>,
   pub test_entry_points: Vec<String>,
   pub shims: Vec<Shim>,
   pub test_shims: Vec<Shim>,
@@ -235,6 +237,7 @@ async fn transform_inner(options: JsValue) -> Result<JsValue, anyhow::Error> {
     WasmHttpClient { cached_only: false },
     dnt::TransformOptions {
       entry_points: parse_module_specifiers(options.entry_points)?,
+      bin_entry_points: parse_module_specifiers(options.bin_entry_points)?,
       test_entry_points: parse_module_specifiers(options.test_entry_points)?,
       shims: options.shims,
       test_shims: options.test_shims,


### PR DESCRIPTION
Closes #319
Closes #338
Closes #409

Four related fixes.

**A binary's modules are no longer in the script output (#319)**

A binary is only ever run by Node.js, so emitting its modules to `script/` as well as `esm/` was dead weight. The transform now returns the output files that are only reachable from a binary entrypoint and they're left out of the script program. A module that something else uses (an export entrypoint or a test) still goes to both.

Following your note on the issue, the reachability is computed in the rust code. As a side effect a binary may now use a top level await even when the package has a CommonJS output.

**A binary entrypoint may go without a name (#338)**

`{ kind: "bin", path: "./cli.ts" }` produced `"bin": { "undefined": "./esm/cli.js" }`. It now emits the string form, which npm treats as the package name being the command:

```json
"bin": "./esm/cli.js"
```

`name` is optional on `EntryPoint` now, and it errors when an export entrypoint has no name or when there are multiple binaries and one of them has no name.

**The binary pointed at a file that doesn't exist**

With `esModule: false` the `"bin"` entry still pointed at `./esm/...`. It now points at the script output in that case.

**Shim type declarations reach the dev dependencies (#409)**

A shim's `typesPackage` (ex. `@types/ws` for the webSocket shim) went into the test environment's dependencies, so it was dropped when `test` was `false` and the output failed to type check. They now go through the types dependencies that #509 added, which always reach `devDependencies`.