### PR TITLE
fix: exclude a test dependency's declaration file from the package

### DIFF
--- a/lib/npm_ignore.test.ts
+++ b/lib/npm_ignore.test.ts
@@ -170,6 +170,58 @@ Deno.test("should keep the src directory when the declaration maps need it", () 
   });
 });
 
+Deno.test("should ignore a dependency's declaration file", () => {
+  // a dependency that ships a declaration file (ex. a prebuilt package
+  // published to JSR) is copied as-is rather than compiled to `.js` + `.d.ts`
+  const depDts = "deps/jsr.io/@scope/dep/1.0.0/dep.d.ts";
+
+  function run(options: {
+    declaration: "separate" | "inline" | false;
+    declarationMap?: boolean;
+    includeEsModule?: boolean;
+    includeScriptModule?: boolean;
+  }) {
+    return getNpmIgnoreText({
+      sourceMap: undefined,
+      inlineSources: undefined,
+      testFiles: [{ filePath: depDts, fileText: "" }],
+      includeEsModule: options.includeEsModule ?? true,
+      includeScriptModule: options.includeScriptModule ?? true,
+      declaration: options.declaration,
+      declarationMap: options.declarationMap,
+    });
+  }
+
+  // inline declarations are copied beside the emitted code
+  assertEquals(
+    run({ declaration: "inline" }),
+    `/src/\n/esm/${depDts}\n/script/${depDts}\n` +
+      "/test_runner.cjs\nyarn.lock\npnpm-lock.yaml\n",
+  );
+  // inline declarations with declaration maps (the maps reference `/src/`, so
+  // the individual source files are ignored instead of the whole directory)
+  assertEquals(
+    run({ declaration: "inline", declarationMap: true }),
+    `/src/${depDts}\n/esm/${depDts}\n/esm/${depDts}.map\n/script/${depDts}\n` +
+      `/script/${depDts}.map\n/test_runner.cjs\nyarn.lock\npnpm-lock.yaml\n`,
+  );
+  // separate declarations only end up in the types directory
+  assertEquals(
+    run({ declaration: "separate" }),
+    `/src/\n/types/${depDts}\n/test_runner.cjs\nyarn.lock\npnpm-lock.yaml\n`,
+  );
+  // no declarations means the file is never emitted
+  assertEquals(
+    run({ declaration: false }),
+    `/src/\n/test_runner.cjs\nyarn.lock\npnpm-lock.yaml\n`,
+  );
+  // only the esm output is emitted
+  assertEquals(
+    run({ declaration: "inline", includeScriptModule: false }),
+    `/src/\n/esm/${depDts}\n/test_runner.cjs\nyarn.lock\npnpm-lock.yaml\n`,
+  );
+});
+
 function runTest(options: {
   sourceMaps: SourceMapOptions | undefined;
   inlineSources: boolean | undefined;

--- a/lib/npm_ignore.ts
+++ b/lib/npm_ignore.ts
@@ -2,7 +2,7 @@
 
 import type { OutputFile } from "../transform.ts";
 import type { SourceMapOptions } from "./compiler.ts";
-import { toDtsFilePath, toJsFilePath } from "./utils.ts";
+import { isDeclarationFilePath, toDtsFilePath, toJsFilePath } from "./utils.ts";
 
 export function getNpmIgnoreText(options: {
   sourceMap?: SourceMapOptions;
@@ -27,14 +27,22 @@ export function getNpmIgnoreText(options: {
 
   function* getTestFileNames() {
     for (const file of options.testFiles) {
-      const filePath = toJsFilePath(file.filePath);
-      const dtsFilePath = toDtsFilePath(file.filePath);
       // the whole directory is excluded above when it's not published
       if (isReferencingSrcDir()) {
         yield `/src/${file.filePath}`;
       }
+      // A dependency can ship a declaration file directly (ex. a prebuilt
+      // package published to JSR). The compiler copies it as-is beside the
+      // emitted code rather than turning it into a `.js` + `.d.ts` pair, so it
+      // has different output paths than a regular source file.
+      if (isDeclarationFilePath(file.filePath)) {
+        yield* getDeclarationTestFileNames(file.filePath);
+        continue;
+      }
+      const jsFilePath = toJsFilePath(file.filePath);
+      const dtsFilePath = toDtsFilePath(file.filePath);
       if (options.includeEsModule) {
-        const esmFilePath = `/esm/${filePath}`;
+        const esmFilePath = `/esm/${jsFilePath}`;
         yield esmFilePath;
         if (options.sourceMap === true) {
           yield `${esmFilePath}.map`;
@@ -47,7 +55,7 @@ export function getNpmIgnoreText(options: {
         }
       }
       if (options.includeScriptModule) {
-        const scriptFilePath = `/script/${filePath}`;
+        const scriptFilePath = `/script/${jsFilePath}`;
         yield scriptFilePath;
         if (options.sourceMap === true) {
           yield `${scriptFilePath}.map`;
@@ -67,6 +75,31 @@ export function getNpmIgnoreText(options: {
       }
     }
     yield "/test_runner.cjs";
+  }
+
+  /** A declaration file emits no `.js`, so the compiler only copies it where
+   * declarations are output: beside the code when they're inlined, or the
+   * `types` directory when they're kept separate. */
+  function* getDeclarationTestFileNames(dtsFilePath: string) {
+    if (options.declaration === "inline") {
+      if (options.includeEsModule) {
+        yield `/esm/${dtsFilePath}`;
+        if (options.declarationMap) {
+          yield `/esm/${dtsFilePath}.map`;
+        }
+      }
+      if (options.includeScriptModule) {
+        yield `/script/${dtsFilePath}`;
+        if (options.declarationMap) {
+          yield `/script/${dtsFilePath}.map`;
+        }
+      }
+    } else if (options.declaration === "separate") {
+      yield `/types/${dtsFilePath}`;
+      if (options.declarationMap) {
+        yield `/types/${dtsFilePath}.map`;
+      }
+    }
   }
 
   /** Whether any emitted map points back at the files in `/src/`, in which

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -19,6 +19,12 @@ export function toDtsFilePath(filePath: string): string {
 // emits as `.js` files (the transform already outputs `.mts` and `.mjs` as `.js`)
 const COMPILED_EXT_RE = /\.(?:ts|tsx|jsx)$/i;
 
+/** Whether the provided output file path is a declaration file, which the
+ * TypeScript compiler copies as-is instead of compiling to a `.js` file. */
+export function isDeclarationFilePath(filePath: string): boolean {
+  return /\.d\.[cm]?ts$/i.test(filePath);
+}
+
 /**
  * Gets the files found in the provided root dir path based on the glob.
  *


### PR DESCRIPTION
A test-only dependency that ships a declaration file (ex. a prebuilt package published to JSR that provides `dist/foo.d.ts`) was leaking into the published npm package because its `.d.ts` was never listed in `.npmignore`.

The ignore paths were computed with `toJsFilePath`/`toDtsFilePath`, whose regex only handles regular source files, so a `.d.ts` input produced nonsense paths (`foo.d.js`, `foo.d.d.ts`) that never matched the file the compiler actually emitted. Declaration files aren't compiled to a `.js` + `.d.ts` pair — the compiler copies them as-is, and only where declarations are emitted (beside the code when inlined, or the `types` directory when separate). Detect declaration test files and emit the correct ignore entries for them.

Closes #522