### PR TITLE
feat: add a testIsolation build option to run each test file in its own process

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Object.assign(globalThis, { Headers, Response });
 
 The module is transformed and type checked like the test files are and it is not
 included in the npm package. It is loaded once for each of the emitted script
-and ESM output, before any test file.
+and ESM output, before each test file.
 
 ### Polyfills
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,28 @@ Object.assign(globalThis, { Headers, Response });
 
 The module is transformed and type checked like the test files are and it is not
 included in the npm package. It is loaded once for each of the emitted script
-and ESM output, before each test file.
+and ESM output, before any test file.
+
+### Test File Isolation
+
+All the test files run in the same process by default, so the module state of a
+test file can affect the next one. For example, the global hooks of
+`@std/testing/bdd` error with "Cannot add global hooks after a global test is
+registered" when a second test file uses them.
+
+Set the `testIsolation` build option to `"process"` to run each test file in its
+own process, which is what `deno test` does by running each file in its own
+isolate:
+
+```ts
+await build({
+  // ...etc...
+  testIsolation: "process",
+});
+```
+
+This is slower because it starts a process per test file, and a preload module
+is loaded before each test file rather than once per output.
 
 ### Polyfills
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -58,6 +58,7 @@
     "tests/polyfill_disabled_project/npm",
     "tests/polyfill_project/npm",
     "tests/shim_project/npm",
+    "tests/test_hooks_project/npm",
     "tests/test_project/npm",
     "tests/tla_project/npm",
     "tests/types_package_project/npm",

--- a/deno.lock
+++ b/deno.lock
@@ -8,6 +8,7 @@
     "jsr:@deno/wasmbuild@0.19.2": "0.19.2",
     "jsr:@std/assert@0.221": "0.221.0",
     "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/bytes@^1.0.4": "1.0.4",
     "jsr:@std/cli@^1.0.11": "1.0.32",
     "jsr:@std/csv@*": "1.0.6",
@@ -26,6 +27,7 @@
     "jsr:@std/semver@1": "1.0.8",
     "jsr:@std/streams@^1.0.17": "1.1.1",
     "jsr:@std/tar@~0.1.4": "0.1.10",
+    "jsr:@std/testing@^1.0.19": "1.0.19",
     "jsr:@ts-morph/bootstrap@0.29": "0.29.0",
     "jsr:@ts-morph/common@0.29": "0.29.0",
     "npm:@types/node@*": "18.16.19",
@@ -158,6 +160,13 @@
       "integrity": "6bf907f3a4bc8bfef42973ba132d946756a6161ef6b914a9e1c06debe664db17",
       "dependencies": [
         "jsr:@std/streams"
+      ]
+    },
+    "@std/testing@1.0.19": {
+      "integrity": "f4236172365b216728dc3cc8b5e80a9f4c33083d1e4ede7613d5b25b4014898e",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/internal@^1.0.14"
       ]
     },
     "@ts-morph/bootstrap@0.29.0": {

--- a/lib/test_runner/get_test_runner_code.test.ts
+++ b/lib/test_runner/get_test_runner_code.test.ts
@@ -24,26 +24,43 @@ const filePaths = [
 ];
 
 async function main() {
-  for (const [i, filePath] of filePaths.entries()) {
-    if (i > 0) {
-      console.log("");
+  const fileIndexArg = process.argv[2];
+  if (fileIndexArg == null) {
+    const { spawnSync } = require("child_process");
+    let failed = false;
+    for (const [i, _] of filePaths.entries()) {
+      if (i > 0) {
+        console.log("");
+      }
+      const result = spawnSync(process.execPath, [__filename, String(i)], {
+        stdio: "inherit",
+      });
+      if (result.status !== 0) {
+        failed = true;
+      }
     }
-
-    const scriptPath = "./script/" + filePath;
-    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
-    process.chdir(__dirname + "/script");
-    try {
-      require(scriptPath);
-    } catch(err) {
-      console.error(err);
+    if (failed) {
       process.exit(1);
     }
-
-    const esmPath = "./esm/" + filePath;
-    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
-    process.chdir(__dirname + "/esm");
-    await import(esmPath);
+    return;
   }
+
+  const filePath = filePaths[Number(fileIndexArg)];
+
+  const scriptPath = "./script/" + filePath;
+  console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+  process.chdir(__dirname + "/script");
+  try {
+    require(scriptPath);
+  } catch(err) {
+    console.error(err);
+    process.exit(1);
+  }
+
+  const esmPath = "./esm/" + filePath;
+  console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+  process.chdir(__dirname + "/esm");
+  await import(esmPath);
 }
 
 main();
@@ -71,43 +88,212 @@ const filePaths = [
 ];
 
 async function main() {
+  const fileIndexArg = process.argv[2];
+  if (fileIndexArg == null) {
+    const { spawnSync } = require("child_process");
+    let failed = false;
+    for (const [i, _] of filePaths.entries()) {
+      if (i > 0) {
+        console.log("");
+      }
+      const result = spawnSync(process.execPath, [__filename, String(i)], {
+        stdio: "inherit",
+      });
+      if (result.status !== 0) {
+        failed = true;
+      }
+    }
+    if (failed) {
+      process.exit(1);
+    }
+    return;
+  }
+
+  const filePath = filePaths[Number(fileIndexArg)];
+
   const testContext = {
     process,
     pc,
   };
-  for (const [i, filePath] of filePaths.entries()) {
-    if (i > 0) {
-      console.log("");
-    }
-
-    const scriptPath = "./script/" + filePath;
-    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
-    process.chdir(__dirname + "/script");
-    const scriptTestContext = {
-      origin: pathToFileURL(filePath).toString(),
-      ...testContext,
-    };
-    try {
-      require(scriptPath);
-    } catch(err) {
-      console.error(err);
-      process.exit(1);
-    }
-    await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), scriptTestContext);
-
-    const esmPath = "./esm/" + filePath;
-    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
-    process.chdir(__dirname + "/esm");
-    const esmTestContext = {
-      origin: pathToFileURL(filePath).toString(),
-      ...testContext,
-    };
-    await import(esmPath);
-    await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), esmTestContext);
+  const scriptPath = "./script/" + filePath;
+  console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+  process.chdir(__dirname + "/script");
+  const scriptTestContext = {
+    origin: pathToFileURL(filePath).toString(),
+    ...testContext,
+  };
+  try {
+    require(scriptPath);
+  } catch(err) {
+    console.error(err);
+    process.exit(1);
   }
+  await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), scriptTestContext);
+
+  const esmPath = "./esm/" + filePath;
+  console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+  process.chdir(__dirname + "/esm");
+  const esmTestContext = {
+    origin: pathToFileURL(filePath).toString(),
+    ...testContext,
+  };
+  await import(esmPath);
+  await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), esmTestContext);
 }
 
