### PR TITLE
feat: add a `cwd` build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,27 +108,6 @@ test escapeChar ... ok
 
 ## Docs
 
-### Building a Directory Other Than the Current Working Directory
-
-By default, dnt operates on the current working directory. Provide a `cwd`
-option to point it at another directory, which is useful when the build script
-is run from somewhere else (ex. the root of a monorepo):
-
-```ts
-await build({
-  cwd: "./packages/add",
-  // resolved as ./packages/add/mod.ts
-  entryPoints: ["./mod.ts"],
-  // written to ./packages/add/npm
-  outDir: "./npm",
-  // ...etc...
-});
-```
-
-All the relative paths in the build options resolve from this directory, test
-files are searched for here, and it's where a deno.json, package.json, and
-deno.lock are discovered from when the entry points are all remote.
-
 ### Disabling Type Checking, Testing, Declaration Emit, or CommonJS/UMD Output
 
 Use the following options to disable any one of these, which are enabled by
@@ -769,7 +748,7 @@ await build({
   // ...etc...
   testPattern: "**/*.test.{ts,tsx,js,mjs,jsx}",
   // and/or provide a directory to start searching for test
-  // files from, which defaults to the `cwd` option
+  // files from, which defaults to the current working directory
   rootTestDir: "./tests",
 });
 ```

--- a/README.md
+++ b/README.md
@@ -108,6 +108,27 @@ test escapeChar ... ok
 
 ## Docs
 
+### Building a Directory Other Than the Current Working Directory
+
+By default, dnt operates on the current working directory. Provide a `cwd`
+option to point it at another directory, which is useful when the build script
+is run from somewhere else (ex. the root of a monorepo):
+
+```ts
+await build({
+  cwd: "./packages/add",
+  // resolved as ./packages/add/mod.ts
+  entryPoints: ["./mod.ts"],
+  // written to ./packages/add/npm
+  outDir: "./npm",
+  // ...etc...
+});
+```
+
+All the relative paths in the build options resolve from this directory, test
+files are searched for here, and it's where a deno.json, package.json, and
+deno.lock are discovered from when the entry points are all remote.
+
 ### Disabling Type Checking, Testing, Declaration Emit, or CommonJS/UMD Output
 
 Use the following options to disable any one of these, which are enabled by
@@ -748,7 +769,7 @@ await build({
   // ...etc...
   testPattern: "**/*.test.{ts,tsx,js,mjs,jsx}",
   // and/or provide a directory to start searching for test
-  // files from, which defaults to the current working directory
+  // files from, which defaults to the `cwd` option
   rootTestDir: "./tests",
 });
 ```

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -46,6 +46,9 @@
     "tests/bare_mapping_project/npm",
     "tests/bin_project/npm",
     "tests/config_discovery_project/npm",
