### PR TITLE
fix: unify differing version requirements of a mapped `jsr:` specifier

### DIFF
--- a/rs-lib/src/graph.rs
+++ b/rs-lib/src/graph.rs
@@ -11,6 +11,7 @@ use crate::parser::ScopeAnalysisParser;
 use crate::specifiers::get_specifiers;
 use crate::specifiers::Specifiers;
 use crate::MappedSpecifier;
+use crate::PackageMappedSpecifier;
 
 use anyhow::bail;
 use anyhow::Result;
@@ -35,6 +36,9 @@ use deno_resolver::factory::WorkspaceFactorySys;
 use deno_resolver::graph::DefaultDenoResolverRc;
 use deno_resolver::npm::DenoInNpmPackageChecker;
 use deno_semver::jsr::JsrPackageReqReference;
+use deno_semver::RangeBound;
+use deno_semver::Version;
+use deno_semver::VersionReq;
 use sys_traits::impls::RealSys;
 
 pub struct ModuleGraphOptions<'a, TSys: WorkspaceFactorySys> {
@@ -431,7 +435,8 @@ impl JsrSpecifierMappings {
     };
     let mut package = package.clone();
     if package.version.is_none() {
-      package.version = jsr_version_req(&specifier);
+      package.version =
+        jsr_version_req(&specifier).map(|req| req.version_text().to_string());
     }
     Some(MappedSpecifier::Package(package))
   }
@@ -454,6 +459,79 @@ impl JsrSpecifierMappings {
   }
 }
 
+/// Uses a single version requirement for the packages that mapped `jsr:`
+/// specifiers with overlapping version requirements resolve to.
+///
+/// A mapped `jsr:` specifier gets its version requirement from the specifier
+/// instead of the mapping, so a dependency requiring another range of the same
+/// package (ex. `jsr:@scope/name@0.3` when this package requires
+/// `jsr:@scope/name@^0.3.3`) would otherwise look like two versions of the
+/// same package. Deno resolves both to one version, so use the most
+/// restrictive requirement for all of them.
+pub fn unify_mapped_jsr_versions<'a>(
+  mapped_specifiers: impl Iterator<
+    Item = (&'a ModuleSpecifier, &'a mut PackageMappedSpecifier),
+  >,
+) {
+  let mut by_name: HashMap<
+    String,
+    Vec<(VersionReq, &mut PackageMappedSpecifier)>,
+  > = HashMap::new();
+  for (specifier, mapped) in mapped_specifiers {
+    let Some(version_req) = from_graph_specifier(specifier)
+      .as_ref()
+      .and_then(jsr_version_req)
+    else {
+      continue;
+    };
+    // a version requirement the mapping specified wins over the specifier's,
+    // so leave it alone
+    if mapped.version.as_deref() != Some(version_req.version_text()) {
+      continue;
+    }
+    by_name
+      .entry(mapped.name.clone())
+      .or_default()
+      .push((version_req, mapped));
+  }
+
+  for mut entries in by_name.into_values() {
+    if entries.len() < 2 {
+      continue;
+    }
+    // requirements that don't overlap are different versions of the package,
+    // which the mapping needs to disambiguate with a version of its own
+    let all_overlap = entries.iter().enumerate().all(|(i, (req, _))| {
+      entries[i + 1..]
+        .iter()
+        .all(|(other, _)| req.intersects(other))
+    });
+    if !all_overlap {
+      continue;
+    }
+    let Some(version) = entries
+      .iter()
+      .max_by(|(a, _), (b, _)| {
+        lowest_matching_version(a).cmp(&lowest_matching_version(b))
+      })
+      .map(|(req, _)| req.version_text().to_string())
+    else {
+      continue;
+    };
+    for (_, mapped) in entries.iter_mut() {
+      mapped.version = Some(version.clone());
+    }
+  }
+}
+
+/// Specifier to show the user, which hides the scheme mapped `jsr:` specifiers
+/// have within the module graph.
+pub fn display_specifier(specifier: &ModuleSpecifier) -> String {
+  from_graph_specifier(specifier)
+    .unwrap_or_else(|| specifier.clone())
+    .to_string()
+}
+
 /// Scheme mapped `jsr:` specifiers have within the module graph.
 const MAPPED_JSR_SCHEME: &str = "dnt-jsr";
 
