### PR TITLE
feat: use `util.styleText` in the test runner instead of picocolors

### DIFF
--- a/lib/package_json.test.ts
+++ b/lib/package_json.test.ts
@@ -4,7 +4,6 @@ import { assertEquals } from "@std/assert";
 import { getPackageJson, type GetPackageJsonOptions } from "./package_json.ts";
 
 const versions = {
-  picocolors: "^1.0.0",
   nodeTypes: "^20.9.0",
   tsLib: "^2.6.2",
 };
@@ -64,7 +63,6 @@ Deno.test("single entrypoint", () => {
     },
     devDependencies: {
       "@types/node": versions.nodeTypes,
-      "picocolors": versions.picocolors,
       "test-dep": "0.1.0",
       "@deno/shim-deno": "~0.1.0",
     },
@@ -519,7 +517,6 @@ Deno.test("peer dependencies", () => {
         },
         devDependencies: {
           "@types/node": versions.nodeTypes,
-          "picocolors": versions.picocolors,
           "test-dep": "0.1.0",
           "@deno/shim-deno": "~0.1.0",
         },

--- a/lib/package_json.ts
+++ b/lib/package_json.ts
@@ -71,11 +71,6 @@ export function getPackageJson({
   };
   const testDevDependencies = testEnabled
     ? ({
-      ...(!Object.keys(dependencies).includes("picocolors")
-        ? {
-          "picocolors": "^1.0.0",
-        }
-        : {}),
       // add dependencies from transform
       ...Object.fromEntries(
         // ignore peer dependencies on this

--- a/lib/test_runner/get_test_runner_code.test.ts
+++ b/lib/test_runner/get_test_runner_code.test.ts
@@ -16,7 +16,7 @@ Deno.test("gets code when no shim used", () => {
   });
   assertEquals(
     code,
-    `const pc = require("picocolors");
+    `const { styleText } = require("util");
 const process = require("process");
 
 const filePaths = [
@@ -30,7 +30,7 @@ async function main() {
     }
 
     const scriptPath = "./script/" + filePath;
-    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    console.log("Running tests in " + styleText("underline", scriptPath) + "...\\n");
     process.chdir(__dirname + "/script");
     try {
       require(scriptPath);
@@ -40,7 +40,7 @@ async function main() {
     }
 
     const esmPath = "./esm/" + filePath;
-    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    console.log("\\nRunning tests in " + styleText("underline", esmPath) + "...\\n");
     process.chdir(__dirname + "/esm");
     await import(esmPath);
   }
@@ -60,7 +60,7 @@ Deno.test("gets code when shim used", () => {
   });
   assertEquals(
     code,
-    `const pc = require("picocolors");
+    `const { styleText } = require("util");
 const process = require("process");
 const { pathToFileURL } = require("url");
 const { testDefinitions } = require("test-shim-package/test-internals");
@@ -73,7 +73,7 @@ const filePaths = [
 async function main() {
   const testContext = {
     process,
-    pc,
+    styleText,
   };
   for (const [i, filePath] of filePaths.entries()) {
     if (i > 0) {
@@ -81,7 +81,7 @@ async function main() {
     }
 
     const scriptPath = "./script/" + filePath;
-    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    console.log("Running tests in " + styleText("underline", scriptPath) + "...\\n");
     process.chdir(__dirname + "/script");
     const scriptTestContext = {
       origin: pathToFileURL(filePath).toString(),
@@ -96,7 +96,7 @@ async function main() {
     await runTestDefinitions(testDefinitions.splice(0, testDefinitions.length), scriptTestContext);
 
     const esmPath = "./esm/" + filePath;
-    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    console.log("\\nRunning tests in " + styleText("underline", esmPath) + "...\\n");
     process.chdir(__dirname + "/esm");
     const esmTestContext = {
       origin: pathToFileURL(filePath).toString(),
@@ -163,7 +163,7 @@ Deno.test("gets code when a preload module is used", () => {
   });
   assertEquals(
     code,
-    `const pc = require("picocolors");
+    `const { styleText } = require("util");
 const process = require("process");
 
 const filePaths = [
@@ -187,7 +187,7 @@ async function main() {
     }
 
     const scriptPath = "./script/" + filePath;
-    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    console.log("Running tests in " + styleText("underline", scriptPath) + "...\\n");
     process.chdir(__dirname + "/script");
     try {
       require(scriptPath);
@@ -197,7 +197,7 @@ async function main() {
     }
 
     const esmPath = "./esm/" + filePath;
-    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    console.log("\\nRunning tests in " + styleText("underline", esmPath) + "...\\n");
     process.chdir(__dirname + "/esm");
     await import(esmPath);
   }
@@ -218,7 +218,7 @@ Deno.test("gets code when a preload module is used without cjs", () => {
   });
   assertEquals(
     code,
-    `const pc = require("picocolors");
+    `const { styleText } = require("util");
 const process = require("process");
 
 const filePaths = [
@@ -235,7 +235,7 @@ async function main() {
     }
 
     const esmPath = "./esm/" + filePath;
-    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    console.log("\\nRunning tests in " + styleText("underline", esmPath) + "...\\n");
     process.chdir(__dirname + "/esm");
     await import(esmPath);
   }
@@ -256,7 +256,7 @@ Deno.test("gets code when a preload module is used without esm", () => {
   });
   assertEquals(
     code,
-    `const pc = require("picocolors");
+    `const { styleText } = require("util");
 const process = require("process");
 
 const filePaths = [
@@ -278,7 +278,7 @@ async function main() {
     }
 
     const scriptPath = "./script/" + filePath;
-    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    console.log("Running tests in " + styleText("underline", scriptPath) + "...\\n");
     process.chdir(__dirname + "/script");
     try {
       require(scriptPath);
@@ -322,7 +322,7 @@ Deno.test("gets code when cjs is not used", () => {
   });
   assertEquals(
     code,
-    `const pc = require("picocolors");
+    `const { styleText } = require("util");
 const process = require("process");
 
 const filePaths = [
@@ -336,7 +336,7 @@ async function main() {
     }
 
     const esmPath = "./esm/" + filePath;
-    console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");
+    console.log("\\nRunning tests in " + styleText("underline", esmPath) + "...\\n");
     process.chdir(__dirname + "/esm");
     await import(esmPath);
   }
@@ -356,7 +356,7 @@ Deno.test("gets code when esm is not used", () => {
   });
   assertEquals(
     code,
-    `const pc = require("picocolors");
+    `const { styleText } = require("util");
 const process = require("process");
 
 const filePaths = [
@@ -370,7 +370,7 @@ async function main() {
     }
 
     const scriptPath = "./script/" + filePath;
-    console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");
+    console.log("Running tests in " + styleText("underline", scriptPath) + "...\\n");
     process.chdir(__dirname + "/script");
     try {
       require(scriptPath);

--- a/lib/test_runner/get_test_runner_code.ts
+++ b/lib/test_runner/get_test_runner_code.ts
@@ -17,7 +17,7 @@ export function getTestRunnerCode(options: {
     ? undefined
     : toJsFilePath(options.preloadEntryPoint);
   const writer = createWriter();
-  writer.writeLine(`const pc = require("picocolors");`)
+  writer.writeLine(`const { styleText } = require("util");`)
     .writeLine(`const process = require("process");`);
   if (usesDenoTest) {
     writer.writeLine(`const { pathToFileURL } = require("url");`);
@@ -61,7 +61,7 @@ export function getTestRunnerCode(options: {
     if (usesDenoTest) {
       writer.write("const testContext = ").inlineBlock(() => {
         writer.writeLine("process,");
-        writer.writeLine("pc,");
+        writer.writeLine("styleText,");
       }).write(";").newLine();
     }
     if (isolateTestFiles) {
@@ -131,7 +131,7 @@ export function getTestRunnerCode(options: {
     if (options.includeScriptModule) {
       writer.writeLine(`const scriptPath = "./script/" + filePath;`);
       writer.writeLine(
-        `console.log("Running tests in " + pc.underline(scriptPath) + "...\\n");`,
+        `console.log("Running tests in " + styleText("underline", scriptPath) + "...\\n");`,
       );
       writer.writeLine(`process.chdir(__dirname + "/script");`);
       if (usesDenoTest) {
@@ -159,7 +159,7 @@ export function getTestRunnerCode(options: {
       }
       writer.writeLine(`const esmPath = "./esm/" + filePath;`);
       writer.writeLine(
-        `console.log("\\nRunning tests in " + pc.underline(esmPath) + "...\\n");`,
+        `console.log("\\nRunning tests in " + styleText("underline", esmPath) + "...\\n");`,
       );
       writer.writeLine(`process.chdir(__dirname + "/esm");`);
       if (usesDenoTest) {

--- a/lib/test_runner/test_runner.test.ts
+++ b/lib/test_runner/test_runner.test.ts
@@ -131,16 +131,17 @@ function getContext() {
       return output;
     },
     origin: "file:///file.ts",
-    pc: {
-      red(text: string) {
-        return `R${text}R`;
-      },
-      green(text: string) {
-        return `G${text}G`;
-      },
-      gray(text: string) {
-        return `Y${text}Y`;
-      },
+    styleText(format: string, text: string) {
+      switch (format) {
+        case "red":
+          return `R${text}R`;
+        case "green":
+          return `G${text}G`;
+        case "gray":
+          return `Y${text}Y`;
+        default:
+          return text;
+      }
     },
     process: {
       stdout: {

--- a/lib/test_runner/test_runner.ts
+++ b/lib/test_runner/test_runner.ts
@@ -1,11 +1,5 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
-export interface Picocolors {
-  green(text: string): string;
-  red(text: string): string;
-  gray(text: string): string;
-}
-
 export interface NodeProcess {
   stdout: {
     write(text: string): void;
@@ -14,7 +8,8 @@ export interface NodeProcess {
 }
 
 export interface RunTestDefinitionsOptions {
-  pc: Picocolors;
+  /** `util.styleText` from Node.js. */
+  styleText(format: string, text: string): string;
   process: NodeProcess;
   /** The file the tests are running in. */
   origin: string;
@@ -54,7 +49,9 @@ export async function runTestDefinitions(
   for (const definition of testDefinitions) {
     options.process.stdout.write("test " + definition.name + " ...");
     if (definition.ignore) {
-      options.process.stdout.write(` ${options.pc.gray("ignored")}\n`);
+      options.process.stdout.write(
+        ` ${options.styleText("gray", "ignored")}\n`,
+      );
       continue;
     }
     const context = getTestContext(definition, undefined);
@@ -193,12 +190,12 @@ export async function runTestDefinitions(
   function getStatusText(status: TestContext["status"]) {
     switch (status) {
       case "ok":
-        return options.pc.green(status);
+        return options.styleText("green", status);
       case "fail":
       case "pending":
-        return options.pc.red(status);
+        return options.styleText("red", status);
       case "ignored":
-        return options.pc.gray(status);
+        return options.styleText("gray", status);
       default: {
         const _assertNever: never = status;
         return status;

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -14,7 +14,6 @@ const versions = {
   promptsShim: "~0.1.0",
   weakRefSham: "~0.1.0",
   undici: "^6.0.0",
-  picocolors: "^1.0.0",
   nodeTypes: "^20.9.0",
   newNodeTypes: "^22.16.3",
   tsLib: "^2.6.2",
@@ -79,7 +78,6 @@ Deno.test("should build test project - basic", async () => {
       },
       devDependencies: {
         "@types/node": versions.nodeTypes,
-        picocolors: versions.picocolors,
         "@deno/shim-deno": versions.denoShim,
         "@deno/sham-weakref": versions.weakRefSham,
       },
@@ -158,7 +156,6 @@ Deno.test("should build test project without esm", async () => {
       },
       devDependencies: {
         "@types/node": versions.nodeTypes,
-        picocolors: versions.picocolors,
         "@deno/shim-deno": versions.denoShim,
         "@deno/sham-weakref": versions.weakRefSham,
       },
@@ -381,7 +378,6 @@ Deno.test("should build test project with declarations inline by default", async
         },
         devDependencies: {
           "@types/node": versions.nodeTypes,
-          picocolors: versions.picocolors,
           "@deno/shim-deno": versions.denoShim,
         },
         _generatedBy: "dnt@dev",
@@ -502,7 +498,6 @@ Deno.test("should build bin project", async () => {
       },
       devDependencies: {
         "@types/node": versions.nodeTypes,
-        picocolors: versions.picocolors,
         "@deno/shim-deno": versions.denoShim,
       },
       _generatedBy: "dnt@dev",
@@ -544,9 +539,6 @@ Deno.test("should build bin project with a shebang", async () => {
       },
       scripts: {
         test: "node test_runner.cjs",
-      },
-      devDependencies: {
-        picocolors: versions.picocolors,
       },
       _generatedBy: "dnt@dev",
     });
@@ -704,7 +696,6 @@ Deno.test("should run tests when using @deno/shim-deno-test shim", async () => {
     output.assertNotExists("esm/mod.js.map");
     assertEquals(output.packageJson.devDependencies, {
       "@types/node": versions.nodeTypes,
-      picocolors: versions.picocolors,
       "@deno/shim-deno-test": versions.denoTestShim,
       "@deno/sham-weakref": versions.weakRefSham,
     });
@@ -762,7 +753,6 @@ Deno.test("not error for TLA when not using CommonJS", async () => {
       types: "./types/mod.d.ts",
       devDependencies: {
         "@types/node": versions.nodeTypes,
-        picocolors: versions.picocolors,
         "@deno/shim-deno": versions.denoShim,
       },
       _generatedBy: "dnt@dev",
@@ -894,7 +884,6 @@ Deno.test("should build with package mappings", async () => {
       },
       devDependencies: {
         "@types/node": versions.nodeTypes,
-        picocolors: versions.picocolors,
         "@deno/shim-deno": versions.denoShim,
       },
       _generatedBy: "dnt@dev",
@@ -965,7 +954,6 @@ Deno.test("should build with peer dependencies in mappings", async () => {
       },
       devDependencies: {
         "@types/node": versions.nodeTypes,
-        picocolors: versions.picocolors,
         "@deno/shim-deno": versions.denoShim,
       },
       _generatedBy: "dnt@dev",
@@ -1050,7 +1038,6 @@ Deno.test("should build shim project with everything enabled", async () => {
     assertEquals(output.packageJson.devDependencies, {
       "@types/domexception": versions.domExceptionShimTypes,
       "@types/node": versions.nodeTypes,
-      "picocolors": versions.picocolors,
     });
   });
 });
@@ -1649,7 +1636,6 @@ Deno.test("should build jsr project", async () => {
       },
       devDependencies: {
         "@types/node": versions.nodeTypes,
-        picocolors: versions.picocolors,
         "@deno/shim-deno": versions.denoShim,
       },
       _generatedBy: "dnt@dev",
@@ -1765,9 +1751,6 @@ Deno.test("should build workspace project", async () => {
         },
         dependencies: {
           tslib: versions.tsLib,
-        },
-        devDependencies: {
-          picocolors: versions.picocolors,
         },
         _generatedBy: "dnt@dev",
       });


### PR DESCRIPTION
Replaces picocolors with Node's built-in [`util.styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text-options) in the generated `test_runner.cjs`, which means dnt no longer adds a `picocolors` dev dependency to generated packages.

- the runner now does `const { styleText } = require("util");` and passes `styleText` into the test context instead of `pc`
- `RunTestDefinitionsOptions` takes a `styleText(format, text)` function in place of the `Picocolors` interface

Note this makes Node >= 20.12 (or >= 21.7) an effective minimum for running a generated package's tests, since that's when `styleText` landed.

Part of https://github.com/denoland/dnt/issues/454