### PR TITLE
fix: don't use the `globalThis` shim when there are no shimmed globals

### DIFF
--- a/rs-lib/src/visitors/globals.rs
+++ b/rs-lib/src/visitors/globals.rs
@@ -87,13 +87,16 @@ fn visit_children(node: Node, import_name: &str, context: &mut Context) {
     let ident_text = ident.text_fast(context.program);
 
     if is_unresolved_context {
-      // check to replace globalThis
+      // check to replace globalThis, which is only necessary when there
+      // are globals to merge into it
       if ident_text == "globalThis" {
-        if let Some(text_change) =
-          get_global_this_text_change(ident, import_name, context)
-        {
-          context.text_changes.push(text_change);
-          context.import_shim = true;
+        if !context.shim_global_names.is_empty() {
+          if let Some(text_change) =
+            get_global_this_text_change(ident, import_name, context)
+          {
+            context.text_changes.push(text_change);
+            context.import_shim = true;
+          }
         }
         return;
       }

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -462,6 +462,28 @@ async fn transform_global_this_shim() {
 }
 
 #[tokio::test]
+async fn no_transform_global_this_when_no_shims() {
+  // there's nothing to merge into `globalThis`, so it should be left
+  // alone and no shim file should be created
+  let text = concat!(
+    "globalThis.Deno.readTextFile();",
+    "true ? globalThis : globalThis;",
+    "typeof globalThis;",
+    "globalThis == null;",
+    "type Test = typeof globalThis;",
+  );
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader.add_local_file("/mod.ts", text);
+    })
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(result.main.files, &[("mod.ts", text)]);
+}
+
+#[tokio::test]
 async fn no_transform_window() {
   // `window` is not a global in Node.js nor Deno, so leave it alone
   // (ex. `typeof window === "object"` should stay a browser check)


### PR DESCRIPTION
With `shims: {}` (or every shim disabled), dnt still rewrote every unresolved `globalThis` to `dntShim.dntGlobalThis` and emitted an `_dnt.shims.ts` into the output, where the proxy merged `globalThis` with an empty object:

```js
// in
export function isBrowser() {
  return typeof globalThis !== "undefined" && globalThis != null;
}
// out (before)
import * as dntShim from "./_dnt.shims.js";
export function isBrowser() {
    return typeof dntShim.dntGlobalThis !== "undefined" && dntShim.dntGlobalThis != null;
}
```

There's nothing to merge into `globalThis` in that case, so the rewrite is skipped when no shim declares any global names. The shim file is only emitted when something imports it, so it now disappears from the output as well.

Behaviour with shims configured is unchanged.

Closes https://github.com/denoland/dnt/issues/454