-${runTestDefinitionsCode}
+async function runTestDefinitions(testDefinitions, options) {
+  const testFailures = [];
+  const hasOnly = testDefinitions.some((d)=>d.only);
+  if (hasOnly) {
+    testDefinitions = testDefinitions.filter((d)=>d.only);
+  }
+  for (const definition of testDefinitions){
+    options.process.stdout.write("test " + definition.name + " ...");
+    if (definition.ignore) {
+      options.process.stdout.write(\` \${options.pc.gray("ignored")}\\n\`);
+      continue;
+    }
+    const context = getTestContext(definition, undefined);
+    let pass = false;
+    try {
+      await definition.fn(context);
+      if (context.hasFailingChild) {
+        testFailures.push({
+          name: definition.name,
+          err: new Error("Had failing test step.")
+        });
+      } else {
+        pass = true;
+      }
+    } catch (err) {
+      testFailures.push({
+        name: definition.name,
+        err
+      });
+    }
+    const testStepOutput = context.getOutput();
+    if (testStepOutput.length > 0) {
+      options.process.stdout.write(testStepOutput);
+    } else {
+      options.process.stdout.write(" ");
+    }
+    options.process.stdout.write(getStatusText(pass ? "ok" : "fail"));
+    options.process.stdout.write("\\n");
+  }
+  if (testFailures.length > 0) {
+    options.process.stdout.write("\\nFAILURES");
+    for (const failure of testFailures){
+      options.process.stdout.write("\\n\\n");
+      options.process.stdout.write(failure.name + "\\n");
+      options.process.stdout.write(indentText((failure.err?.stack ?? failure.err).toString(), 1));
+    }
+    options.process.exit(1);
+  } else if (hasOnly) {
+    options.process.stdout.write('error: Test failed because the "only" option was used.\\n');
+    options.process.exit(1);
+  }
+  function getTestContext(definition, parent) {
+    return {
+      name: definition.name,
+      parent,
+      origin: options.origin,
+      /** @type {any} */ err: undefined,
+      status: "ok",
+      children: [],
+      get hasFailingChild () {
+        return this.children.some((c)=>c.status === "fail" || c.status === "pending");
+      },
+      getOutput () {
+        let output = "";
+        if (this.parent) {
+          output += "test " + this.name + " ...";
+        }
+        if (this.children.length > 0) {
+          output += "\\n" + this.children.map((c)=>indentText(c.getOutput(), 1)).join("\\n") + "\\n";
+        } else if (!this.err) {
+          output += " ";
+        }
+        if (this.parent && this.err) {
+          output += "\\n";
+        }
+        if (this.err) {
+          output += indentText((this.err.stack ?? this.err).toString(), 1);
+          if (this.parent) {
+            output += "\\n";
+          }
+        }
+        if (this.parent) {
+          output += getStatusText(this.status);
+        }
+        return output;
+      },
+      async step (nameOrTestDefinition, fn) {
+        const definition = getDefinition();
+        const context = getTestContext(definition, this);
+        context.status = "pending";
+        this.children.push(context);
+        if (definition.ignore) {
+          context.status = "ignored";
+          return false;
+        }
+        try {
+          await definition.fn(context);
+          context.status = "ok";
+          if (context.hasFailingChild) {
+            context.status = "fail";
+            return false;
+          }
+          return true;
+        } catch (err) {
+          context.status = "fail";
+          context.err = err;
+          return false;
+        }
+        /** @returns {TestDefinition} */ function getDefinition() {
+          if (typeof nameOrTestDefinition === "string") {
+            if (!(fn instanceof Function)) {
+              throw new TypeError("Expected function for second argument.");
+            }
+            return {
+              name: nameOrTestDefinition,
+              fn
+            };
+          } else if (typeof nameOrTestDefinition === "object") {
+            return nameOrTestDefinition;
+          } else {
+            throw new TypeError("Expected a test definition or name and function.");
+          }
+        }
+      }
+    };
+  }
+  function getStatusText(status) {
+    switch(status){
+      case "ok":
+        return options.pc.green(status);
+      case "fail":
+      case "pending":
+        return options.pc.red(status);
+      case "ignored":
+        return options.pc.gray(status);
+      default:
+        {
+          const _assertNever = status;
+          return status;
+        }
+    }
+  }
+  function indentText(text, indentLevel) {
+    if (text === undefined) {
+      text = "[undefined]";
+    } else if (text === null) {
+      text = "[null]";
+    } else {
+      text = text.toString();
+    }
+    return text.split(/\\r?\\n/).map((line)=>"  ".repeat(indentLevel) + line).join("\\n");
+  }
+}
 
 main();
 `,
@@ -132,6 +318,29 @@ const filePaths = [
 ];
 
 async function main() {
+  const fileIndexArg = process.argv[2];
+  if (fileIndexArg == null) {
+    const { spawnSync } = require("child_process");
+    let failed = false;
+    for (const [i, _] of filePaths.entries()) {
+      if (i > 0) {
+        console.log("");
+      }
+      const result = spawnSync(process.execPath, [__filename, String(i)], {
+        stdio: "inherit",
+      });
+      if (result.status !== 0) {
+        failed = true;
+      }
+    }
+    if (failed) {
+      process.exit(1);
+    }
+    return;
+  }
+
+  const filePath = filePaths[Number(fileIndexArg)];
+
   process.chdir(__dirname + "/script");
   try {
     require("./script/scripts/test_preload.js");
@@ -142,26 +351,20 @@ async function main() {
   process.chdir(__dirname + "/esm");
   await import("./esm/scripts/test_preload.js");
 
-  for (const [i, filePath] of filePaths.entries()) {
-    if (i > 0) {
-      console.log("");
-    }
-
-    const scriptPath = "./script/" + filePath;
-    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
-    process.chdir(__dirname + "/script");
-    try {
-      require(scriptPath);
-    } catch(err) {
-      console.error(err);
-      process.exit(1);
-    }
-
-    const esmPath = "./esm/" + filePath;
-    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
-    process.chdir(__dirname + "/esm");
-    await import(esmPath);
+  const scriptPath = "./script/" + filePath;
+  console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+  process.chdir(__dirname + "/script");
+  try {
+    require(scriptPath);
+  } catch(err) {
+    console.error(err);
+    process.exit(1);
   }
+
+  const esmPath = "./esm/" + filePath;
+  console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+  process.chdir(__dirname + "/esm");
+  await import(esmPath);
 }
 
 main();
@@ -187,19 +390,36 @@ const filePaths = [
 ];
 
 async function main() {
+  const fileIndexArg = process.argv[2];
+  if (fileIndexArg == null) {
+    const { spawnSync } = require("child_process");
+    let failed = false;
+    for (const [i, _] of filePaths.entries()) {
+      if (i > 0) {
+        console.log("");
+      }
+      const result = spawnSync(process.execPath, [__filename, String(i)], {
+        stdio: "inherit",
+      });
+      if (result.status !== 0) {
+        failed = true;
+      }
+    }
+    if (failed) {
+      process.exit(1);
+    }
+    return;
+  }
+
+  const filePath = filePaths[Number(fileIndexArg)];
+
   process.chdir(__dirname + "/esm");
   await import("./esm/test_preload.js");
 
-  for (const [i, filePath] of filePaths.entries()) {
-    if (i > 0) {
-      console.log("");
-    }
-
-    const esmPath = "./esm/" + filePath;
-    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
-    process.chdir(__dirname + "/esm");
-    await import(esmPath);
-  }
+  const esmPath = "./esm/" + filePath;
+  console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+  process.chdir(__dirname + "/esm");
+  await import(esmPath);
 }
 
 main();
@@ -225,6 +445,29 @@ const filePaths = [
 ];
 
 async function main() {
+  const fileIndexArg = process.argv[2];
+  if (fileIndexArg == null) {
+    const { spawnSync } = require("child_process");
+    let failed = false;
+    for (const [i, _] of filePaths.entries()) {
+      if (i > 0) {
+        console.log("");
+      }
+      const result = spawnSync(process.execPath, [__filename, String(i)], {
+        stdio: "inherit",
+      });
+      if (result.status !== 0) {
+        failed = true;
+      }
+    }
+    if (failed) {
+      process.exit(1);
+    }
+    return;
+  }
+
+  const filePath = filePaths[Number(fileIndexArg)];
+
   process.chdir(__dirname + "/script");
   try {
     require("./script/test_preload.js");
@@ -233,20 +476,14 @@ async function main() {
     process.exit(1);
   }
 
-  for (const [i, filePath] of filePaths.entries()) {
-    if (i > 0) {
-      console.log("");
-    }
-
-    const scriptPath = "./script/" + filePath;
-    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
-    process.chdir(__dirname + "/script");
-    try {
-      require(scriptPath);
-    } catch(err) {
-      console.error(err);
-      process.exit(1);
-    }
+  const scriptPath = "./script/" + filePath;
+  console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+  process.chdir(__dirname + "/script");
+  try {
+    require(scriptPath);
+  } catch(err) {
+    console.error(err);
+    process.exit(1);
   }
 }
 
@@ -291,16 +528,33 @@ const filePaths = [
 ];
 
 async function main() {
-  for (const [i, filePath] of filePaths.entries()) {
-    if (i > 0) {
-      console.log("");
+  const fileIndexArg = process.argv[2];
+  if (fileIndexArg == null) {
+    const { spawnSync } = require("child_process");
+    let failed = false;
+    for (const [i, _] of filePaths.entries()) {
+      if (i > 0) {
+        console.log("");
+      }
+      const result = spawnSync(process.execPath, [__filename, String(i)], {
+        stdio: "inherit",
+      });
+      if (result.status !== 0) {
+        failed = true;
+      }
     }
-
-    const esmPath = "./esm/" + filePath;
-    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
-    process.chdir(__dirname + "/esm");
-    await import(esmPath);
+    if (failed) {
+      process.exit(1);
+    }
+    return;
   }
+
+  const filePath = filePaths[Number(fileIndexArg)];
+
+  const esmPath = "./esm/" + filePath;
+  console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+  process.chdir(__dirname + "/esm");
+  await import(esmPath);
 }
 
 main();
@@ -325,20 +579,37 @@ const filePaths = [
 ];
 
 async function main() {
-  for (const [i, filePath] of filePaths.entries()) {
-    if (i > 0) {
-      console.log("");
+  const fileIndexArg = process.argv[2];
+  if (fileIndexArg == null) {
+    const { spawnSync } = require("child_process");
+    let failed = false;
+    for (const [i, _] of filePaths.entries()) {
+      if (i > 0) {
+        console.log("");
+      }
+      const result = spawnSync(process.execPath, [__filename, String(i)], {
+        stdio: "inherit",
+      });
+      if (result.status !== 0) {
+        failed = true;
+      }
     }
-
-    const scriptPath = "./script/" + filePath;
-    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
-    process.chdir(__dirname + "/script");
-    try {
-      require(scriptPath);
-    } catch(err) {
-      console.error(err);
+    if (failed) {
       process.exit(1);
     }
+    return;
+  }
+
+  const filePath = filePaths[Number(fileIndexArg)];
+
+  const scriptPath = "./script/" + filePath;
+  console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+  process.chdir(__dirname + "/script");
+  try {
+    require(scriptPath);
+  } catch(err) {
+    console.error(err);
+    process.exit(1);
   }
 }
 

--- a/lib/test_runner/get_test_runner_code.test.ts
+++ b/lib/test_runner/get_test_runner_code.test.ts
@@ -28,24 +28,31 @@ async function main() {
   if (fileIndexArg == null) {
     const { spawnSync } = require("child_process");
     let failed = false;
-    for (const [i, _] of filePaths.entries()) {
+    for (const i of filePaths.keys()) {
       if (i > 0) {
         console.log("");
       }
-      const result = spawnSync(process.execPath, [__filename, String(i)], {
-        stdio: "inherit",
-      });
+      const args = [...process.execArgv, __filename, String(i)];
+      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
+      if (result.error != null) {
+        console.error(result.error);
+      }
       if (result.status !== 0) {
         failed = true;
       }
     }
     if (failed) {
-      process.exit(1);
+      process.exitCode = 1;
     }
     return;
   }
 
   const filePath = filePaths[Number(fileIndexArg)];
+  if (filePath == null) {
+    console.error("Unknown test file index: " + fileIndexArg);
+    process.exitCode = 1;
+    return;
+  }
 
   const scriptPath = "./script/" + filePath;
   console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
@@ -92,24 +99,31 @@ async function main() {
   if (fileIndexArg == null) {
     const { spawnSync } = require("child_process");
     let failed = false;
-    for (const [i, _] of filePaths.entries()) {
+    for (const i of filePaths.keys()) {
       if (i > 0) {
         console.log("");
       }
-      const result = spawnSync(process.execPath, [__filename, String(i)], {
-        stdio: "inherit",
-      });
+      const args = [...process.execArgv, __filename, String(i)];
+      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
+      if (result.error != null) {
+        console.error(result.error);
+      }
       if (result.status !== 0) {
         failed = true;
       }
     }
     if (failed) {
-      process.exit(1);
+      process.exitCode = 1;
     }
     return;
   }
 
   const filePath = filePaths[Number(fileIndexArg)];
+  if (filePath == null) {
+    console.error("Unknown test file index: " + fileIndexArg);
+    process.exitCode = 1;
+    return;
+  }
 
   const testContext = {
     process,
@@ -322,24 +336,31 @@ async function main() {
   if (fileIndexArg == null) {
     const { spawnSync } = require("child_process");
     let failed = false;
-    for (const [i, _] of filePaths.entries()) {
+    for (const i of filePaths.keys()) {
       if (i > 0) {
         console.log("");
       }
-      const result = spawnSync(process.execPath, [__filename, String(i)], {
-        stdio: "inherit",
-      });
+      const args = [...process.execArgv, __filename, String(i)];
+      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
+      if (result.error != null) {
+        console.error(result.error);
+      }
       if (result.status !== 0) {
         failed = true;
       }
     }
     if (failed) {
-      process.exit(1);
+      process.exitCode = 1;
     }
     return;
   }
 
   const filePath = filePaths[Number(fileIndexArg)];
+  if (filePath == null) {
+    console.error("Unknown test file index: " + fileIndexArg);
+    process.exitCode = 1;
+    return;
+  }
 
   process.chdir(__dirname + "/script");
   try {
@@ -394,24 +415,31 @@ async function main() {
   if (fileIndexArg == null) {
     const { spawnSync } = require("child_process");
     let failed = false;
-    for (const [i, _] of filePaths.entries()) {
+    for (const i of filePaths.keys()) {
       if (i > 0) {
         console.log("");
       }
-      const result = spawnSync(process.execPath, [__filename, String(i)], {
-        stdio: "inherit",
-      });
+      const args = [...process.execArgv, __filename, String(i)];
+      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
+      if (result.error != null) {
+        console.error(result.error);
+      }
       if (result.status !== 0) {
         failed = true;
       }
     }
     if (failed) {
-      process.exit(1);
+      process.exitCode = 1;
     }
     return;
   }
 
   const filePath = filePaths[Number(fileIndexArg)];
+  if (filePath == null) {
+    console.error("Unknown test file index: " + fileIndexArg);
+    process.exitCode = 1;
+    return;
+  }
 
   process.chdir(__dirname + "/esm");
   await import("./esm/test_preload.js");
@@ -449,24 +477,31 @@ async function main() {
   if (fileIndexArg == null) {
     const { spawnSync } = require("child_process");
     let failed = false;
-    for (const [i, _] of filePaths.entries()) {
+    for (const i of filePaths.keys()) {
       if (i > 0) {
         console.log("");
       }
-      const result = spawnSync(process.execPath, [__filename, String(i)], {
-        stdio: "inherit",
-      });
+      const args = [...process.execArgv, __filename, String(i)];
+      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
+      if (result.error != null) {
+        console.error(result.error);
+      }
       if (result.status !== 0) {
         failed = true;
       }
     }
     if (failed) {
-      process.exit(1);
+      process.exitCode = 1;
     }
     return;
   }
 
   const filePath = filePaths[Number(fileIndexArg)];
+  if (filePath == null) {
+    console.error("Unknown test file index: " + fileIndexArg);
+    process.exitCode = 1;
+    return;
+  }
 
   process.chdir(__dirname + "/script");
   try {
@@ -532,24 +567,31 @@ async function main() {
   if (fileIndexArg == null) {
     const { spawnSync } = require("child_process");
     let failed = false;
-    for (const [i, _] of filePaths.entries()) {
+    for (const i of filePaths.keys()) {
       if (i > 0) {
         console.log("");
       }
-      const result = spawnSync(process.execPath, [__filename, String(i)], {
-        stdio: "inherit",
-      });
+      const args = [...process.execArgv, __filename, String(i)];
+      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
+      if (result.error != null) {
+        console.error(result.error);
+      }
       if (result.status !== 0) {
         failed = true;
       }
     }
     if (failed) {
-      process.exit(1);
+      process.exitCode = 1;
     }
     return;
   }
 
   const filePath = filePaths[Number(fileIndexArg)];
+  if (filePath == null) {
+    console.error("Unknown test file index: " + fileIndexArg);
+    process.exitCode = 1;
+    return;
+  }
 
   const esmPath = "./esm/" + filePath;
   console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
@@ -583,24 +625,31 @@ async function main() {
   if (fileIndexArg == null) {
     const { spawnSync } = require("child_process");
     let failed = false;
-    for (const [i, _] of filePaths.entries()) {
+    for (const i of filePaths.keys()) {
       if (i > 0) {
         console.log("");
       }
-      const result = spawnSync(process.execPath, [__filename, String(i)], {
-        stdio: "inherit",
-      });
+      const args = [...process.execArgv, __filename, String(i)];
+      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
+      if (result.error != null) {
+        console.error(result.error);
+      }
       if (result.status !== 0) {
         failed = true;
       }
     }
     if (failed) {
-      process.exit(1);
+      process.exitCode = 1;
     }
     return;
   }
 
   const filePath = filePaths[Number(fileIndexArg)];
+  if (filePath == null) {
+    console.error("Unknown test file index: " + fileIndexArg);
+    process.exitCode = 1;
+    return;
+  }
 
   const scriptPath = "./script/" + filePath;
   console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");

--- a/lib/test_runner/get_test_runner_code.test.ts
+++ b/lib/test_runner/get_test_runner_code.test.ts
@@ -24,50 +24,26 @@ const filePaths = [
 ];
 
 async function main() {
-  const fileIndexArg = process.argv[2];
-  if (fileIndexArg == null) {
-    const { spawnSync } = require("child_process");
-    let failed = false;
-    for (const i of filePaths.keys()) {
-      if (i > 0) {
-        console.log("");
-      }
-      const args = [...process.execArgv, __filename, String(i)];
-      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
-      if (result.error != null) {
-        console.error(result.error);
-      }
-      if (result.status !== 0) {
-        failed = true;
-      }
+  for (const [i, filePath] of filePaths.entries()) {
+    if (i > 0) {
+      console.log("");
     }
-    if (failed) {
-      process.exitCode = 1;
+
+    const scriptPath = "./script/" + filePath;
+    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    process.chdir(__dirname + "/script");
+    try {
+      require(scriptPath);
+    } catch(err) {
+      console.error(err);
+      process.exit(1);
     }
-    return;
-  }
 
-  const filePath = filePaths[Number(fileIndexArg)];
-  if (filePath == null) {
-    console.error("Unknown test file index: " + fileIndexArg);
-    process.exitCode = 1;
-    return;
+    const esmPath = "./esm/" + filePath;
+    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    process.chdir(__dirname + "/esm");
+    await import(esmPath);
   }
-
-  const scriptPath = "./script/" + filePath;
-  console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
-  process.chdir(__dirname + "/script");
-  try {
-    require(scriptPath);
-  } catch(err) {
-    console.error(err);
-    process.exit(1);
-  }
-
-  const esmPath = "./esm/" + filePath;
-  console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
-  process.chdir(__dirname + "/esm");
-  await import(esmPath);
 }
 
 main();
@@ -95,7 +71,60 @@ const filePaths = [
 ];
 
 async function main() {
-  const fileIndexArg = process.argv[2];
+  const testContext = {
+    process,
+    pc,
+  };
+  for (const [i, filePath] of filePaths.entries()) {
+    if (i > 0) {
+      console.log("");
+    }
+
+    const scriptPath = "./script/" + filePath;
+    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    process.chdir(__dirname + "/script");
+    const scriptTestContext = {
+      origin: pathToFileURL(filePath).toString(),
+      ...testContext,
+    };
+    try {
+      require(scriptPath);
+    } catch(err) {
+      console.error(err);
+      process.exit(1);
+    }
+    await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), scriptTestContext);
+
+    const esmPath = "./esm/" + filePath;
+    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    process.chdir(__dirname + "/esm");
+    const esmTestContext = {
+      origin: pathToFileURL(filePath).toString(),
+      ...testContext,
+    };
+    await import(esmPath);
+    await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), esmTestContext);
+  }
+}
+
+${runTestDefinitionsCode}
+
+main();
+`,
+  );
+});
+
+Deno.test("gets code when isolating the test files", () => {
+  const code = getTestRunnerCode({
+    testEntryPoints: ["./test.ts"],
+    denoTestShimPackageName: undefined,
+    includeEsModule: true,
+    includeScriptModule: true,
+    testIsolation: "process",
+  });
+  assertStringIncludes(
+    code,
+    `  const fileIndexArg = process.argv[2];
   if (fileIndexArg == null) {
     const { spawnSync } = require("child_process");
     let failed = false;
@@ -118,200 +147,10 @@ async function main() {
     return;
   }
 
-  const filePath = filePaths[Number(fileIndexArg)];
-  if (filePath == null) {
-    console.error("Unknown test file index: " + fileIndexArg);
-    process.exitCode = 1;
-    return;
-  }
-
-  const testContext = {
-    process,
-    pc,
-  };
-  const scriptPath = "./script/" + filePath;
-  console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
-  process.chdir(__dirname + "/script");
-  const scriptTestContext = {
-    origin: pathToFileURL(filePath).toString(),
-    ...testContext,
-  };
-  try {
-    require(scriptPath);
-  } catch(err) {
-    console.error(err);
-    process.exit(1);
-  }
-  await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), scriptTestContext);
-
-  const esmPath = "./esm/" + filePath;
-  console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
-  process.chdir(__dirname + "/esm");
-  const esmTestContext = {
-    origin: pathToFileURL(filePath).toString(),
-    ...testContext,
-  };
-  await import(esmPath);
-  await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), esmTestContext);
-}
-
-async function runTestDefinitions(testDefinitions, options) {
-  const testFailures = [];
-  const hasOnly = testDefinitions.some((d)=>d.only);
-  if (hasOnly) {
-    testDefinitions = testDefinitions.filter((d)=>d.only);
-  }
-  for (const definition of testDefinitions){
-    options.process.stdout.write("test " + definition.name + " ...");
-    if (definition.ignore) {
-      options.process.stdout.write(\` \${options.pc.gray("ignored")}\\n\`);
-      continue;
-    }
-    const context = getTestContext(definition, undefined);
-    let pass = false;
-    try {
-      await definition.fn(context);
-      if (context.hasFailingChild) {
-        testFailures.push({
-          name: definition.name,
-          err: new Error("Had failing test step.")
-        });
-      } else {
-        pass = true;
-      }
-    } catch (err) {
-      testFailures.push({
-        name: definition.name,
-        err
-      });
-    }
-    const testStepOutput = context.getOutput();
-    if (testStepOutput.length > 0) {
-      options.process.stdout.write(testStepOutput);
-    } else {
-      options.process.stdout.write(" ");
-    }
-    options.process.stdout.write(getStatusText(pass ? "ok" : "fail"));
-    options.process.stdout.write("\\n");
-  }
-  if (testFailures.length > 0) {
-    options.process.stdout.write("\\nFAILURES");
-    for (const failure of testFailures){
-      options.process.stdout.write("\\n\\n");
-      options.process.stdout.write(failure.name + "\\n");
-      options.process.stdout.write(indentText((failure.err?.stack ?? failure.err).toString(), 1));
-    }
-    options.process.exit(1);
-  } else if (hasOnly) {
-    options.process.stdout.write('error: Test failed because the "only" option was used.\\n');
-    options.process.exit(1);
-  }
-  function getTestContext(definition, parent) {
-    return {
-      name: definition.name,
-      parent,
-      origin: options.origin,
-      /** @type {any} */ err: undefined,
-      status: "ok",
-      children: [],
-      get hasFailingChild () {
-        return this.children.some((c)=>c.status === "fail" || c.status === "pending");
-      },
-      getOutput () {
-        let output = "";
-        if (this.parent) {
-          output += "test " + this.name + " ...";
-        }
-        if (this.children.length > 0) {
-          output += "\\n" + this.children.map((c)=>indentText(c.getOutput(), 1)).join("\\n") + "\\n";
-        } else if (!this.err) {
-          output += " ";
-        }
-        if (this.parent && this.err) {
-          output += "\\n";
-        }
-        if (this.err) {
-          output += indentText((this.err.stack ?? this.err).toString(), 1);
-          if (this.parent) {
-            output += "\\n";
-          }
-        }
-        if (this.parent) {
-          output += getStatusText(this.status);
-        }
-        return output;
-      },
-      async step (nameOrTestDefinition, fn) {
-        const definition = getDefinition();
-        const context = getTestContext(definition, this);
-        context.status = "pending";
-        this.children.push(context);
-        if (definition.ignore) {
-          context.status = "ignored";
-          return false;
-        }
-        try {
-          await definition.fn(context);
-          context.status = "ok";
-          if (context.hasFailingChild) {
-            context.status = "fail";
-            return false;
-          }
-          return true;
-        } catch (err) {
-          context.status = "fail";
-          context.err = err;
-          return false;
-        }
-        /** @returns {TestDefinition} */ function getDefinition() {
-          if (typeof nameOrTestDefinition === "string") {
-            if (!(fn instanceof Function)) {
-              throw new TypeError("Expected function for second argument.");
-            }
-            return {
-              name: nameOrTestDefinition,
-              fn
-            };
-          } else if (typeof nameOrTestDefinition === "object") {
-            return nameOrTestDefinition;
-          } else {
-            throw new TypeError("Expected a test definition or name and function.");
-          }
-        }
-      }
-    };
-  }
-  function getStatusText(status) {
-    switch(status){
-      case "ok":
-        return options.pc.green(status);
-      case "fail":
-      case "pending":
-        return options.pc.red(status);
-      case "ignored":
-        return options.pc.gray(status);
-      default:
-        {
-          const _assertNever = status;
-          return status;
-        }
-    }
-  }
-  function indentText(text, indentLevel) {
-    if (text === undefined) {
-      text = "[undefined]";
-    } else if (text === null) {
-      text = "[null]";
-    } else {
-      text = text.toString();
-    }
-    return text.split(/\\r?\\n/).map((line)=>"  ".repeat(indentLevel) + line).join("\\n");
-  }
-}
-
-main();
-`,
+  const filePath = filePaths[Number(fileIndexArg)];`,
   );
+  // there's no loop over the files because each one runs in its own process
+  assertEquals(code.includes("for (const [i, filePath]"), false);
 });
 
 Deno.test("gets code when a preload module is used", () => {
@@ -332,36 +171,6 @@ const filePaths = [
 ];
 
 async function main() {
-  const fileIndexArg = process.argv[2];
-  if (fileIndexArg == null) {
-    const { spawnSync } = require("child_process");
-    let failed = false;
-    for (const i of filePaths.keys()) {
-      if (i > 0) {
-        console.log("");
-      }
-      const args = [...process.execArgv, __filename, String(i)];
-      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
-      if (result.error != null) {
-        console.error(result.error);
-      }
-      if (result.status !== 0) {
-        failed = true;
-      }
-    }
-    if (failed) {
-      process.exitCode = 1;
-    }
-    return;
-  }
-
-  const filePath = filePaths[Number(fileIndexArg)];
-  if (filePath == null) {
-    console.error("Unknown test file index: " + fileIndexArg);
-    process.exitCode = 1;
-    return;
-  }
-
   process.chdir(__dirname + "/script");
   try {
     require("./script/scripts/test_preload.js");
@@ -372,20 +181,26 @@ async function main() {
   process.chdir(__dirname + "/esm");
   await import("./esm/scripts/test_preload.js");
 
-  const scriptPath = "./script/" + filePath;
-  console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
-  process.chdir(__dirname + "/script");
-  try {
-    require(scriptPath);
-  } catch(err) {
-    console.error(err);
-    process.exit(1);
-  }
+  for (const [i, filePath] of filePaths.entries()) {
+    if (i > 0) {
+      console.log("");
+    }
 
-  const esmPath = "./esm/" + filePath;
-  console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
-  process.chdir(__dirname + "/esm");
-  await import(esmPath);
+    const scriptPath = "./script/" + filePath;
+    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    process.chdir(__dirname + "/script");
+    try {
+      require(scriptPath);
+    } catch(err) {
+      console.error(err);
+      process.exit(1);
+    }
+
+    const esmPath = "./esm/" + filePath;
+    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    process.chdir(__dirname + "/esm");
+    await import(esmPath);
+  }
 }
 
 main();
@@ -411,43 +226,19 @@ const filePaths = [
 ];
 
 async function main() {
-  const fileIndexArg = process.argv[2];
-  if (fileIndexArg == null) {
-    const { spawnSync } = require("child_process");
-    let failed = false;
-    for (const i of filePaths.keys()) {
-      if (i > 0) {
-        console.log("");
-      }
-      const args = [...process.execArgv, __filename, String(i)];
-      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
-      if (result.error != null) {
-        console.error(result.error);
-      }
-      if (result.status !== 0) {
-        failed = true;
-      }
-    }
-    if (failed) {
-      process.exitCode = 1;
-    }
-    return;
-  }
-
-  const filePath = filePaths[Number(fileIndexArg)];
-  if (filePath == null) {
-    console.error("Unknown test file index: " + fileIndexArg);
-    process.exitCode = 1;
-    return;
-  }
-
   process.chdir(__dirname + "/esm");
   await import("./esm/test_preload.js");
 
-  const esmPath = "./esm/" + filePath;
-  console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
-  process.chdir(__dirname + "/esm");
-  await import(esmPath);
+  for (const [i, filePath] of filePaths.entries()) {
+    if (i > 0) {
+      console.log("");
+    }
+
+    const esmPath = "./esm/" + filePath;
+    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    process.chdir(__dirname + "/esm");
+    await import(esmPath);
+  }
 }
 
 main();
@@ -473,36 +264,6 @@ const filePaths = [
 ];
 
 async function main() {
-  const fileIndexArg = process.argv[2];
-  if (fileIndexArg == null) {
-    const { spawnSync } = require("child_process");
-    let failed = false;
-    for (const i of filePaths.keys()) {
-      if (i > 0) {
-        console.log("");
-      }
-      const args = [...process.execArgv, __filename, String(i)];
-      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
-      if (result.error != null) {
-        console.error(result.error);
-      }
-      if (result.status !== 0) {
-        failed = true;
-      }
-    }
-    if (failed) {
-      process.exitCode = 1;
-    }
-    return;
-  }
-
-  const filePath = filePaths[Number(fileIndexArg)];
-  if (filePath == null) {
-    console.error("Unknown test file index: " + fileIndexArg);
-    process.exitCode = 1;
-    return;
-  }
-
   process.chdir(__dirname + "/script");
   try {
     require("./script/test_preload.js");
@@ -511,14 +272,20 @@ async function main() {
     process.exit(1);
   }
 
-  const scriptPath = "./script/" + filePath;
-  console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
-  process.chdir(__dirname + "/script");
-  try {
-    require(scriptPath);
-  } catch(err) {
-    console.error(err);
-    process.exit(1);
+  for (const [i, filePath] of filePaths.entries()) {
+    if (i > 0) {
+      console.log("");
+    }
+
+    const scriptPath = "./script/" + filePath;
+    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    process.chdir(__dirname + "/script");
+    try {
+      require(scriptPath);
+    } catch(err) {
+      console.error(err);
+      process.exit(1);
+    }
   }
 }
 
@@ -563,40 +330,16 @@ const filePaths = [
 ];
 
 async function main() {
-  const fileIndexArg = process.argv[2];
-  if (fileIndexArg == null) {
-    const { spawnSync } = require("child_process");
-    let failed = false;
-    for (const i of filePaths.keys()) {
-      if (i > 0) {
-        console.log("");
-      }
-      const args = [...process.execArgv, __filename, String(i)];
-      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
-      if (result.error != null) {
-        console.error(result.error);
-      }
-      if (result.status !== 0) {
-        failed = true;
-      }
+  for (const [i, filePath] of filePaths.entries()) {
+    if (i > 0) {
+      console.log("");
     }
-    if (failed) {
-      process.exitCode = 1;
-    }
-    return;
-  }
 
-  const filePath = filePaths[Number(fileIndexArg)];
-  if (filePath == null) {
-    console.error("Unknown test file index: " + fileIndexArg);
-    process.exitCode = 1;
-    return;
+    const esmPath = "./esm/" + filePath;
+    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    process.chdir(__dirname + "/esm");
+    await import(esmPath);
   }
-
-  const esmPath = "./esm/" + filePath;
-  console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
-  process.chdir(__dirname + "/esm");
-  await import(esmPath);
 }
 
 main();
@@ -621,44 +364,20 @@ const filePaths = [
 ];
 
 async function main() {
-  const fileIndexArg = process.argv[2];
-  if (fileIndexArg == null) {
-    const { spawnSync } = require("child_process");
-    let failed = false;
-    for (const i of filePaths.keys()) {
-      if (i > 0) {
-        console.log("");
-      }
-      const args = [...process.execArgv, __filename, String(i)];
-      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
-      if (result.error != null) {
-        console.error(result.error);
-      }
-      if (result.status !== 0) {
-        failed = true;
-      }
+  for (const [i, filePath] of filePaths.entries()) {
+    if (i > 0) {
+      console.log("");
     }
-    if (failed) {
-      process.exitCode = 1;
+
+    const scriptPath = "./script/" + filePath;
+    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    process.chdir(__dirname + "/script");
+    try {
+      require(scriptPath);
+    } catch(err) {
+      console.error(err);
+      process.exit(1);
     }
-    return;
-  }
-
-  const filePath = filePaths[Number(fileIndexArg)];
-  if (filePath == null) {
-    console.error("Unknown test file index: " + fileIndexArg);
-    process.exitCode = 1;
-    return;
-  }
-
-  const scriptPath = "./script/" + filePath;
-  console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
-  process.chdir(__dirname + "/script");
-  try {
-    require(scriptPath);
-  } catch(err) {
-    console.error(err);
-    process.exit(1);
   }
 }
 

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -10,6 +10,7 @@ export function getTestRunnerCode(options: {
   includeEsModule: boolean | undefined;
   includeScriptModule: boolean | undefined;
   preloadEntryPoint?: string;
+  testIsolation?: "process" | "none";
 }) {
   const usesDenoTest = options.denoTestShimPackageName != null;
   const preloadPath = options.preloadEntryPoint == null
@@ -34,7 +35,59 @@ export function getTestRunnerCode(options: {
   });
   writer.writeLine("];").newLine();
 
+  const isolateTestFiles = options.testIsolation === "process";
   writer.write("async function main()").block(() => {
+    if (isolateTestFiles) {
+      writeSpawnPerFile();
+    }
+    if (preloadPath != null) {
+      if (options.includeScriptModule) {
+        writer.writeLine(`process.chdir(__dirname + "/script");`);
+        writer.write("try ").inlineBlock(() => {
+          writer.write("require(").quote(`./script/${preloadPath}`).write(");")
+            .newLine();
+        }).write(" catch(err)").block(() => {
+          writer.writeLine("console.error(err);");
+          writer.writeLine("process.exit(1);");
+        });
+      }
+      if (options.includeEsModule) {
+        writer.writeLine(`process.chdir(__dirname + "/esm");`);
+        writer.write("await import(").quote(`./esm/${preloadPath}`).write(");")
+          .newLine();
+      }
+      writer.blankLine();
+    }
+    if (usesDenoTest) {
+      writer.write("const testContext = ").inlineBlock(() => {
+        writer.writeLine("process,");
+        writer.writeLine("pc,");
+      }).write(";").newLine();
+    }
+    if (isolateTestFiles) {
+      writeTestFileRun();
+    } else {
+      writer.write("for (const [i, filePath] of filePaths.entries())")
+        .block(() => {
+          writer.write("if (i > 0)").block(() => {
+            writer.writeLine(`console.log("");`);
+          }).blankLine();
+
+          writeTestFileRun();
+        });
+    }
+  });
+  writer.blankLine();
+
+  if (options.denoTestShimPackageName != null) {
+    writer.writeLine(`${getRunTestDefinitionsCode()}`);
+    writer.blankLine();
+  }
+
+  writer.writeLine("main();");
+  return writer.toString();
+
+  function writeSpawnPerFile() {
     // run each test file in its own process so that the module state of a
     // test file doesn't leak into the next one, which is what `deno test`
     // does by running each file in its own isolate
@@ -72,31 +125,9 @@ export function getTestRunnerCode(options: {
       writer.writeLine("process.exitCode = 1;");
       writer.writeLine("return;");
     }).blankLine();
+  }
 
-    if (preloadPath != null) {
-      if (options.includeScriptModule) {
-        writer.writeLine(`process.chdir(__dirname + "/script");`);
-        writer.write("try ").inlineBlock(() => {
-          writer.write("require(").quote(`./script/${preloadPath}`).write(");")
-            .newLine();
-        }).write(" catch(err)").block(() => {
-          writer.writeLine("console.error(err);");
-          writer.writeLine("process.exit(1);");
-        });
-      }
-      if (options.includeEsModule) {
-        writer.writeLine(`process.chdir(__dirname + "/esm");`);
-        writer.write("await import(").quote(`./esm/${preloadPath}`).write(");")
-          .newLine();
-      }
-      writer.blankLine();
-    }
-    if (usesDenoTest) {
-      writer.write("const testContext = ").inlineBlock(() => {
-        writer.writeLine("process,");
-        writer.writeLine("pc,");
-      }).write(";").newLine();
-    }
+  function writeTestFileRun() {
     if (options.includeScriptModule) {
       writer.writeLine(`const scriptPath = "./script/" + filePath;`);
       writer.writeLine(
@@ -144,16 +175,7 @@ export function getTestRunnerCode(options: {
         );
       }
     }
-  });
-  writer.blankLine();
-
-  if (options.denoTestShimPackageName != null) {
-    writer.writeLine(`${getRunTestDefinitionsCode()}`);
-    writer.blankLine();
   }
-
-  writer.writeLine("main();");
-  return writer.toString();
 }
 
 function getRunTestDefinitionsCode() {

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -35,6 +35,36 @@ export function getTestRunnerCode(options: {
   writer.writeLine("];").newLine();
 
   writer.write("async function main()").block(() => {
+    // run each test file in its own process so that the module state of a
+    // test file doesn't leak into the next one, which is what `deno test`
+    // does by running each file in its own isolate
+    writer.writeLine("const fileIndexArg = process.argv[2];");
+    writer.write("if (fileIndexArg == null)").block(() => {
+      writer.writeLine(`const { spawnSync } = require("child_process");`);
+      writer.writeLine("let failed = false;");
+      writer.write("for (const [i, _] of filePaths.entries())").block(() => {
+        writer.write("if (i > 0)").block(() => {
+          writer.writeLine(`console.log("");`);
+        });
+        writer.writeLine(
+          `const result = spawnSync(process.execPath, [__filename, String(i)], {`,
+        );
+        writer.indent(() => {
+          writer.writeLine(`stdio: "inherit",`);
+        });
+        writer.writeLine("});");
+        writer.write("if (result.status !== 0)").block(() => {
+          writer.writeLine("failed = true;");
+        });
+      });
+      writer.write("if (failed)").block(() => {
+        writer.writeLine("process.exit(1);");
+      });
+      writer.writeLine("return;");
+    }).blankLine();
+    writer.writeLine("const filePath = filePaths[Number(fileIndexArg)];")
+      .blankLine();
+
     if (preloadPath != null) {
       if (options.includeScriptModule) {
         writer.writeLine(`process.chdir(__dirname + "/script");`);
@@ -59,12 +89,8 @@ export function getTestRunnerCode(options: {
         writer.writeLine("pc,");
       }).write(";").newLine();
     }
-    writer.write("for (const [i, filePath] of filePaths.entries())")
-      .block(() => {
-        writer.write("if (i > 0)").block(() => {
-          writer.writeLine(`console.log("");`);
-        }).blankLine();
-
+    {
+      {
         if (options.includeScriptModule) {
           writer.writeLine(`const scriptPath = "./script/" + filePath;`);
           writer.writeLine(
@@ -112,7 +138,8 @@ export function getTestRunnerCode(options: {
             );
           }
         }
-      });
+      }
+    }
   });
   writer.blankLine();
 

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -42,28 +42,36 @@ export function getTestRunnerCode(options: {
     writer.write("if (fileIndexArg == null)").block(() => {
       writer.writeLine(`const { spawnSync } = require("child_process");`);
       writer.writeLine("let failed = false;");
-      writer.write("for (const [i, _] of filePaths.entries())").block(() => {
+      writer.write("for (const i of filePaths.keys())").block(() => {
         writer.write("if (i > 0)").block(() => {
           writer.writeLine(`console.log("");`);
         });
         writer.writeLine(
-          `const result = spawnSync(process.execPath, [__filename, String(i)], {`,
+          "const args = [...process.execArgv, __filename, String(i)];",
         );
-        writer.indent(() => {
-          writer.writeLine(`stdio: "inherit",`);
+        writer.writeLine(
+          `const result = spawnSync(process.execPath, args, { stdio: "inherit" });`,
+        );
+        writer.write("if (result.error != null)").block(() => {
+          writer.writeLine("console.error(result.error);");
         });
-        writer.writeLine("});");
         writer.write("if (result.status !== 0)").block(() => {
           writer.writeLine("failed = true;");
         });
       });
       writer.write("if (failed)").block(() => {
-        writer.writeLine("process.exit(1);");
+        writer.writeLine("process.exitCode = 1;");
       });
       writer.writeLine("return;");
     }).blankLine();
-    writer.writeLine("const filePath = filePaths[Number(fileIndexArg)];")
-      .blankLine();
+    writer.writeLine("const filePath = filePaths[Number(fileIndexArg)];");
+    writer.write("if (filePath == null)").block(() => {
+      writer.writeLine(
+        `console.error("Unknown test file index: " + fileIndexArg);`,
+      );
+      writer.writeLine("process.exitCode = 1;");
+      writer.writeLine("return;");
+    }).blankLine();
 
     if (preloadPath != null) {
       if (options.includeScriptModule) {
@@ -89,55 +97,51 @@ export function getTestRunnerCode(options: {
         writer.writeLine("pc,");
       }).write(";").newLine();
     }
-    {
-      {
-        if (options.includeScriptModule) {
-          writer.writeLine(`const scriptPath = "./script/" + filePath;`);
-          writer.writeLine(
-            `console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");`,
-          );
-          writer.writeLine(`process.chdir(__dirname + "/script");`);
-          if (usesDenoTest) {
-            writer.write(`const scriptTestContext = `).inlineBlock(() => {
-              writer.writeLine("origin: pathToFileURL(filePath).toString(),");
-              writer.writeLine("...testContext,");
-            }).write(";").newLine();
-          }
-          writer.write("try ").inlineBlock(() => {
-            writer.writeLine(`require(scriptPath);`);
-          }).write(" catch(err)").block(() => {
-            writer.writeLine("console.error(err);");
-            writer.writeLine("process.exit(1);");
-          });
-          if (usesDenoTest) {
-            writer.writeLine(
-              "await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), scriptTestContext);",
-            );
-          }
-        }
+    if (options.includeScriptModule) {
+      writer.writeLine(`const scriptPath = "./script/" + filePath;`);
+      writer.writeLine(
+        `console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");`,
+      );
+      writer.writeLine(`process.chdir(__dirname + "/script");`);
+      if (usesDenoTest) {
+        writer.write(`const scriptTestContext = `).inlineBlock(() => {
+          writer.writeLine("origin: pathToFileURL(filePath).toString(),");
+          writer.writeLine("...testContext,");
+        }).write(";").newLine();
+      }
+      writer.write("try ").inlineBlock(() => {
+        writer.writeLine(`require(scriptPath);`);
+      }).write(" catch(err)").block(() => {
+        writer.writeLine("console.error(err);");
+        writer.writeLine("process.exit(1);");
+      });
+      if (usesDenoTest) {
+        writer.writeLine(
+          "await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), scriptTestContext);",
+        );
+      }
+    }
 
-        if (options.includeEsModule) {
-          if (options.includeScriptModule) {
-            writer.blankLine();
-          }
-          writer.writeLine(`const esmPath = "./esm/" + filePath;`);
-          writer.writeLine(
-            `console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");`,
-          );
-          writer.writeLine(`process.chdir(__dirname + "/esm");`);
-          if (usesDenoTest) {
-            writer.write(`const esmTestContext = `).inlineBlock(() => {
-              writer.writeLine("origin: pathToFileURL(filePath).toString(),");
-              writer.writeLine("...testContext,");
-            }).write(";").newLine();
-          }
-          writer.writeLine(`await import(esmPath);`);
-          if (usesDenoTest) {
-            writer.writeLine(
-              "await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), esmTestContext);",
-            );
-          }
-        }
+    if (options.includeEsModule) {
+      if (options.includeScriptModule) {
+        writer.blankLine();
+      }
+      writer.writeLine(`const esmPath = "./esm/" + filePath;`);
+      writer.writeLine(
+        `console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");`,
+      );
+      writer.writeLine(`process.chdir(__dirname + "/esm");`);
+      if (usesDenoTest) {
+        writer.write(`const esmTestContext = `).inlineBlock(() => {
+          writer.writeLine("origin: pathToFileURL(filePath).toString(),");
+          writer.writeLine("...testContext,");
+        }).write(";").newLine();
+      }
+      writer.writeLine(`await import(esmPath);`);
+      if (usesDenoTest) {
+        writer.writeLine(
+          "await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), esmTestContext);",
+        );
       }
     }
   });

--- a/mod.ts
+++ b/mod.ts
@@ -141,6 +141,17 @@ export interface BuildOptions {
    * Note that `node_modules` directories are never searched.
    */
   testPattern?: string;
+  /** How to isolate the test files from each other.
+   *
+   * * `"process"` - Run each test file in its own process, which is what
+   *   `deno test` does by running each file in its own isolate. Use this when
+   *   the module state of a test file affects the next one (ex. the global
+   *   hooks of `@std/testing/bdd`).
+   * * `"none"` - Run all the test files in the same process, which is faster
+   *   because it doesn't start a process per test file.
+   * @default "none"
+   */
+  testIsolation?: "process" | "none";
   /** Path to a module to load before running the tests. Ex. `./scripts/test_preload.ts`
    *
    * This is useful for setting up the Node.js environment the tests run in
@@ -814,6 +825,7 @@ export async function build(options: BuildOptions): Promise<void> {
       path.join(options.outDir, "test_runner.cjs"),
       transformCodeToTarget(
         getTestRunnerCode({
+          testIsolation: options.testIsolation,
           denoTestShimPackageName: denoTestShimPackage == null
             ? undefined
             : denoTestShimPackage.name === "@deno/shim-deno"

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1516,6 +1516,21 @@ Deno.test("using declaration project", async () => {
   });
 });
 
+Deno.test("should run each test file in its own process", async () => {
+  await runTest("test_hooks_project", {
+    entryPoints: ["mod.ts"],
+    outDir: "./npm",
+    typeCheck: false,
+    shims: {
+      deno: "dev",
+    },
+    package: {
+      name: "hooks",
+      version: "0.0.0",
+    },
+  });
+});
+
 Deno.test("should build jsr project", async () => {
   await runTest("jsr_project", {
     entryPoints: ["mod.ts"],
@@ -1758,6 +1773,7 @@ async function runTest(
     | "undici_project"
     | "shim_project"
     | "test_preload_project"
+    | "test_hooks_project"
     | "test_project"
     | "tla_project"
     | "types_package_project"

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1520,6 +1520,7 @@ Deno.test("should run each test file in its own process", async () => {
   await runTest("test_hooks_project", {
     entryPoints: ["mod.ts"],
     outDir: "./npm",
+    testIsolation: "process",
     typeCheck: false,
     shims: {
       deno: "dev",
@@ -1839,7 +1840,7 @@ function assertPreloadModuleOutput(output: Output) {
   assertStringIncludes(output.npmIgnore, "/esm/scripts/test_preload.js\n");
   assertStringIncludes(output.npmIgnore, "/script/scripts/test_preload.js\n");
 
-  // it should be loaded once for each output, before each test file
+  // it should be loaded once for each output, before any test file
   const testRunnerText = output.getFileText("test_runner.cjs");
   assertStringIncludes(
     testRunnerText,

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1839,7 +1839,7 @@ function assertPreloadModuleOutput(output: Output) {
   assertStringIncludes(output.npmIgnore, "/esm/scripts/test_preload.js\n");
   assertStringIncludes(output.npmIgnore, "/script/scripts/test_preload.js\n");
 
-  // it should be loaded once for each output, before any test file
+  // it should be loaded once for each output, before each test file
   const testRunnerText = output.getFileText("test_runner.cjs");
   assertStringIncludes(
     testRunnerText,

--- a/tests/test_hooks_project/a.test.ts
+++ b/tests/test_hooks_project/a.test.ts
@@ -1,19 +1,11 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
-import { beforeEach, describe, it } from "jsr:@std/testing@^1.0.19/bdd";
+import { describe, it } from "jsr:@std/testing@^1.0.19/bdd";
 import { add } from "./mod.ts";
-
-let value = 0;
-
-// a global hook can only be added once per test file, so this fails
-// when the test files aren't run in their own process
-beforeEach(() => {
-  value = 1;
-});
 
 describe("a", () => {
   it("adds", () => {
-    if (add(value, 1) !== 2) {
+    if (add(1, 1) !== 2) {
       throw new Error("Failed.");
     }
   });

--- a/tests/test_hooks_project/a.test.ts
+++ b/tests/test_hooks_project/a.test.ts
@@ -1,0 +1,20 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { beforeEach, describe, it } from "@std/testing/bdd";
+import { add } from "./mod.ts";
+
+let value = 0;
+
+// a global hook can only be added once per test file, so this fails
+// when the test files aren't run in their own process
+beforeEach(() => {
+  value = 1;
+});
+
+describe("a", () => {
+  it("adds", () => {
+    if (add(value, 1) !== 2) {
+      throw new Error("Failed.");
+    }
+  });
+});

--- a/tests/test_hooks_project/a.test.ts
+++ b/tests/test_hooks_project/a.test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
-import { beforeEach, describe, it } from "@std/testing/bdd";
+import { beforeEach, describe, it } from "jsr:@std/testing@^1.0.19/bdd";
 import { add } from "./mod.ts";
 
 let value = 0;

--- a/tests/test_hooks_project/b.test.ts
+++ b/tests/test_hooks_project/b.test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
-import { beforeEach, describe, it } from "@std/testing/bdd";
+import { beforeEach, describe, it } from "jsr:@std/testing@^1.0.19/bdd";
 import { add } from "./mod.ts";
 
 let value = 0;

--- a/tests/test_hooks_project/b.test.ts
+++ b/tests/test_hooks_project/b.test.ts
@@ -1,0 +1,20 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { beforeEach, describe, it } from "@std/testing/bdd";
+import { add } from "./mod.ts";
+
+let value = 0;
+
+// a global hook can only be added once per test file, so this fails
+// when the test files aren't run in their own process
+beforeEach(() => {
+  value = 1;
+});
+
+describe("b", () => {
+  it("adds", () => {
+    if (add(value, 1) !== 2) {
+      throw new Error("Failed.");
+    }
+  });
+});

--- a/tests/test_hooks_project/b.test.ts
+++ b/tests/test_hooks_project/b.test.ts
@@ -5,8 +5,8 @@ import { add } from "./mod.ts";
 
 let value = 0;
 
-// a global hook can only be added once per test file, so this fails
-// when the test files aren't run in their own process
+// a global hook errors when another test file already registered a global
+// test, so this only works when each test file runs in its own process
 beforeEach(() => {
   value = 1;
 });

--- a/tests/test_hooks_project/deno.json
+++ b/tests/test_hooks_project/deno.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "@std/testing": "jsr:@std/testing@^1.0.19"
-  }
-}

--- a/tests/test_hooks_project/deno.json
+++ b/tests/test_hooks_project/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@std/testing": "jsr:@std/testing@^1.0.19"
+  }
+}

--- a/tests/test_hooks_project/mod.ts
+++ b/tests/test_hooks_project/mod.ts
@@ -1,0 +1,5 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+export function add(a: number, b: number) {
+  return a + b;
+}


### PR DESCRIPTION
Closes #432

The test runner loads every test file into the same process, so a test file's module state leaks into the next one. With `@std/testing/bdd` the second file's global hooks hit `TestSuiteInternal.started`:

```
Error: Cannot add global hooks after a global test is registered
```

...or, when the first file already created the global suite, the hooks silently attach to the already drained global test so **those tests never run**:

```
Running tests in ./script/b.test.js...

Running tests in ./esm/b.test.js...
```

`deno test` gives each test file its own isolate. Since doing the equivalent means starting a process per test file, it's opt in:

```ts
await build({
  // ...etc...
  testIsolation: "process",
});
```

The generated runner then re-spawns itself once per test file. The children inherit stdio so the output is the same, the node arguments of the parent are forwarded, and the parent exits non-zero when any file fails. A preload module is loaded before each test file in this mode, which is what the isolation implies.

The default (`"none"`) keeps the current behavior of running everything in one process, so nothing changes for anyone who doesn't opt in.

Added `tests/test_hooks_project`, where the second test file adds a global hook. Loading both of its output files in one process errors with the message above, and the fixture passes with `testIsolation: "process"`.