+    // this project is only ever built by dnt and resolves its bare specifiers
+    // via its own deno.json, so keep deno from type checking it from the root
+    "tests/cwd_project",
     "tests/declaration_import_project/npm",
     "tests/frozen_lockfile_project/npm",
     "tests/import_map_project/npm",

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -51,16 +51,22 @@ Deno.test({
 });
 
 Deno.test("valueToUrl", () => {
-  assertEquals(valueToUrl("npm:test"), "npm:test");
-  assertEquals(valueToUrl("node:path"), "node:path");
-  assertEquals(valueToUrl("jsr:@scope/package"), "jsr:@scope/package");
-  assertEquals(valueToUrl("https://deno.land"), "https://deno.land");
-  assertEquals(valueToUrl("http://deno.land"), "http://deno.land");
+  const cwd = Deno.cwd();
+  assertEquals(valueToUrl("npm:test", cwd), "npm:test");
+  assertEquals(valueToUrl("node:path", cwd), "node:path");
+  assertEquals(valueToUrl("jsr:@scope/package", cwd), "jsr:@scope/package");
+  assertEquals(valueToUrl("https://deno.land", cwd), "https://deno.land");
+  assertEquals(valueToUrl("http://deno.land", cwd), "http://deno.land");
   assertEquals(
-    valueToUrl("test"),
+    valueToUrl("test", cwd),
     path.toFileUrl(path.resolve("test")).toString(),
   );
-  assertEquals(valueToUrl("file:///test"), "file:///test");
+  assertEquals(valueToUrl("file:///test", cwd), "file:///test");
+  // a relative value resolves from the provided cwd
+  assertEquals(
+    valueToUrl("test", path.resolve("other")),
+    path.toFileUrl(path.resolve("other", "test")).toString(),
+  );
 });
 
 Deno.test("getDntVersion", () => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -102,14 +102,18 @@ export async function runCommand(opts: {
   }
 }
 
-export function standardizePath(fileOrDirPath: string) {
+/** Resolves the provided path or file url to an absolute path,
+ * resolving a relative path from `cwd` (defaults to `Deno.cwd()`). */
+export function standardizePath(fileOrDirPath: string, cwd?: string) {
   if (fileOrDirPath.startsWith("file:")) {
     return path.fromFileUrl(fileOrDirPath);
   }
-  return path.resolve(fileOrDirPath);
+  return resolvePath(fileOrDirPath, cwd);
 }
 
-export function valueToUrl(value: string) {
+/** Resolves the provided value to a url, resolving a relative path
+ * from `cwd` (defaults to `Deno.cwd()`). */
+export function valueToUrl(value: string, cwd?: string) {
   const lowerCaseValue = value.toLowerCase();
   if (
     lowerCaseValue.startsWith("http:") ||
@@ -121,11 +125,17 @@ export function valueToUrl(value: string) {
   ) {
     return value;
   } else {
-    return path.toFileUrl(path.resolve(value)).toString();
+    return path.toFileUrl(resolvePath(value, cwd)).toString();
   }
 }
 
 export function getDntVersion(url = import.meta.url) {
   return /\/(?:dnt@|@deno\/dnt\/)([0-9]+\.[0-9]+\.[0-9]+)\//.exec(url)?.[1] ??
     "dev";
+}
+
+function resolvePath(fileOrDirPath: string, cwd: string | undefined) {
+  return cwd == null
+    ? path.resolve(fileOrDirPath)
+    : path.resolve(cwd, fileOrDirPath);
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -103,17 +103,16 @@ export async function runCommand(opts: {
 }
 
 /** Resolves the provided path or file url to an absolute path,
- * resolving a relative path from `cwd` (defaults to `Deno.cwd()`). */
-export function standardizePath(fileOrDirPath: string, cwd?: string) {
+ * resolving a relative path from `cwd`. */
+export function standardizePath(fileOrDirPath: string, cwd: string) {
   if (fileOrDirPath.startsWith("file:")) {
     return path.fromFileUrl(fileOrDirPath);
   }
-  return resolvePath(fileOrDirPath, cwd);
+  return path.resolve(cwd, fileOrDirPath);
 }
 
-/** Resolves the provided value to a url, resolving a relative path
- * from `cwd` (defaults to `Deno.cwd()`). */
-export function valueToUrl(value: string, cwd?: string) {
+/** Resolves the provided value to a url, resolving a relative path from `cwd`. */
+export function valueToUrl(value: string, cwd: string) {
   const lowerCaseValue = value.toLowerCase();
   if (
     lowerCaseValue.startsWith("http:") ||
@@ -125,17 +124,11 @@ export function valueToUrl(value: string, cwd?: string) {
   ) {
     return value;
   } else {
-    return path.toFileUrl(resolvePath(value, cwd)).toString();
+    return path.toFileUrl(path.resolve(cwd, value)).toString();
   }
 }
 
 export function getDntVersion(url = import.meta.url) {
   return /\/(?:dnt@|@deno\/dnt\/)([0-9]+\.[0-9]+\.[0-9]+)\//.exec(url)?.[1] ??
     "dev";
-}
-
-function resolvePath(fileOrDirPath: string, cwd: string | undefined) {
-  return cwd == null
-    ? path.resolve(fileOrDirPath)
-    : path.resolve(cwd, fileOrDirPath);
 }

--- a/mod.ts
+++ b/mod.ts
@@ -69,6 +69,15 @@ export interface BuildOptions {
   outDir: string;
   /** Shims to use. */
   shims: ShimOptions;
+  /** Directory that dnt operates on.
+   *
+   * The relative paths in these options resolve from here, test files are
+   * searched for here, and a deno.json, package.json, and deno.lock are
+   * discovered relative to it when the entry points are all remote.
+   *
+   * @default `Deno.cwd()`
+   */
+  cwd?: string;
   /** Type check the output.
    * * `"both"` - Type checks both the ESM and script modules separately. This
    *   is the recommended option when publishing a dual ESM and script package,
@@ -135,7 +144,7 @@ export interface BuildOptions {
    * @default false
    */
   skipSourceOutput?: boolean;
-  /** Root directory to find test files in. Defaults to the cwd. */
+  /** Root directory to find test files in. Defaults to the `cwd` option. */
   rootTestDir?: string;
   /**
    * Glob pattern to use to find tests files. Defaults to `deno test`'s pattern.
@@ -321,10 +330,12 @@ export async function build(options: BuildOptions): Promise<void> {
   if (options.scriptModule === false && options.esModule === false) {
     throw new Error("`scriptModule` and `esModule` cannot both be `false`");
   }
+  // the directory that all the relative paths in the options resolve from
+  const cwd = standardizePath(options.cwd ?? ".");
   // set defaults
   options = {
     ...options,
-    outDir: standardizePath(options.outDir),
+    outDir: standardizePath(options.outDir, cwd),
     entryPoints: options.entryPoints,
     scriptModule: options.scriptModule ?? "cjs",
     esModule: options.esModule ?? true,
@@ -345,7 +356,6 @@ export async function build(options: BuildOptions): Promise<void> {
         `outputs the declarations beside the code they describe.`,
     );
   }
-  const cwd = Deno.cwd();
   // the declaration maps point at the `src` directory, so they're only useful
   // when it's written out and published alongside them
   const declarationMap = (options.declarationMap ?? false) &&
@@ -370,19 +380,19 @@ export async function build(options: BuildOptions): Promise<void> {
     if (typeof e === "string") {
       return {
         name: i === 0 ? "." : e.replace(/\.tsx?$/i, ".js"),
-        path: standardizePath(e),
+        path: standardizePath(e, cwd),
       };
     } else {
       return {
         ...e,
-        path: standardizePath(e.path),
+        path: standardizePath(e.path, cwd),
       };
     }
   });
   validateEntryPoints(entryPoints);
   const testPreloadModule = options.testPreloadModule == null
     ? undefined
-    : standardizePath(options.testPreloadModule);
+    : standardizePath(options.testPreloadModule, cwd);
 
   await Deno.permissions.request({ name: "write", path: options.outDir });
 
@@ -790,7 +800,7 @@ export async function build(options: BuildOptions): Promise<void> {
       importMap: options.importMap,
       configFile: options.configFile,
       frozenLockfile: options.frozenLockfile,
-      cwd: path.toFileUrl(cwd).toString(),
+      cwd,
     });
   }
 
@@ -808,7 +818,9 @@ export async function build(options: BuildOptions): Promise<void> {
   async function getTestEntryPoints() {
     const filePaths = await glob({
       pattern: getTestPattern(),
-      rootDir: options.rootTestDir ?? Deno.cwd(),
+      rootDir: options.rootTestDir == null
+        ? cwd
+        : standardizePath(options.rootTestDir, cwd),
       excludeDirs: [options.outDir],
     });
     if (testPreloadModule == null) {

--- a/mod.ts
+++ b/mod.ts
@@ -331,7 +331,7 @@ export async function build(options: BuildOptions): Promise<void> {
     throw new Error("`scriptModule` and `esModule` cannot both be `false`");
   }
   // the directory that all the relative paths in the options resolve from
-  const cwd = standardizePath(options.cwd ?? ".");
+  const cwd = standardizePath(options.cwd ?? ".", Deno.cwd());
   // set defaults
   options = {
     ...options,
@@ -406,7 +406,7 @@ export async function build(options: BuildOptions): Promise<void> {
   if (transformOutput.discoveredConfigFile != null) {
     log(
       `Auto-discovered config file: ${
-        standardizePath(transformOutput.discoveredConfigFile)
+        standardizePath(transformOutput.discoveredConfigFile, cwd)
       }`,
     );
   }

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -293,6 +293,8 @@ pub struct TransformOptions {
   ///
   /// Leave this `None` to use the `lock.frozen` setting in the deno.json file.
   pub frozen_lockfile: Option<bool>,
+  /// Directory that a config file, `deno.lock`, and `node_modules` directory
+  /// are discovered relative to.
   pub cwd: PathBuf,
 }
 

--- a/tests/cwd_project/add.test.ts
+++ b/tests/cwd_project/add.test.ts
@@ -1,0 +1,9 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { add } from "./add.ts";
+
+Deno.test("should add in cwd project", () => {
+  if (add(1, 2) !== "marker: 3") {
+    throw new Error("Did not add.");
+  }
+});

--- a/tests/cwd_project/add.ts
+++ b/tests/cwd_project/add.ts
@@ -1,0 +1,7 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+import { marker } from "@dnt/marker";
+
+export function add(a: number, b: number) {
+  return `${marker}: ${a + b}`;
+}

--- a/tests/cwd_project/deno.json
+++ b/tests/cwd_project/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@dnt/marker": "./marker.ts"
+  }
+}

--- a/tests/cwd_project/marker.ts
+++ b/tests/cwd_project/marker.ts
@@ -1,0 +1,3 @@
+// Copyright 2018-2024 the Deno authors. MIT license.
+
+export const marker = "marker";

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1688,6 +1688,44 @@ Deno.test("should auto-discover the deno.json", async () => {
   );
 });
 
+Deno.test("should build a project in another directory with the cwd option", async () => {
+  // note: this test intentionally does not change the cwd of the process
+  const projectDir = path.join(Deno.cwd(), "tests", "cwd_project");
+  const outDir = path.join(projectDir, "npm");
+  tryRemoveDir(outDir);
+  try {
+    await build({
+      cwd: "./tests/cwd_project",
+      entryPoints: ["add.ts"],
+      outDir: "./npm",
+      shims: {
+        ...getAllShimOptions(false),
+        deno: "dev",
+      },
+      package: {
+        name: "add",
+        version: "1.0.0",
+      },
+    });
+
+    // the deno.json beside the entry point was auto-discovered
+    assertStringIncludes(
+      Deno.readTextFileSync(path.join(outDir, "esm", "add.js")),
+      `from "./marker.js"`,
+    );
+    // the test files were searched for from the cwd option and not
+    // from this repo's directory
+    const testRunnerText = Deno.readTextFileSync(
+      path.join(outDir, "test_runner.cjs"),
+    );
+    const filePaths = /const filePaths = \[([^\]]*)\]/.exec(testRunnerText)![1];
+    assertStringIncludes(filePaths, "add.test.js");
+    assertEquals(filePaths.includes("integration.test"), false);
+  } finally {
+    tryRemoveDir(outDir);
+  }
+});
+
 Deno.test("should not auto-discover the deno.json when configFile is false", async () => {
   const err = await assertRejects(() =>
     runTest("config_discovery_project", {
@@ -1883,12 +1921,16 @@ async function runTest(
   }
 
   function tryRemoveOutDir() {
-    try {
-      Deno.removeSync(outDirPath, { recursive: true });
-    } catch (err) {
-      if (!(err instanceof Deno.errors.NotFound)) {
-        console.error(`Error removing dir: ${err}`);
-      }
+    tryRemoveDir(outDirPath);
+  }
+}
+
+function tryRemoveDir(dirPath: string) {
+  try {
+    Deno.removeSync(dirPath, { recursive: true });
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) {
+      console.error(`Error removing dir: ${err}`);
     }
   }
 }

--- a/transform.ts
+++ b/transform.ts
@@ -10,7 +10,7 @@ import { existsSync } from "@std/fs";
 import * as path from "@std/path";
 import * as wasm from "./lib/pkg/dnt_wasm.js";
 import type { PolyfillName, ScriptTarget } from "./lib/types.ts";
-import { valueToUrl } from "./lib/utils.ts";
+import { standardizePath, valueToUrl } from "./lib/utils.ts";
 
 /** Specifier to specifier mappings. */
 export interface SpecifierMappings {
@@ -108,6 +108,9 @@ export interface TransformOptions {
    * Leave this undefined to use the `lock.frozen` setting in the deno.json file.
    */
   frozenLockfile?: boolean;
+  /** Path or file url to the directory that the relative paths in these
+   * options resolve from and that a config file, `deno.lock`, and
+   * `node_modules` directory are discovered relative to. */
   cwd: string;
 }
 
@@ -160,40 +163,47 @@ export function transform(
   if (options.entryPoints.length === 0) {
     throw new Error("Specify one or more entry points.");
   }
+  // all the relative paths in the options resolve from here
+  const cwd = standardizePath(options.cwd);
   const newOptions = {
     ...options,
     mappings: Object.fromEntries(
       Object.entries(options.mappings ?? {}).map(([key, value]) => {
-        return [mapMappingKey(key), mapMappedSpecifier(value)];
+        return [mapMappingKey(key, cwd), mapMappedSpecifier(value, cwd)];
       }),
     ),
-    entryPoints: options.entryPoints.map(valueToUrl),
-    binEntryPoints: (options.binEntryPoints ?? []).map(valueToUrl),
-    testEntryPoints: (options.testEntryPoints ?? []).map(valueToUrl),
-    shims: (options.shims ?? []).map(mapShim),
-    testShims: (options.testShims ?? []).map(mapShim),
+    entryPoints: options.entryPoints.map((e) => valueToUrl(e, cwd)),
+    binEntryPoints: (options.binEntryPoints ?? []).map((e) =>
+      valueToUrl(e, cwd)
+    ),
+    testEntryPoints: (options.testEntryPoints ?? []).map((e) =>
+      valueToUrl(e, cwd)
+    ),
+    shims: (options.shims ?? []).map((s) => mapShim(s, cwd)),
+    testShims: (options.testShims ?? []).map((s) => mapShim(s, cwd)),
     target: options.target,
     polyfills: options.polyfills ?? {},
     importMap: options.importMap == null
       ? undefined
-      : valueToUrl(options.importMap),
+      : valueToUrl(options.importMap, cwd),
     configFile: typeof options.configFile === "string"
-      ? valueToUrl(options.configFile)
+      ? valueToUrl(options.configFile, cwd)
       : undefined,
     noConfig: options.configFile === false,
+    cwd: path.toFileUrl(cwd).toString(),
   };
   return wasm.transform(newOptions);
 }
 
-function mapMappingKey(key: string) {
+function mapMappingKey(key: string, cwd: string) {
   key = key.trim();
   if (/^[a-z]+:/i.test(key) || isRelativeOrAbsolutePath(key)) {
-    return valueToUrl(key);
+    return valueToUrl(key, cwd);
   }
   // fall back to a path for a key like `mod.ts` that resolved to
   // one before bare specifiers were supported
-  if (existsSync(key)) {
-    return valueToUrl(key);
+  if (existsSync(path.resolve(cwd, key))) {
+    return valueToUrl(key, cwd);
   }
   // leave bare specifiers alone so that they're resolved
   // via the config file's import map (ex. `my-lib`)
@@ -214,12 +224,13 @@ type SerializableMappedSpecifier = {
 
 function mapMappedSpecifier(
   value: string | PackageMappedSpecifier,
+  cwd: string,
 ): SerializableMappedSpecifier {
   if (typeof value === "string") {
     if (isPathOrUrl(value)) {
       return {
         kind: "module",
-        value: valueToUrl(value),
+        value: valueToUrl(value, cwd),
       };
     } else {
       return {
@@ -242,7 +253,7 @@ type SerializableShim = { kind: "package"; value: PackageShim } | {
   value: ModuleShim;
 };
 
-function mapShim(value: Shim): SerializableShim {
+function mapShim(value: Shim, cwd: string): SerializableShim {
   const newValue: Shim = {
     ...value,
     globalNames: value.globalNames.map(mapToGlobalName),
@@ -254,7 +265,7 @@ function mapShim(value: Shim): SerializableShim {
       kind: "module",
       value: {
         ...newValue,
-        module: resolveBareSpecifierOrPath(newValue.module),
+        module: resolveBareSpecifierOrPath(newValue.module, cwd),
       },
     };
   }
@@ -276,10 +287,10 @@ function mapToGlobalName(value: string | GlobalName): GlobalName {
   }
 }
 
-function resolveBareSpecifierOrPath(value: string) {
+function resolveBareSpecifierOrPath(value: string, cwd: string) {
   value = value.trim();
   if (isPathOrUrl(value)) {
-    return valueToUrl(value);
+    return valueToUrl(value, cwd);
   } else {
     return value;
   }

--- a/transform.ts
+++ b/transform.ts
@@ -164,7 +164,7 @@ export function transform(
     throw new Error("Specify one or more entry points.");
   }
   // all the relative paths in the options resolve from here
-  const cwd = standardizePath(options.cwd);
+  const cwd = standardizePath(options.cwd, Deno.cwd());
   const newOptions = {
     ...options,
     mappings: Object.fromEntries(


### PR DESCRIPTION
Adds a `cwd` build option so that dnt can operate on a directory other than the process's current working directory:

```ts
await build({
  cwd: "./packages/add",
  entryPoints: ["./mod.ts"], // ./packages/add/mod.ts
  outDir: "./npm",           // ./packages/add/npm
  // ...etc...
});
```

It defaults to `Deno.cwd()`, so existing builds are unaffected.

There were three separate places relying on the process cwd:

1. `standardizePath` resolved `entryPoints`, `outDir`, and `testPreloadModule` against it.
2. The test file glob used `rootTestDir ?? Deno.cwd()` as its root (this is what causes an unrelated subdirectory of the cwd to get pulled into a build).
3. It was passed to the transform as the workspace root, which is what discovers a deno.json, package.json, and deno.lock when the entry points are all remote.

All three now resolve from the `cwd` option. Along the way:

- The lower level `transform()` API now resolves its own relative paths (entry points, mappings, `importMap`, `configFile`, module shims) from its existing `cwd` option instead of the process cwd, and accepts a plain path there in addition to a file url.
- `rootTestDir` was previously handed to `expandGlob` unresolved, so a relative value resolved against the process cwd. It now resolves from the `cwd` option.
- `mapMappingKey`'s `existsSync(key)` fallback was probing the process cwd.

Closes #337
