### PR TITLE
fix: stop rewriting the `window` global

### DIFF
--- a/rs-lib/src/visitors/globals.rs
+++ b/rs-lib/src/visitors/globals.rs
@@ -87,26 +87,6 @@ fn visit_children(node: Node, import_name: &str, context: &mut Context) {
     let ident_text = ident.text_fast(context.program);
 
     if is_unresolved_context {
-      // change `window` -> `globalThis`
-      if ident_text == "window" {
-        if !context.top_level_decls.contains("window")
-          && !has_ignore_comment(ident.into(), context)
-        {
-          if let Some(text_change) =
-            get_global_this_text_change(ident, import_name, context)
-          {
-            context.text_changes.push(text_change);
-            context.import_shim = true;
-          } else {
-            context.text_changes.push(TextChange {
-              range: create_range(ident.start(), ident.end(), context),
-              new_text: get_replacement_text(ident, "globalThis", context),
-            });
-          }
-        }
-        return;
-      }
-
       // check to replace globalThis
       if ident_text == "globalThis" {
         if let Some(text_change) =

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -103,13 +103,6 @@ const obj = { Deno: dntShim.Deno, [dntShim.Deno]: 1, ...dntShim.Deno };"
       ),
     ),
     (
-      "const obj = { window };",
-      concat!(
-        r#"import * as dntShim from "./_dnt.shims.js";"#,
-        "\nconst obj = { window: dntShim.dntGlobalThis };"
-      ),
-    ),
-    (
       concat!(
         "const decl01 = Deno;\n",
         "const decl02 = setTimeout;\n",
@@ -445,7 +438,6 @@ async fn transform_global_this_shim() {
       "type Test1 = typeof globalThis;",
       "type Test2 = typeof globalThis.Window;",
       "type Test3 = typeof globalThis.Deno;",
-      "type Test4 = window.Something;",
     ),
     concat!(
       r#"import * as dntShim from "./_dnt.shims.js";"#,
@@ -464,28 +456,22 @@ async fn transform_global_this_shim() {
       "type Test1 = typeof dntShim.dntGlobalThis;",
       "type Test2 = typeof globalThis.Window;",
       "type Test3 = typeof dntShim.Deno;",
-      "type Test4 = globalThis.Something;",
     ),
   )])
   .await;
 }
 
 #[tokio::test]
-async fn transform_window() {
-  assert_transforms(vec![
-    (
-      concat!("window.test = 5;", "window.Deno.test();",),
-      concat!(
-        r#"import * as dntShim from "./_dnt.shims.js";"#,
-        "\nglobalThis.test = 5;",
-        "dntShim.dntGlobalThis.Deno.test();",
-      ),
-    ),
-    (
-      // should be as-is because there's a declaration
-      "const window = {}; window.test;",
-      "const window = {}; window.test;",
-    ),
+async fn no_transform_window() {
+  // `window` is not a global in Node.js nor Deno, so leave it alone
+  // (ex. `typeof window === "object"` should stay a browser check)
+  assert_identity_transforms(vec![
+    "window.test = 5;",
+    "window.Deno.test();",
+    "const obj = { window };",
+    r#"typeof window === "object";"#,
+    "type Test = window.Something;",
+    "const window = {}; window.test;",
   ])
   .await;
 }


### PR DESCRIPTION
dnt was rewriting any unresolved `window` identifier to `globalThis`, or to `dntShim.dntGlobalThis` when the global shim proxy was in play. That breaks browser detection: `typeof window === "object"` came out as `typeof dntShim.dntGlobalThis === "object"`, which is always true.

`window` no longer exists in Deno, so there's nothing to transform — it's now left completely alone. `globalThis` handling is unchanged, and the `dntGlobalThis` merge proxy never defined `window`.

Closes the `window` part of #454 (see https://github.com/denoland/dnt/issues/454#issuecomment-2987818117).
