### PR TITLE
fix: keep a peer dependency out of `dependencies` when a sub path resolves to it

### DIFF
--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -1176,6 +1176,18 @@ fn get_dependencies(
       }
     })
     .collect::<Vec<_>>();
+  // a package.json lists a package as a peer dependency or a dependency, but
+  // never both, so a package mapped as a peer dependency stays one even when
+  // another specifier resolves to it (ex. a sub path of the same package,
+  // whose `npm:` specifier the user has no reason to map on its own)
+  let peer_names = dependencies
+    .iter()
+    .filter(|d| d.peer_dependency)
+    .map(|d| d.name.clone())
+    .collect::<HashSet<_>>();
+  for dependency in dependencies.iter_mut() {
+    dependency.peer_dependency |= peer_names.contains(&dependency.name);
+  }
   dependencies.sort_by(|a, b| a.name.cmp(&b.name));
   dependencies.dedup(); // only works after sorting
   dependencies

--- a/rs-lib/tests/integration/test_builder.rs
+++ b/rs-lib/tests/integration/test_builder.rs
@@ -180,6 +180,24 @@ impl TestBuilder {
     self
   }
 
+  pub fn add_peer_package_specifier_mapping(
+    &mut self,
+    specifier: impl AsRef<str>,
+    bare_specifier: impl AsRef<str>,
+    version: Option<&str>,
+  ) -> &mut Self {
+    self.specifier_mappings.insert(
+      normalize_urls(specifier.as_ref()),
+      MappedSpecifier::Package(PackageMappedSpecifier {
+        name: bare_specifier.as_ref().to_string(),
+        version: version.map(|v| v.to_string()),
+        sub_path: None,
+        peer_dependency: true,
+      }),
+    );
+    self
+  }
+
   pub fn add_module_specifier_mapping(
     &mut self,
     from: impl AsRef<str>,

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -3126,6 +3126,40 @@ async fn npm_specifier() {
 }
 
 #[tokio::test]
+async fn npm_specifier_peer_dependency_with_sub_path() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader.add_local_file(
+        "/mod.ts",
+        concat!(
+          "import * as pkg from 'npm:using-statement@^0.4';\n",
+          "import * as sub from 'npm:using-statement@^0.4/sub';\n",
+          "console.log(pkg, sub);\n",
+        ),
+      );
+    })
+    .add_peer_package_specifier_mapping(
+      "npm:using-statement@^0.4",
+      "using-statement",
+      Some("^0.4"),
+    )
+    .transform()
+    .await
+    .unwrap();
+
+  // the sub path resolves to the same package, so it must not also
+  // show up as a non-peer dependency
+  assert_eq!(
+    result.main.dependencies,
+    &[Dependency {
+      name: "using-statement".to_string(),
+      version: "^0.4".to_string(),
+      peer_dependency: true,
+    }]
+  );
+}
+
+#[tokio::test]
 async fn npm_types_specifier() {
   let result = TestBuilder::new()
     .with_loader(|loader| {


### PR DESCRIPTION
Found while checking whether #433 still reproduces. The cases reported there are all fixed on `main`, but a neighbouring one isn't.

A package imported both bare and by a sub path produces two `npm:` specifiers:

```ts
import pc from "picocolors";
import "picocolors/types";
```

Only the bare specifier matches the user's mapping, so the sub path gets an auto derived `PackageMappedSpecifier` with `peer_dependency: false`. `get_dependencies` emits both entries, and `package_json.ts` filters that same list into each section, so the package lands in both:

```json
"dependencies": { "picocolors": "^1.1.1" },
"peerDependencies": { "picocolors": "^1.1.1" }
```

npm then installs it as a regular dependency, which is the symptom #433 describes.

Being a peer dependency is a property of the package in the package.json rather than of an individual specifier, so a name marked as one anywhere stays one. The entries are then identical and collapse in the existing `dedup()`.

Mapping `npm:pkg@^1` when the source only imports `pkg/sub` still errors with "specifiers were indicated to be mapped to a package, but were not found". That seems right — the specifier that's actually imported is the one to map, which is what `subPath` is for.