@@ -472,14 +550,29 @@ fn jsr_mapping_key(specifier: &ModuleSpecifier) -> Option<JsrMappingKey> {
   ))
 }
 
-fn jsr_version_req(specifier: &ModuleSpecifier) -> Option<String> {
+fn jsr_version_req(specifier: &ModuleSpecifier) -> Option<VersionReq> {
   let req_ref = JsrPackageReqReference::from_specifier(specifier).ok()?;
-  let version_text = req_ref.req().version_req.version_text();
+  let version_req = &req_ref.req().version_req;
   // no version requirement, so leave it up to the mapping
-  if version_text == "*" {
+  if version_req.version_text() == "*" {
     return None;
   }
-  Some(version_text.to_string())
+  Some(version_req.clone())
+}
+
+/// Lowest version a requirement matches, which is [`None`] when it has no
+/// lower bound.
+fn lowest_matching_version(version_req: &VersionReq) -> Option<&Version> {
+  let mut lowest: Option<&Version> = None;
+  for range in version_req.range()?.0.iter() {
+    let RangeBound::Version(bound) = &range.start else {
+      return None;
+    };
+    if lowest.is_none_or(|lowest| bound.version < *lowest) {
+      lowest = Some(&bound.version);
+    }
+  }
+  lowest
 }
 
 fn from_graph_specifier(
@@ -510,7 +603,6 @@ fn format_specifiers_for_message(
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::PackageMappedSpecifier;
 
   #[test]
   fn test_jsr_mappings_graph_specifier() {
@@ -583,6 +675,74 @@ mod test {
       &parse("https://localhost/mod.ts"),
       [parse("https://localhost/other.ts")].iter()
     ));
+  }
+
+  #[test]
+  fn test_unify_mapped_jsr_versions() {
+    // the most restrictive of the overlapping requirements is used, including
+    // for a sub path of the same package
+    run_test(
+      &[
+        ("dnt-jsr:@scope/name@0.3", "package", Some("0.3")),
+        ("dnt-jsr:@scope/name@^0.3.3", "package", Some("^0.3.3")),
+        ("dnt-jsr:@scope/name@~0.3.1/sub", "package", Some("~0.3.1")),
+      ],
+      &[Some("^0.3.3"), Some("^0.3.3"), Some("^0.3.3")],
+    );
+    // requirements that don't overlap are different versions of the package,
+    // so they're left for the user to disambiguate
+    run_test(
+      &[
+        ("dnt-jsr:@scope/name@0.2", "package", Some("0.2")),
+        ("dnt-jsr:@scope/name@0.3", "package", Some("0.3")),
+      ],
+      &[Some("0.2"), Some("0.3")],
+    );
+    // a version the mapping specified is not changed
+    run_test(
+      &[
+        ("dnt-jsr:@scope/name@0.3", "package", Some("~0.3.5")),
+        ("dnt-jsr:@scope/name@^0.3.3", "package", Some("^0.3.3")),
+      ],
+      &[Some("~0.3.5"), Some("^0.3.3")],
+    );
+    // requirements of other packages and other schemes are not touched
+    run_test(
+      &[
+        ("dnt-jsr:@scope/name@^1.0.0", "package", Some("^1.0.0")),
+        ("dnt-jsr:@scope/other@^1.2.0", "other", Some("^1.2.0")),
+        ("https://localhost/name@^1.4.0", "package", Some("^1.4.0")),
+      ],
+      &[Some("^1.0.0"), Some("^1.2.0"), Some("^1.4.0")],
+    );
+
+    fn run_test(
+      packages: &[(&str, &str, Option<&str>)],
+      expected: &[Option<&str>],
+    ) {
+      let mut mapped = packages
+        .iter()
+        .map(|(specifier, name, version)| {
+          (
+            parse(specifier),
+            PackageMappedSpecifier {
+              name: name.to_string(),
+              version: version.map(ToOwned::to_owned),
+              sub_path: None,
+              peer_dependency: false,
+            },
+          )
+        })
+        .collect::<BTreeMap<_, _>>();
+      unify_mapped_jsr_versions(mapped.iter_mut());
+      assert_eq!(
+        packages
+          .iter()
+          .map(|(specifier, ..)| mapped[&parse(specifier)].version.as_deref())
+          .collect::<Vec<_>>(),
+        expected,
+      );
+    }
   }
 
   fn mappings() -> JsrSpecifierMappings {

--- a/rs-lib/src/graph.rs
+++ b/rs-lib/src/graph.rs
@@ -36,8 +36,7 @@ use deno_resolver::factory::WorkspaceFactorySys;
 use deno_resolver::graph::DefaultDenoResolverRc;
 use deno_resolver::npm::DenoInNpmPackageChecker;
 use deno_semver::jsr::JsrPackageReqReference;
-use deno_semver::RangeBound;
-use deno_semver::Version;
+use deno_semver::VersionRange;
 use deno_semver::VersionReq;
 use sys_traits::impls::RealSys;
 
@@ -224,6 +223,7 @@ impl ModuleGraph {
     let specifiers = get_specifiers(
       &options.entry_points,
       loader_specifiers,
+      &jsr_specifier_mappings,
       &graph,
       graph.all_modules(),
     )?;
@@ -457,69 +457,88 @@ impl JsrSpecifierMappings {
         .is_some_and(|s| s == key)
     })
   }
-}
 
-/// Uses a single version requirement for the packages that mapped `jsr:`
-/// specifiers with overlapping version requirements resolve to.
-///
-/// A mapped `jsr:` specifier gets its version requirement from the specifier
-/// instead of the mapping, so a dependency requiring another range of the same
-/// package (ex. `jsr:@scope/name@0.3` when this package requires
-/// `jsr:@scope/name@^0.3.3`) would otherwise look like two versions of the
-/// same package. Deno resolves both to one version, so use the most
-/// restrictive requirement for all of them.
-pub fn unify_mapped_jsr_versions<'a>(
-  mapped_specifiers: impl Iterator<
-    Item = (&'a ModuleSpecifier, &'a mut PackageMappedSpecifier),
-  >,
-) {
-  let mut by_name: HashMap<
-    String,
-    Vec<(VersionReq, &mut PackageMappedSpecifier)>,
-  > = HashMap::new();
-  for (specifier, mapped) in mapped_specifiers {
-    let Some(version_req) = from_graph_specifier(specifier)
-      .as_ref()
-      .and_then(jsr_version_req)
-    else {
-      continue;
-    };
-    // a version requirement the mapping specified wins over the specifier's,
-    // so leave it alone
-    if mapped.version.as_deref() != Some(version_req.version_text()) {
-      continue;
+  /// Uses a single version requirement for each package that the mapped `jsr:`
+  /// specifiers with overlapping version requirements resolve to.
+  ///
+  /// A mapping without a version gets its version requirement from the
+  /// specifier, so a dependency requiring another range of the same package
+  /// (ex. `jsr:@scope/name@0.3` when this package requires
+  /// `jsr:@scope/name@^0.3.3`) would otherwise look like two versions of the
+  /// same package. Deno resolves them to one version, so use the requirement
+  /// that only matches the versions all of them match.
+  pub fn unify_versions<'a>(
+    &self,
+    mapped_specifiers: impl Iterator<
+      Item = (&'a ModuleSpecifier, &'a mut PackageMappedSpecifier),
+    >,
+  ) {
+    let mut by_name: HashMap<
+      String,
+      Vec<(VersionRange, &mut PackageMappedSpecifier)>,
+    > = HashMap::new();
+    for (specifier, mapped) in mapped_specifiers {
+      let Some(range) = self.specifier_version_range(specifier) else {
+        continue;
+      };
+      by_name
+        .entry(mapped.name.clone())
+        .or_default()
+        .push((range, mapped));
     }
-    by_name
-      .entry(mapped.name.clone())
-      .or_default()
-      .push((version_req, mapped));
+
+    for mut entries in by_name.into_values() {
+      if entries.len() < 2 {
+        continue;
+      }
+      // requirements that don't overlap are different versions of the package,
+      // which the mapping needs to disambiguate with a version of its own
+      let all_overlap = entries.iter().enumerate().all(|(i, (range, _))| {
+        entries[i + 1..]
+          .iter()
+          .all(|(other, _)| range.intersects_range(other))
+      });
+      if !all_overlap {
+        continue;
+      }
+      let intersection = entries[1..]
+        .iter()
+        .fold(entries[0].0.clone(), |intersection, (range, _)| {
+          intersection.clamp(range)
+        });
+      // keep the requirement the user wrote when one of them is the
+      // intersection, which is usually the case
+      let version = entries
+        .iter()
+        .find(|(range, _)| *range == intersection)
+        .and_then(|(_, mapped)| mapped.version.clone())
+        .unwrap_or_else(|| intersection.to_string());
+      for (_, mapped) in entries.iter_mut() {
+        mapped.version = Some(version.clone());
+      }
+    }
   }
 
-  for mut entries in by_name.into_values() {
-    if entries.len() < 2 {
-      continue;
-    }
-    // requirements that don't overlap are different versions of the package,
-    // which the mapping needs to disambiguate with a version of its own
-    let all_overlap = entries.iter().enumerate().all(|(i, (req, _))| {
-      entries[i + 1..]
-        .iter()
-        .all(|(other, _)| req.intersects(other))
-    });
-    if !all_overlap {
-      continue;
-    }
-    let Some(version) = entries
-      .iter()
-      .max_by(|(a, _), (b, _)| {
-        lowest_matching_version(a).cmp(&lowest_matching_version(b))
-      })
-      .map(|(req, _)| req.version_text().to_string())
-    else {
-      continue;
+  /// Version requirement a specifier in the module graph provides for its
+  /// mapping, which is [`None`] when the mapping specifies its own version or
+  /// the requirement is not a single range of versions.
+  fn specifier_version_range(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Option<VersionRange> {
+    let specifier = from_graph_specifier(specifier)?;
+    let mapping = self
+      .by_name_and_sub_path
+      .get(&jsr_mapping_key(&specifier)?)?;
+    let MappedSpecifier::Package(package) = mapping else {
+      return None;
     };
-    for (_, mapped) in entries.iter_mut() {
-      mapped.version = Some(version.clone());
+    if package.version.is_some() {
+      return None;
+    }
+    match jsr_version_req(&specifier)?.range()?.0.as_ref() {
+      [range] => Some(range.clone()),
+      _ => None,
     }
   }
 }
@@ -558,21 +577,6 @@ fn jsr_version_req(specifier: &ModuleSpecifier) -> Option<VersionReq> {
     return None;
   }
   Some(version_req.clone())
-}
-
-/// Lowest version a requirement matches, which is [`None`] when it has no
-/// lower bound.
-fn lowest_matching_version(version_req: &VersionReq) -> Option<&Version> {
-  let mut lowest: Option<&Version> = None;
-  for range in version_req.range()?.0.iter() {
-    let RangeBound::Version(bound) = &range.start else {
-      return None;
-    };
-    if lowest.is_none_or(|lowest| bound.version < *lowest) {
-      lowest = Some(&bound.version);
-    }
-  }
-  lowest
 }
 
 fn from_graph_specifier(
@@ -678,9 +682,9 @@ mod test {
   }
 
   #[test]
-  fn test_unify_mapped_jsr_versions() {
-    // the most restrictive of the overlapping requirements is used, including
-    // for a sub path of the same package
+  fn test_jsr_mappings_unify_versions() {
+    // the requirement that only matches the versions all of them match is
+    // used, including for a sub path of the same package
     run_test(
       &[
         ("dnt-jsr:@scope/name@0.3", "package", Some("0.3")),
@@ -688,6 +692,30 @@ mod test {
         ("dnt-jsr:@scope/name@~0.3.1/sub", "package", Some("~0.3.1")),
       ],
       &[Some("^0.3.3"), Some("^0.3.3"), Some("^0.3.3")],
+    );
+    // ...which is their intersection when none of them is it
+    run_test(
+      &[
+        ("dnt-jsr:@scope/name@~1.2.0", "package", Some("~1.2.0")),
+        ("dnt-jsr:@scope/name@^1.2.5", "package", Some("^1.2.5")),
+      ],
+      &[Some("~1.2.5"), Some("~1.2.5")],
+    );
+    // the requirements reach the mappings in an arbitrary order, so the same
+    // requirement is picked no matter which one comes first
+    run_test(
+      &[
+        ("dnt-jsr:@scope/name@1.0.0", "package", Some("1.0.0")),
+        ("dnt-jsr:@scope/name@^1.0.0", "package", Some("^1.0.0")),
+      ],
+      &[Some("1.0.0"), Some("1.0.0")],
+    );
+    run_test(
+      &[
+        ("dnt-jsr:@scope/name@^1.0.0", "package", Some("^1.0.0")),
+        ("dnt-jsr:@scope/name@1.0.0", "package", Some("1.0.0")),
+      ],
+      &[Some("1.0.0"), Some("1.0.0")],
     );
     // requirements that don't overlap are different versions of the package,
     // so they're left for the user to disambiguate
@@ -698,13 +726,22 @@ mod test {
       ],
       &[Some("0.2"), Some("0.3")],
     );
-    // a version the mapping specified is not changed
+    // a version the mapping specified is not changed, even when it's the same
+    // as the specifier's requirement
     run_test(
       &[
-        ("dnt-jsr:@scope/name@0.3", "package", Some("~0.3.5")),
-        ("dnt-jsr:@scope/name@^0.3.3", "package", Some("^0.3.3")),
+        ("dnt-jsr:@scope/pinned@^1.2.5", "package", Some("^1.2.5")),
+        ("dnt-jsr:@scope/name@1.2.9", "package", Some("1.2.9")),
       ],
-      &[Some("~0.3.5"), Some("^0.3.3")],
+      &[Some("^1.2.5"), Some("1.2.9")],
+    );
+    // a requirement that isn't a single range of versions is left alone
+    run_test(
+      &[
+        ("dnt-jsr:@scope/name@latest", "package", Some("latest")),
+        ("dnt-jsr:@scope/name@^1.0.0", "package", Some("^1.0.0")),
+      ],
+      &[Some("latest"), Some("^1.0.0")],
     );
     // requirements of other packages and other schemes are not touched
     run_test(
@@ -733,15 +770,25 @@ mod test {
             },
           )
         })
-        .collect::<BTreeMap<_, _>>();
-      unify_mapped_jsr_versions(mapped.iter_mut());
+        .collect::<Vec<_>>();
+      unify_mappings().unify_versions(mapped.iter_mut().map(|(s, p)| (&*s, p)));
       assert_eq!(
-        packages
+        mapped
           .iter()
-          .map(|(specifier, ..)| mapped[&parse(specifier)].version.as_deref())
+          .map(|(_, p)| p.version.as_deref())
           .collect::<Vec<_>>(),
         expected,
       );
+    }
+
+    fn unify_mappings() -> JsrSpecifierMappings {
+      JsrSpecifierMappings::new(&HashMap::from([
+        (parse("jsr:@scope/name"), mapping(None)),
+        (parse("jsr:@scope/name/sub"), mapping(None)),
+        (parse("jsr:@scope/other"), mapping(None)),
+        // a mapping that specifies its own version
+        (parse("jsr:@scope/pinned"), mapping(Some("^1.2.5"))),
+      ]))
     }
   }
 

--- a/rs-lib/src/specifiers.rs
+++ b/rs-lib/src/specifiers.rs
@@ -13,7 +13,7 @@ use deno_semver::npm::NpmPackageReqReference;
 use crate::declaration_file_resolution::resolve_declaration_file_mappings;
 use crate::declaration_file_resolution::DeclarationFileResolution;
 use crate::graph::display_specifier;
-use crate::graph::unify_mapped_jsr_versions;
+use crate::graph::JsrSpecifierMappings;
 use crate::graph::ModuleGraph;
 use crate::loader::LoaderSpecifiers;
 use crate::PackageMappedSpecifier;
@@ -46,6 +46,7 @@ pub struct EnvironmentSpecifiers {
 pub fn get_specifiers<'a>(
   entry_points: &[ModuleSpecifier],
   mut specifiers: LoaderSpecifiers,
+  jsr_specifier_mappings: &JsrSpecifierMappings,
   module_graph: &ModuleGraph,
   modules: impl Iterator<Item = &'a Module>,
 ) -> Result<Specifiers> {
@@ -177,7 +178,7 @@ pub fn get_specifiers<'a>(
     }
   }
 
-  unify_mapped_jsr_versions(
+  jsr_specifier_mappings.unify_versions(
     found_mapped_specifiers
       .iter_mut()
       .chain(specifiers.mapped_packages.iter_mut()),

--- a/rs-lib/src/specifiers.rs
+++ b/rs-lib/src/specifiers.rs
@@ -12,6 +12,8 @@ use deno_semver::npm::NpmPackageReqReference;
 
 use crate::declaration_file_resolution::resolve_declaration_file_mappings;
 use crate::declaration_file_resolution::DeclarationFileResolution;
+use crate::graph::display_specifier;
+use crate::graph::unify_mapped_jsr_versions;
 use crate::graph::ModuleGraph;
 use crate::loader::LoaderSpecifiers;
 use crate::PackageMappedSpecifier;
@@ -175,6 +177,11 @@ pub fn get_specifiers<'a>(
     }
   }
 
+  unify_mapped_jsr_versions(
+    found_mapped_specifiers
+      .iter_mut()
+      .chain(specifiers.mapped_packages.iter_mut()),
+  );
   ensure_package_mapped_specifiers_valid(
     &found_mapped_specifiers,
     &specifiers.mapped_packages,
@@ -285,9 +292,9 @@ fn ensure_package_mapped_specifiers_valid(
     if let Some(specifier) = specifier_for_name.get(&mapped_specifier.name) {
       if specifier.1.version != mapped_specifier.version {
         anyhow::bail!("Specifier {} with version {} did not match specifier {} with version {}.",
-          specifier.0,
+          display_specifier(&specifier.0),
           specifier.1.version.as_deref().unwrap_or("<unknown>"),
-          from_specifier,
+          display_specifier(from_specifier),
           mapped_specifier.version.as_deref().unwrap_or("<unknown>"),
         );
       }

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1454,6 +1454,76 @@ async fn transform_jsr_specifier_mappings() {
 }
 
 #[tokio::test]
+async fn transform_jsr_specifier_mapping_different_version_reqs() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader.add_local_file(
+        "/mod.ts",
+        concat!(
+          "import * as pkg from 'jsr:@scope/name@0.3';\n",
+          "import * as sub from 'jsr:@scope/name@^0.3.3/sub';\n",
+        ),
+      );
+    })
+    // no version on the mappings, so the specifiers' are used
+    .add_package_specifier_mapping("jsr:@scope/name", "scope-name", None, None)
+    .add_package_specifier_mapping(
+      "jsr:@scope/name/sub",
+      "scope-name",
+      None,
+      Some("sub"),
+    )
+    .transform()
+    .await
+    .unwrap();
+
+  assert_files!(
+    result.main.files,
+    &[(
+      "mod.ts",
+      concat!(
+        "import * as pkg from 'scope-name';\n",
+        "import * as sub from 'scope-name/sub';\n",
+      )
+    )]
+  );
+  // the version requirements overlap, so the most restrictive one is used
+  assert_eq!(
+    result.main.dependencies,
+    &[Dependency {
+      name: "scope-name".to_string(),
+      version: "^0.3.3".to_string(),
+      peer_dependency: false,
+    }]
+  );
+}
+
+#[tokio::test]
+async fn transform_jsr_specifier_mapping_incompatible_version_reqs() {
+  let error_message = TestBuilder::new()
+    .with_loader(|loader| {
+      loader.add_local_file(
+        "/mod.ts",
+        concat!(
+          "import * as pkg from 'jsr:@scope/name@0.2';\n",
+          "import * as other from 'jsr:@scope/name@0.3';\n",
+        ),
+      );
+    })
+    .add_package_specifier_mapping("jsr:@scope/name", "scope-name", None, None)
+    .transform()
+    .await
+    .err()
+    .unwrap();
+
+  // the version requirements don't overlap, so the mapping needs a version
+  assert_eq!(
+    error_message.to_string(),
+    "Specifier jsr:@scope/name@0.2 with version 0.2 did not match specifier jsr:@scope/name@0.3 with version 0.3."
+  );
+}
+
+#[tokio::test]
 async fn transform_jsr_specifier_mapping_via_config_file() {
   let result = TestBuilder::new()
     .with_loader(|loader| {

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1499,6 +1499,33 @@ async fn transform_jsr_specifier_mapping_different_version_reqs() {
 }
 
 #[tokio::test]
+async fn transform_jsr_specifier_mapping_different_version_reqs_in_test() {
+  let result = TestBuilder::new()
+    .with_loader(|loader| {
+      loader
+        .add_local_file("/mod.ts", "import 'jsr:@scope/name@0.3';\n")
+        .add_local_file("/mod.test.ts", "import 'jsr:@scope/name@^0.3.3';\n");
+    })
+    .add_test_entry_point("file:///mod.test.ts")
+    .add_package_specifier_mapping("jsr:@scope/name", "scope-name", None, None)
+    .transform()
+    .await
+    .unwrap();
+
+  // a requirement in the tests counts towards the main dependency as well
+  assert_eq!(
+    result.main.dependencies,
+    &[Dependency {
+      name: "scope-name".to_string(),
+      version: "^0.3.3".to_string(),
+      peer_dependency: false,
+    }]
+  );
+  // ...so the tests don't need a dev dependency of their own
+  assert_eq!(result.test.dependencies, &[]);
+}
+
+#[tokio::test]
 async fn transform_jsr_specifier_mapping_incompatible_version_reqs() {
   let error_message = TestBuilder::new()
     .with_loader(|loader| {


### PR DESCRIPTION
A mapped `jsr:` specifier gets its version requirement from the specifier instead of the mapping, so a dependency requiring another range of the same package looked like two versions of the same package and errored:

```
error: Uncaught (in promise) "Specifier dnt-jsr:@david/path@^0.3.3 with version ^0.3.3 did not match specifier dnt-jsr:@david/path@0.3 with version 0.3."
```

...which happened with:

```jsonc
// deno.json
"imports": {
  "@david/path": "jsr:@david/path@^0.3.3",
  "@david/temp": "jsr:@david/temp@^0.2.1" // requires `jsr:@david/path@0.3`
}
```

```ts
mappings: {
  "jsr:@david/path": { name: "@dsherret/path" },
}
```

Deno resolves both requirements to one version, so use the most restrictive requirement when they overlap. Requirements that don't overlap are different versions of the package, so they still error for the mapping to disambiguate with a `version` of its own—but without leaking the internal `dnt-jsr:` scheme into the message.
